### PR TITLE
fix: memory leak from path_dir

### DIFF
--- a/cmd/root.h
+++ b/cmd/root.h
@@ -47,19 +47,20 @@ void cmd_entry(int argc, char **argv) {
                     // 解析出目录路径
                     char *output_dir = path_dir(o_arg);
                     if (strlen(output_dir) > 0) {
-                        char temp_path[PATH_MAX] = "";
-                        if (realpath(output_dir, temp_path) == NULL) {
+                        if (realpath(output_dir, BUILD_OUTPUT_DIR) == NULL) {
                             // assertf(false, "output dir='%s' not exists", output_dir);
                             printf("output dir '%s' not exists\n", output_dir);
+                            free(output_dir);
                             exit(EXIT_FAILURE);
                         }
-                        strcpy(BUILD_OUTPUT_DIR, temp_path);
                         if (!dir_exists(BUILD_OUTPUT_DIR)) {
-                            printf("build output dir '%s' not exists\n", BUILD_OUTPUT_DIR);
+                            printf("output path '%s' is not a directory\n", BUILD_OUTPUT_DIR);
+                            free(output_dir);
                             exit(EXIT_FAILURE);
                         }
                         // assertf(dir_exists(BUILD_OUTPUT_DIR), "build output dir='%s' not exists", BUILD_OUTPUT_DIR);
                     }
+                    free(output_dir);
 
                     // 解析出文件名称
                     char *output_name = file_name(o_arg);
@@ -74,19 +75,19 @@ void cmd_entry(int argc, char **argv) {
             }
             case 1: {
                 char *target = optarg;
-                if (strcmp(target, "linux_amd64") == 0) {
+                if (str_equal(target, "linux_amd64")) {
                     BUILD_OS = OS_LINUX;
                     BUILD_ARCH = ARCH_AMD64;
-                } else if (strcmp(target, "linux_arm64") == 0) {
+                } else if (str_equal(target, "linux_arm64")) {
                     BUILD_OS = OS_LINUX;
                     BUILD_ARCH = ARCH_ARM64;
-                } else if (strcmp(target, "linux_riscv64") == 0) {
+                } else if (str_equal(target, "linux_riscv64")) {
                     BUILD_OS = OS_LINUX;
                     BUILD_ARCH = ARCH_RISCV64;
-                } else if (strcmp(target, "darwin_amd64") == 0) {
+                } else if (str_equal(target, "darwin_amd64")) {
                     BUILD_OS = OS_DARWIN;
                     BUILD_ARCH = ARCH_AMD64;
-                } else if (strcmp(target, "darwin_arm64") == 0) {
+                } else if (str_equal(target, "darwin_arm64")) {
                     BUILD_OS = OS_DARWIN;
                     BUILD_ARCH = ARCH_ARM64;
                 } else {

--- a/src/module.c
+++ b/src/module.c
@@ -50,6 +50,7 @@ module_t *module_build(ast_import_t *import, char *source_path, module_type_t ty
         } else {
             m->rel_path = str_replace(m->source_path, temp_dir, "");
         }
+        free(temp_dir);
         assert(m->rel_path);
 
         m->rel_path = ltrim(m->rel_path, "/");

--- a/src/module.h
+++ b/src/module.h
@@ -69,6 +69,7 @@ static inline char *module_unique_ident(ast_import_t *import) {
 
     char *temp_dir = path_dir(import->package_dir);
     char *ident = str_replace(import->full_path, temp_dir, "");
+    free(temp_dir);
     ident = ltrim(ident, "/");
 
     ident = rtrim(ident, ".n");

--- a/tests/test.h
+++ b/tests/test.h
@@ -498,6 +498,7 @@ static inline void feature_testar_test(char *custom_target) {
             if (!dir_exists(dir)) {
                 system(str_connect("mkdir -p ", dir));
             }
+            free(dir);
 
             // 写入文件内容
             FILE *fp = fopen(full_path, "w");


### PR DESCRIPTION

1. Free the memory returned from `path_dir`: `path_dir` uses strdup, which allocates memory dynamically.
2. Change error msg detected by `dir_exists`: If `realpath` returns non-NULL, it tells the path exists. And if `dir_exists` returns false, it means the path isn't a directory. 