### PR TITLE
Minor docs fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ fn main() {
 compile and execute  
   
 ```sh
-> nature build main.n && . /main   
+> nature build main.n && ./main   
 hello nature 
 ```   
   


### PR DESCRIPTION
Typo in `./main`