### PR TITLE
fix: correct u64 max value representation

### DIFF
--- a/tests/features/20250603_00_max_u64_value.c
+++ b/tests/features/20250603_00_max_u64_value.c
@@ -1,0 +1,6 @@
+#include "tests/test.h"
+
+int main(void) {
+    //    TEST_EXEC_IMM
+    feature_testar_test(NULL);
+}

--- a/tests/features/cases/20250603_00_max_u64_value.testar
+++ b/tests/features/cases/20250603_00_max_u64_value.testar
@@ -1,0 +1,9 @@
+=== test_max_u64_value
+--- main.n
+fn main():void! {
+    u64 max = 18446744073709551615
+    println(max)
+}
+
+--- output.txt
+18446744073709551615

--- a/utils/type.h
+++ b/utils/type.h
@@ -713,10 +713,16 @@ static inline bool is_float(type_kind kind) {
 }
 
 
+static inline bool is_signed_integer(type_kind kind) {
+    return kind == TYPE_INT || kind == TYPE_INT8 || kind == TYPE_INT16 || kind == TYPE_INT32 || kind == TYPE_INT64;
+}
+
+static inline bool is_unsigned_integer(type_kind kind) {
+    return kind == TYPE_UINT || kind == TYPE_UINT8 || kind == TYPE_UINT16 || kind == TYPE_UINT32 || kind == TYPE_UINT64;
+}
+
 static inline bool is_integer(type_kind kind) {
-    return kind == TYPE_INT || kind == TYPE_INT8 || kind == TYPE_INT16 || kind == TYPE_INT32 || kind == TYPE_INT64 ||
-           kind == TYPE_UINT ||
-           kind == TYPE_UINT8 || kind == TYPE_UINT16 || kind == TYPE_UINT32 || kind == TYPE_UINT64;
+    return is_signed_integer(kind) || is_unsigned_integer(kind);
 }
 
 static inline bool is_integer_or_anyptr(type_kind kind) {


### PR DESCRIPTION
Fixes bug where `u64` type failed to represent its maximum value (`2^64 - 1 = 18446744073709551615`). Previously, the u64 type could only represent values up to the max of i64 (`2^63-1`).