### PR TITLE
refactor(build): Extract platform-related macro definitions into sepa…

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -18,6 +18,7 @@ pub fn build(b: *std.Build) !void {
     const lib_path_arch = switch (arch) {
         .x86_64 => "amd64",
         .aarch64 => "arm64",
+        .riscv64 => "riscv64",
         else => "unknown",
     };
 


### PR DESCRIPTION
Extract platform-related macro definitions into separate functions

Extract repeated platform-related macro definition logic into setCMacros function. Unify macro definitions of different operating systems and architectures.

`zig build -Druntime=true -Dtarget=x86_64-linux` `zig build -Druntime=true -Dtarget=riscv64-linux` be compiled successfully