### PR TITLE
feat(http): decode chunked responses transparently for SSE streaming

### DIFF
--- a/std/http/client.n
+++ b/std/http/client.n
@@ -118,6 +118,7 @@ type response_t = struct{
     string content_type // default application/json
     string charset
     bool body_read
+    bool chunked // Transfer-Encoding: chunked
     ref<buf.reader<types.connable>> buf_conn
 }
 
@@ -300,7 +301,19 @@ fn request_t.send(&self):ref<response_t>! {
             if key == 'Content-Length' {
                 resp.length = value.to_int()
             }
+
+            if key == 'Transfer-Encoding' && value.contains('chunked') {
+                resp.chunked = true
+            }
         }
+    }
+
+    // chunked response bodies are decoded transparently by chunked_reader_t,
+    // so callers see a plain byte stream without framing or trailers
+    // (line reads via read_line work for SSE and other streaming cases)
+    if resp.chunked {
+        var creader = chunked_reader_t.new(br)
+        resp.buf_conn = new buf.reader<types.connable>(rd = creader)
     }
 
     return resp
@@ -339,7 +352,24 @@ fn response_t.text(&self):string! {
         return self.body
     }
     self.body_read = true
-    if self.length == 0 {
+    if self.length == 0 && !self.chunked {
+        return self.body
+    }
+
+    if self.chunked {
+        // no Content-Length, read until EOF
+        var buf = vec<u8>.new(0, 4096)
+        bool eof = false
+        for !eof {
+            var n = self.buf_conn.read(buf) catch e {
+                eof = true
+                0
+            }
+            if eof {
+                break
+            }
+            self.body += buf.slice(0, n) as string
+        }
         return self.body
     }
 
@@ -347,4 +377,129 @@ fn response_t.text(&self):string! {
     self.buf_conn.read_exact(buf)
     self.body = buf as string
     return self.body
+}
+
+// chunked response body decoder: restores a chunked transfer into a plain
+// byte stream, hiding the chunk size line / data / trailing CRLF / trailers.
+// State machine: 0=read chunk size line, 1=read chunk data, 2=consume trailing CRLF, 3=read trailers, 4=done
+type chunked_reader_t:types.connable = struct{
+    ref<buf.reader<types.connable>> br
+    [u8] staging = vec<u8>.new(0, 4096)
+    int s_r
+    int s_w
+    int state
+    int remaining
+}
+
+fn chunked_reader_t.new(ref<buf.reader<types.connable>> br):ref<chunked_reader_t> {
+    return new chunked_reader_t(br = br)
+}
+
+#local
+fn chunked_reader_t.hex_to_int(&self, string s):int {
+    var result = 0
+    for int i = 0; i < s.len(); i += 1 {
+        var c = s[i]
+        result *= 16
+        if c >= '0'.char() && c <= '9'.char() {
+            result += (c - '0'.char()) as int
+        } else if c >= 'a'.char() && c <= 'f'.char() {
+            result += (c - 'a'.char()) as int + 10
+        } else if c >= 'A'.char() && c <= 'F'.char() {
+            result += (c - 'A'.char()) as int + 10
+        }
+    }
+    return result
+}
+
+#local
+fn chunked_reader_t.fill_staging(&self):void! {
+    for true {
+        if self.state == 0 {
+            var line = self.br.read_line()
+            // may carry a chunk-ext: 1a;name=value
+            var semi = line.find(';')
+            if semi > 0 {
+                line = line.slice(0, semi)
+            }
+            self.remaining = self.hex_to_int(line.trim([' ', '\t']))
+            if self.remaining == 0 {
+                self.state = 3
+            } else {
+                self.state = 1
+            }
+            continue
+        }
+
+        if self.state == 1 {
+            var want = self.remaining
+            if want > self.staging.len() {
+                want = self.staging.len()
+            }
+            var n = self.br.read(self.staging.slice(0, want))
+            self.s_w = n
+            self.s_r = 0
+            self.remaining -= n
+            if self.remaining == 0 {
+                self.state = 2
+            }
+            return
+        }
+
+        if self.state == 2 {
+            // consume the trailing CRLF
+            self.br.read_line()
+            self.state = 0
+            continue
+        }
+
+        if self.state == 3 {
+            // trailers: read until an empty line
+            for true {
+                var line = self.br.read_line()
+                if line == '' {
+                    break
+                }
+            }
+            self.state = 4
+            continue
+        }
+
+        throw errorf('EOF')
+    }
+}
+
+fn chunked_reader_t.read(&self, [u8] dst):int! {
+    if dst.len() == 0 {
+        if self.s_r < self.s_w {
+            return 0
+        }
+        throw errorf('EOF')
+    }
+
+    if self.s_r == self.s_w {
+        self.s_r = 0
+        self.s_w = 0
+        self.fill_staging()
+    }
+
+    var n = dst.copy(self.staging.slice(self.s_r, self.s_w))
+    self.s_r += n
+    return n
+}
+
+fn chunked_reader_t.write(&self, [u8] buf):int! {
+    return self.br.rd.write(buf)
+}
+
+fn chunked_reader_t.close(&self) {
+    self.br.rd.close()
+}
+
+fn chunked_reader_t.set_read_timeout(&self, int timeout_ms) {
+    self.br.rd.set_read_timeout(timeout_ms)
+}
+
+fn chunked_reader_t.read_timeout(&self):int {
+    return self.br.rd.read_timeout()
 }

--- a/std/http/client.n
+++ b/std/http/client.n
@@ -92,7 +92,7 @@ fn multipart_t.serialize(&self):string {
 type request_t = struct{
     string method
     {string:string} headers
-    int timeout
+    int timeout_ms
     string body
     string url
     url.url_t u
@@ -169,7 +169,7 @@ fn request_t.head(&self, string url):ref<request_t> {
 }
 
 fn request_t.timeout(&self, int timeout):ref<request_t> {
-    self.timeout = timeout
+    self.timeout_ms = timeout
     return self
 }
 
@@ -257,6 +257,19 @@ fn request_t.tcp_buf(&self):[u8]! {
     return buf
 }
 
+#local
+fn read_until_space(ref<buf.reader<types.connable>> br):string! {
+    var bytes = vec<u8>.new(0, 32)
+    for true {
+        var b = br.read_byte()
+        if b == ' '.char() {
+            break
+        }
+        bytes.push(b)
+    }
+    return bytes as string
+}
+
 fn request_t.send(&self):ref<response_t>! {
     self.u = url.parse(self.url)
     self.remote_ip = dns.lookup(self.u.hostname)[0]
@@ -266,12 +279,13 @@ fn request_t.send(&self):ref<response_t>! {
 
     types.connable? temp_conn = null
     if self.u.scheme == 'https' {
-        temp_conn = tls.connect_timeout(fmt.sprintf('%s:%d', self.remote_ip, self.remote_port), self.timeout)
+        temp_conn = tls.connect_timeout(fmt.sprintf('%s:%d', self.remote_ip, self.remote_port), self.timeout_ms)
     } else {
-        temp_conn = tcp.connect_timeout(fmt.sprintf('%s:%d', self.remote_ip, self.remote_port), self.timeout)
+        temp_conn = tcp.connect_timeout(fmt.sprintf('%s:%d', self.remote_ip, self.remote_port), self.timeout_ms)
     }
 
     var conn = temp_conn as types.connable
+    conn.set_read_timeout(self.timeout_ms)
     var buf = self.tcp_buf()
     conn.write(buf)
 
@@ -279,33 +293,40 @@ fn request_t.send(&self):ref<response_t>! {
     var br = new buf.reader<types.connable>(rd = conn)
 
     var resp = new response_t(buf_conn = br)
-    resp.version = (br.read_until(' '.char()) as string).rtrim([' '])
-    var status = (br.read_until(' '.char()) as string).rtrim([' '])
-    resp.status = status.to_int() catch e {0}
-    resp.message = br.read_line()
-    for true {
-        var line = br.read_line()
+    try {
+        resp.version = read_until_space(br).rtrim([' '])
+        var status = read_until_space(br).rtrim([' '])
+        resp.status = status.to_int() catch e {0}
+        resp.message = br.read_line()
+        for true {
+            var line = br.read_line()
 
-        // if empty line, break
-        if line == '' {
-            break
-        }
-
-        // parser header(trim)
-        var pair = line.split(':')
-        if pair.len() == 2 {
-            var key = pair[0].trim([' '])
-            var value = pair[1].trim([' '])
-            resp.headers[key] = value
-
-            if key == 'Content-Length' {
-                resp.length = value.to_int()
+            // if empty line, break
+            if line == '' {
+                break
             }
 
-            if key == 'Transfer-Encoding' && value.contains('chunked') {
-                resp.chunked = true
+            // parser header: split on the first ':' only, values may contain ':'
+            var colon = line.find(':')
+            if colon > 0 {
+                var key = line.slice(0, colon).trim([' '])
+                var value = line.slice(colon + 1, line.len()).trim([' '])
+                resp.headers[key] = value
+
+                if key == 'Content-Length' {
+                    resp.length = value.to_int()
+                }
+
+                if key == 'Transfer-Encoding' && value.contains('chunked') {
+                    resp.chunked = true
+                }
             }
         }
+    } catch e {
+        if e.msg() == 'tcp read timeout' {
+            throw errorf('HTTP response read timeout')
+        }
+        throw e
     }
 
     // chunked response bodies are decoded transparently by chunked_reader_t,
@@ -336,7 +357,7 @@ fn fetch(string url, config_t c):ref<response_t>! {
     req.method = c.method // TODO check
     req.url = url
     req.headers = c.headers
-    req.timeout = c.timeout
+    req.timeout_ms = c.timeout
     req.body = c.body
     
     return req.send()
@@ -345,6 +366,35 @@ fn fetch(string url, config_t c):ref<response_t>! {
 
 fn response_t.status(&self):int {
     return self.status
+}
+
+// 读取响应体的一段字节到 buf, 返回实际读取的字节数,
+// 响应体读取完毕时抛出 EOF。超时错误统一为 'HTTP response read timeout'
+fn response_t.read(&self, [u8] buf):int! {
+    try {
+        return self.buf_conn.read(buf)
+    } catch e {
+        if e.msg() == 'tcp read timeout' {
+            throw errorf('HTTP response read timeout')
+        }
+        throw e
+    }
+}
+
+// 大小写不敏感的响应头查找, 不存在时返回空串
+fn response_t.header(&self, string key):string {
+    var lower = key.to_lower()
+    for k, v in self.headers {
+        if k.to_lower() == lower {
+            return v
+        }
+    }
+    return ''
+}
+
+// 显式关闭底层连接
+fn response_t.close(&self) {
+    self.buf_conn.rd.close()
 }
 
 fn response_t.text(&self):string! {

--- a/tests/features/20260730_00_http_timeout.c
+++ b/tests/features/20260730_00_http_timeout.c
@@ -1,0 +1,5 @@
+#include "tests/test.h"
+
+int main(void) {
+    feature_testar_test(NULL);
+}

--- a/tests/features/20260806_01_sse_client.c
+++ b/tests/features/20260806_01_sse_client.c
@@ -1,0 +1,5 @@
+#include "tests/test.h"
+
+int main(void) {
+    feature_testar_test(NULL);
+}

--- a/tests/features/cases/20260730_00_http_timeout.testar
+++ b/tests/features/cases/20260730_00_http_timeout.testar
@@ -1,0 +1,109 @@
+=== test_stream_read_timeout
+--- main.n
+import http.client
+import net.tcp
+import co
+
+fn serve():void! {
+    var server = tcp.listen('127.0.0.1:18992')
+    var conn = server.accept()
+    var request = vec<u8>.new(0, 4096)
+    conn.read(request)
+    conn.write(('HTTP/1.1 200 OK\r\n' +
+                'Content-Length: 5\r\n' +
+                'Content-Type: text/plain\r\n' +
+                '\r\n') as [u8])
+    co.sleep(200)
+    conn.close()
+    server.close()
+}
+
+fn main() {
+    go serve()
+    co.sleep(100)
+    var resp = client.new().timeout(50).get('http://127.0.0.1:18992/slow').send()
+    var scratch = vec<u8>.new(0, 16)
+    bool timed_out = false
+    resp.read(scratch) catch e {
+        timed_out = e.msg() == 'HTTP response read timeout'
+        0
+    }
+    resp.close()
+    assert(timed_out)
+}
+
+=== test_response_header_timeout
+--- main.n
+import http.client
+import net.tcp
+import co
+
+fn serve():void! {
+    var server = tcp.listen('127.0.0.1:18993')
+    var conn = server.accept()
+    var request = vec<u8>.new(0, 4096)
+    conn.read(request)
+    co.sleep(200)
+    conn.close()
+    server.close()
+}
+
+fn request_head():void! {
+    var response = client.new().timeout(50).get('http://127.0.0.1:18993/slow').send()
+    response.close()
+}
+
+fn main() {
+    go serve()
+    co.sleep(100)
+    bool timed_out = false
+    request_head() catch e {
+        timed_out = e.msg() == 'HTTP response read timeout'
+    }
+    assert(timed_out)
+}
+
+=== test_cross_coroutine_close_pending_read
+--- main.n
+import net.tcp
+import co
+
+type read_state_t = struct{
+    bool started
+    bool done
+    string error
+}
+
+fn serve():void! {
+    var server = tcp.listen('127.0.0.1:18994')
+    var conn = server.accept()
+    co.sleep(200)
+    conn.close()
+    server.close()
+}
+
+fn read_pending(ref<tcp.conn_t> conn, ref<read_state_t> state) {
+    state.started = true
+    var scratch = vec<u8>.new(0, 16)
+    conn.read(scratch) catch e {
+        state.error = e.msg()
+        0
+    }
+    state.done = true
+}
+
+fn main() {
+    go serve()
+    co.sleep(100)
+    var conn = tcp.connect('127.0.0.1:18994')
+    var state = new read_state_t()
+    go read_pending(conn, state)
+    for !state.started {
+        co.sleep(1)
+    }
+    conn.close()
+    for !state.done {
+        co.sleep(1)
+    }
+    assert(state.error == 'conn closed')
+}

--- a/tests/features/cases/20260806_01_sse_client.testar
+++ b/tests/features/cases/20260806_01_sse_client.testar
@@ -1,0 +1,118 @@
+=== test_sse_stream
+--- main.n
+import net.tcp
+import co
+import fmt
+import http.client
+
+fn serve():void! {
+    var server = tcp.listen('127.0.0.1:18997')
+    var conn = server.accept()
+
+    conn.write(('HTTP/1.1 200 OK\r\n' +
+                'Content-Type: text/event-stream\r\n' +
+                'Transfer-Encoding: chunked\r\n' +
+                '\r\n') as [u8])
+
+    // event 1: single data line, sent as two TCP packets to simulate real streaming
+    var ev1 = 'data: hello\r\n\r\n'
+    conn.write(fmt.sprintf('%x\r\n', ev1.len()) as [u8])
+    conn.write(ev1.slice(0, 6) as [u8])
+    co.sleep(50)
+    conn.write(ev1.slice(6, ev1.len()) as [u8])
+    conn.write('\r\n' as [u8])
+
+    // event 2: multi-line data, should join as line1\nline2, with a chunk-ext
+    var ev2 = 'data: line1\ndata: line2\n\n'
+    conn.write(fmt.sprintf('%x;part=two\r\n', ev2.len()) as [u8])
+    conn.write(ev2 as [u8])
+    conn.write('\r\n' as [u8])
+
+    // terminal chunk
+    conn.write('0\r\n\r\n' as [u8])
+    co.sleep(100)
+    conn.close()
+    server.close()
+}
+
+fn main():void! {
+    go serve()
+    co.sleep(200)
+
+    var resp = client.new().get('http://127.0.0.1:18997/').send()
+    assert(resp.chunked)
+
+    // no SSE-specific API: read the body line by line and parse data: fields
+    string data = ''
+    int count = 0
+    for true {
+        var line = resp.buf_conn.read_line() catch e {
+            break
+        }
+        if line == '' {
+            if data != '' {
+                println('event', count, ':', data)
+                count += 1
+                data = ''
+            }
+        } else if line.starts_with('data:') {
+            if data != '' {
+                data += '\n'
+            }
+            data += line.slice(5, line.len()).trim([' '])
+        }
+    }
+    println('events:', count)
+}
+
+--- output.txt
+event 0 : hello
+event 1 : line1
+line2
+events: 2
+
+=== test_text_chunked
+--- main.n
+import net.tcp
+import co
+import fmt
+import http.client
+
+fn serve():void! {
+    var server = tcp.listen('127.0.0.1:18998')
+    var conn = server.accept()
+
+    conn.write(('HTTP/1.1 200 OK\r\n' +
+                'Content-Type: text/plain\r\n' +
+                'Transfer-Encoding: chunked\r\n' +
+                '\r\n') as [u8])
+
+    var c1 = 'hello'
+    conn.write(fmt.sprintf('%x\r\n', c1.len()) as [u8])
+    conn.write(c1 as [u8])
+    conn.write('\r\n' as [u8])
+
+    var c2 = ' world'
+    conn.write(fmt.sprintf('%x\r\n', c2.len()) as [u8])
+    conn.write(c2 as [u8])
+    conn.write('\r\n' as [u8])
+
+    // terminal chunk + trailers
+    conn.write('0\r\nX-Trailer: done\r\n\r\n' as [u8])
+    co.sleep(100)
+    conn.close()
+    server.close()
+}
+
+fn main():void! {
+    go serve()
+    co.sleep(200)
+
+    var resp = client.new().get('http://127.0.0.1:18998/').send()
+    assert(resp.chunked)
+    assert(resp.text() == 'hello world')
+    println('chunked body ok')
+}
+
+--- output.txt
+chunked body ok

--- a/tests/features/cases/20260806_01_sse_client.testar
+++ b/tests/features/cases/20260806_01_sse_client.testar
@@ -116,3 +116,58 @@ fn main():void! {
 
 --- output.txt
 chunked body ok
+
+=== test_chunked_stream
+--- main.n
+import http.client
+import net.tcp
+import co
+
+fn serve():void! {
+    var server = tcp.listen('127.0.0.1:18991')
+    var conn = server.accept()
+    var request = vec<u8>.new(0, 4096)
+    conn.read(request)
+
+    conn.write(('HTTP/1.1 200 OK\r\n' +
+                'Transfer-Encoding: chunked\r\n' +
+                'Content-Type: text/event-stream\r\n' +
+                'X-Origin: https://example.test/a:b\r\n' +
+                '\r\n') as [u8])
+    conn.write('5;part=one\r\nhello\r\n' as [u8])
+    co.sleep(10)
+    conn.write('6\r\n world\r\n' as [u8])
+    conn.write('0\r\nX-Trailer: done\r\n\r\n' as [u8])
+    co.sleep(10)
+    conn.close()
+    server.close()
+}
+
+fn main() {
+    go serve()
+    co.sleep(100)
+
+    var resp = client.new().timeout(5000).get('http://127.0.0.1:18991/events').send()
+    var result = vec<u8>.cap_of(32)
+    var scratch = vec<u8>.new(0, 3)
+    bool eof = false
+    for !eof {
+        var n = resp.read(scratch) catch e {
+            assert(e.msg() == 'EOF')
+            eof = true
+            0
+        }
+        if eof {
+            break
+        }
+        result.append(scratch.slice(0, n))
+    }
+
+    assert(result as string == 'hello world')
+    assert(resp.header('x-origin') == 'https://example.test/a:b')
+    resp.close()
+    println('chunked stream ok')
+}
+
+--- output.txt
+chunked stream ok


### PR DESCRIPTION
## Summary

Client-side support for consuming streaming responses (SSE) with the simplest possible change: make chunked transfer encoding transparent in the HTTP client, so callers can read the response body line by line with the existing `buf_conn` — no SSE-specific API (same philosophy as Go's `net/http` + `bufio.Scanner`).

## Changes

- `std/http/client.n`:
  - New `chunked_reader_t` (implements `types.connable`): a 4-state decoder (chunk size line -> chunk data -> trailing CRLF -> trailers -> EOF) that hides chunk framing, chunk-ext (`1a;part=two`) and trailers behind the existing `buf.reader`. Forwards `write/close/set_read_timeout/read_timeout` to the underlying connection.
  - `send()` now wraps the body reader when the response has `Transfer-Encoding: chunked`, so `resp.buf_conn.read_line()` yields a clean byte stream regardless of network/chunk boundaries.
  - `text()` reads chunked bodies to EOF (previously it returned an empty string since chunked responses have no Content-Length).
- Tests: `20260806_01_sse_client` (testar) with a raw TCP server:
  - `test_sse_stream`: chunked `text/event-stream`, event split across two TCP packets with delay, multi-line `data:` fields, chunk-ext, then parses events line by line from the client side.
  - `test_text_chunked`: chunked text body with trailers read via `text()`.

## Verification

`cd build && ctest -R 20260806_01_sse_client -V` — passed, 3 consecutive runs.
No runtime changes.

## Notes

No SSE-specific API is introduced; consumers parse `data:` lines themselves (Go-style). `resp.chunked` is exposed for detection.