### PR TITLE
fix(compiler): correct struct field diagnostics

### DIFF
--- a/src/semantic/infer.c
+++ b/src/semantic/infer.c
@@ -2057,7 +2057,7 @@ static list_t *infer_struct_properties(module_t *m, type_struct_t *type_struct, 
 
         // check can default value
         if (must_assign_value(property->type)) {
-            INFER_ASSERTF(false, "struct filed '%s' must be assigned default value", property->name,
+            INFER_ASSERTF(false, "struct field '%s' must be assigned default value", property->name,
                           type_origin_format(property->type));
         }
     }

--- a/tests/features/cases/20250311_00_interface.testar
+++ b/tests/features/cases/20250311_00_interface.testar
@@ -458,7 +458,7 @@ fn main():void! {
 }
 
 --- output.txt
-nature-test/main.n:35:18: struct filed 'm' must be assigned default value
+nature-test/main.n:35:18: struct field 'm' must be assigned default value
 
 
 

--- a/tests/features/cases/20250827_00_recycle_type.testar
+++ b/tests/features/cases/20250827_00_recycle_type.testar
@@ -24,7 +24,7 @@ fn main() {
 }
 
 --- output.txt
-nature-test/main.n:7:22: struct filed 'next' must be assigned default value
+nature-test/main.n:7:22: struct field 'next' must be assigned default value
 
 === test_linked
 --- main.n
@@ -255,4 +255,3 @@ fn main() {
 
 --- output.txt
 nature-test/main.n:11:11: type inconsistency, expect=http.callback_fn(fn(...):void!), actual=fn(...):void!
-


### PR DESCRIPTION
Fix spelling in struct field diagnostics and update the related testar expectations. The reduced-type sharing change that caused a recycle-type regression and SEGFAULT has been removed.