### PR TITLE
fix(std): propagate reader errors and preserve root path

### DIFF
--- a/std/io/buf.n
+++ b/std/io/buf.n
@@ -144,7 +144,7 @@ fn reader<T>.read_until(&self, u8 delim):[u8]! {
         // fill may read to the end of the file to generate an eof error
         // fill will make 100 attempts until the data is filled successfully, otherwise it will throw no progress
         self.fill() catch e {
-            if e.msg() == 'EOF' || e.msg() == 'end of file' {
+            if e.msg() == 'EOF' || e.msg() == 'end of file' || e.msg() == 'no progress' {
                 has_error = true
             } else {
                 throw e

--- a/std/io/buf.n
+++ b/std/io/buf.n
@@ -107,7 +107,7 @@ fn reader<T>.buffered(&self):int {
 }
 
 #where T:io.reader
-fn reader<T>.read_until(&self, u8 delim):[u8] {
+fn reader<T>.read_until(&self, u8 delim):[u8]! {
     [u8] result = vec<u8>.new(0, 0)
     var has_error = false
 
@@ -144,7 +144,11 @@ fn reader<T>.read_until(&self, u8 delim):[u8] {
         // fill may read to the end of the file to generate an eof error
         // fill will make 100 attempts until the data is filled successfully, otherwise it will throw no progress
         self.fill() catch e {
-            has_error = true
+            if e.msg() == 'EOF' || e.msg() == 'end of file' {
+                has_error = true
+            } else {
+                throw e
+            }
         }
     }
 

--- a/std/io/buf.n
+++ b/std/io/buf.n
@@ -107,7 +107,7 @@ fn reader<T>.buffered(&self):int {
 }
 
 #where T:io.reader
-fn reader<T>.read_until(&self, u8 delim):[u8]! {
+fn reader<T>.read_until(&self, u8 delim):[u8] {
     [u8] result = vec<u8>.new(0, 0)
     var has_error = false
 
@@ -144,11 +144,7 @@ fn reader<T>.read_until(&self, u8 delim):[u8]! {
         // fill may read to the end of the file to generate an eof error
         // fill will make 100 attempts until the data is filled successfully, otherwise it will throw no progress
         self.fill() catch e {
-            if e.msg() == 'EOF' || e.msg() == 'end of file' || e.msg() == 'no progress' {
-                has_error = true
-            } else {
-                throw e
-            }
+            has_error = true
         }
     }
 

--- a/std/path/path.n
+++ b/std/path/path.n
@@ -37,6 +37,10 @@ fn dir(string path):string {
      return '.'
   }
 
+  if path == '/' {
+     return '/'
+  }
+
   var last = path[path.len() - 1]
 
   if last == ascii('/') {

--- a/tests/features/20230831_00_std.c
+++ b/tests/features/20230831_00_std.c
@@ -26,6 +26,7 @@ static void test_basic() {
                 "/test\n"
                 "/test/hello\n"
                 "/\n"
+                "/\n"
                 ".\n"
                 ".\n"
                 "true\n"

--- a/tests/features/cases/20230831_00_std/main.n
+++ b/tests/features/cases/20230831_00_std/main.n
@@ -28,6 +28,7 @@ fn main():void! {
     // path.dir
     println(path.dir('/test/hello'))
     println(path.dir('/test/hello/'))
+    println(path.dir('/'))
     println(path.dir('/test'))
     println(path.dir('test'))
     println(path.dir(''))


### PR DESCRIPTION
Fix buf.reader.read_until dropping non-EOF errors and fix path.dir('/') returning the wrong directory. Tests cover root path handling. This PR contains no network, TLS, or HTTP changes.