### PR TITLE
feat(json): Go-style dynamic parse (any + number), strict validation, stream parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,9 @@ example/
 # Python caches
 __pycache__/
 *.py[cod]
+
+# Worktrees
+.worktrees/
+
+# Testing artifacts
+Testing/

--- a/std/json/json.n
+++ b/std/json/json.n
@@ -1049,9 +1049,10 @@ fn deserialize_t.parser_number_token(&self):string! {
     return self.data.slice(start, self.cursor) as string
 }
 
-// stream_parser_t incrementally frames one JSON value across arbitrary input
-// chunks. Once framing is complete, value() performs the strict semantic parse.
-type stream_parser_t = struct{
+// reader_t incrementally frames one JSON value across arbitrary input
+// chunks (push model, like Boost.JSON's stream_parser). Once framing is
+// complete, value() performs the strict semantic parse.
+type reader_t = struct{
     [u8] data
     [u8] containers
     int scan_cursor
@@ -1063,13 +1064,14 @@ type stream_parser_t = struct{
     bool complete
 }
 
-fn stream_parser():ref<stream_parser_t> {
-    return new stream_parser_t(max_depth = DEFAULT_MAX_DEPTH)
+// reader 创建增量解析器（等价 Go 的 json.Decoder，push 模型）
+fn reader():ref<reader_t> {
+    return new reader_t(max_depth = DEFAULT_MAX_DEPTH)
 }
 
-// Returns true as soon as a complete root value has been framed. Additional
-// non-whitespace bytes are rejected, so one parser always represents one value.
-fn stream_parser_t.feed(&self, [u8] chunk):bool! {
+// write 喂入一个数据块；返回 true 表示一个完整根值已被框架识别。
+// 多余的非空白字节会被拒绝，一个 reader 只消费一个值。
+fn reader_t.write(&self, [u8] chunk):bool! {
     self.data.append(chunk)
 
     for self.scan_cursor < self.data.len() {
@@ -1155,7 +1157,7 @@ fn stream_parser_t.feed(&self, [u8] chunk):bool! {
     return self.complete
 }
 
-fn stream_parser_t.value(&self):any! {
+fn reader_t.value(&self):any! {
     if !self.complete {
         throw errorf('JSON value is incomplete')
     }

--- a/std/json/json.n
+++ b/std/json/json.n
@@ -7,6 +7,9 @@ import runtime
 
 var null_hash = @reflect_hash(null) 
 
+const DEFAULT_MAX_DEPTH = 256
+const DEFAULT_MAX_BYTES = 16777216
+
 // Convert object to json string
 pub fn serialize<T>(T object):string! {
     var t = reflect.typeof(object)
@@ -95,11 +98,13 @@ fn serialize_value(anyptr p, ref<reflect.type_t> t):[u8]! {
     }
 }
 
-fn serialize_string(string s):[u8] {
+fn serialize_string(string s):[u8]! {
     [u8] result = ['\"'.char()]
     
     var bytes = s as [u8]
-    for i, c in bytes {
+    int i = 0
+    for i < bytes.len() {
+        var c = bytes[i]
         match c {
             '\"'.char() -> {
                 result.push('\\'.char())
@@ -136,11 +141,17 @@ fn serialize_string(string s):[u8] {
                     result.push('u'.char())
                     var hex = fmt.sprintf('%04x', c as int)
                     result.append(hex as [u8])
-                } else {
+                } else if c < 0x80 {
                     result.push(c)
+                } else {
+                    var rune_len = valid_utf8_len(bytes, i)
+                    result.append(bytes.slice(i, i + rune_len))
+                    i += rune_len
+                    continue
                 }
             }
         }
+        i += 1
     }
     
     result.push('\"'.char())
@@ -224,15 +235,25 @@ fn serialize_map(anyptr p, ref<reflect.type_t> t):[u8]! {
 type deserialize_t = struct{
     int cursor
     [u8] data
+    int depth
+    int max_depth
 }
 
 // Convert json string to object
 pub fn deserialize<T>(string s):T! {
+    if s.len() > DEFAULT_MAX_BYTES {
+        throw errorf('JSON input exceeds %d bytes', DEFAULT_MAX_BYTES)
+    }
+
     var val = @default(T)
     var t = reflect.typeof(val)
 
-    var d = new deserialize_t(data = s as [u8])
+    var d = new deserialize_t(data = s as [u8], max_depth = DEFAULT_MAX_DEPTH)
     d.parser(&val as anyptr, t)
+    d.skip_whitespace()
+    if d.cursor != d.data.len() {
+        throw errorf('unexpected trailing data at position %d', d.cursor)
+    }
 
     return val
 }
@@ -325,8 +346,10 @@ fn deserialize_t.parser(&self, anyptr p, ref<reflect.type_t> t):void! {
 
 // p points to the stack address of struct
 fn deserialize_t.parser_struct(&self, anyptr p, ref<reflect.type_t> t):void! {
+    self.enter_container()
     self.must('{')
     if self.consume('}') {
+        self.leave_container()
         return
     }
 
@@ -356,13 +379,16 @@ fn deserialize_t.parser_struct(&self, anyptr p, ref<reflect.type_t> t):void! {
             self.must(',')
         }
     }
+    self.leave_container()
 }
 
 fn deserialize_t.parser_vec(&self, anyptr p, ref<reflect.type_t> t):void! {
+    self.enter_container()
     var rv = p as ptr<reflect.vec_t>
     rv.length = 0 // Assignment from zero
     self.must('[')
     if self.consume(']') {
+        self.leave_container()
         return
     }
 
@@ -382,12 +408,15 @@ fn deserialize_t.parser_vec(&self, anyptr p, ref<reflect.type_t> t):void! {
             self.must(',')
         }
     }
+    self.leave_container()
 }
 
 fn deserialize_t.parser_map(&self, anyptr p, ref<reflect.type_t> t):void! {
+    self.enter_container()
     var rv = p as ptr<reflect.map_t>
     self.must('{')
     if self.consume('}') {
+        self.leave_container()
         return
     }
     
@@ -407,6 +436,7 @@ fn deserialize_t.parser_map(&self, anyptr p, ref<reflect.type_t> t):void! {
             self.must(',')
         }
     }
+    self.leave_container()
 }
 
 fn deserialize_t.parser_bool(&self):bool! {
@@ -430,7 +460,7 @@ fn deserialize_t.parser_bool(&self):bool! {
 }
 
 fn deserialize_t.parser_number(&self):f64! {
-    var start = self.cursor
+    self.skip_whitespace()
     var negative = false
     var len = self.data.len()
     
@@ -445,10 +475,18 @@ fn deserialize_t.parser_number(&self):f64! {
     
     var integer_part = 0.0
     
-    // parser integer part
-    for self.cursor < len && self.is_digit(self.data[self.cursor]) {
+    // JSON forbids leading zeroes except for the value zero itself.
+    if self.data[self.cursor] == '0'.char() {
         integer_part = integer_part * 10.0 + (self.data[self.cursor] - '0'.char()) as f64
         self.cursor += 1
+        if self.cursor < len && self.is_digit(self.data[self.cursor]) {
+            throw errorf('leading zero in number at position %d', self.cursor)
+        }
+    } else {
+        for self.cursor < len && self.is_digit(self.data[self.cursor]) {
+            integer_part = integer_part * 10.0 + (self.data[self.cursor] - '0'.char()) as f64
+            self.cursor += 1
+        }
     }
     
     var result = integer_part
@@ -456,6 +494,9 @@ fn deserialize_t.parser_number(&self):f64! {
     // parsing optional fractional parts
     if self.cursor < len && self.data[self.cursor] == '.'.char() {
         self.cursor += 1
+        if self.cursor >= len || !self.is_digit(self.data[self.cursor]) {
+            throw errorf('expected digit after decimal point at position %d', self.cursor)
+        }
         var decimal_part = 0.0
         var decimal_places = 1.0
         
@@ -479,11 +520,18 @@ fn deserialize_t.parser_number(&self):f64! {
         } else if self.cursor < len && self.data[self.cursor] == '+'.char() {
             self.cursor += 1
         }
+
+        if self.cursor >= len || !self.is_digit(self.data[self.cursor]) {
+            throw errorf('expected exponent digit at position %d', self.cursor)
+        }
         
         var exponent = 0
         for self.cursor < len && self.is_digit(self.data[self.cursor]) {
             exponent = exponent * 10 + (self.data[self.cursor] - '0'.char()) as int
             self.cursor += 1
+            if exponent > 400 {
+                throw errorf('number cannot be represented as f64 at position %d', self.cursor)
+            }
         }
         
         var exp_multiplier = 1.0
@@ -536,17 +584,46 @@ fn deserialize_t.parser_string(&self):string! {
                 'n'.char() -> result.push('\n'.char())
                 'r'.char() -> result.push('\r'.char())
                 't'.char() -> result.push('\t'.char())
+                'u'.char() -> {
+                    self.cursor += 1
+                    var codepoint = self.parser_hex4()
+
+                    if codepoint >= 0xD800 && codepoint <= 0xDBFF {
+                        if self.cursor + 2 > self.data.len() ||
+                           self.data[self.cursor] != '\\'.char() ||
+                           self.data[self.cursor + 1] != 'u'.char() {
+                            throw errorf('missing low surrogate at position %d', self.cursor)
+                        }
+                        self.cursor += 2
+                        var low = self.parser_hex4()
+                        if low < 0xDC00 || low > 0xDFFF {
+                            throw errorf('invalid low surrogate at position %d', self.cursor - 4)
+                        }
+                        codepoint = 0x10000 + ((codepoint - 0xD800) << 10) + (low - 0xDC00)
+                    } else if codepoint >= 0xDC00 && codepoint <= 0xDFFF {
+                        throw errorf('unexpected low surrogate at position %d', self.cursor - 4)
+                    }
+
+                    result = append_utf8(result, codepoint)
+                    continue
+                }
                 _ -> {
                     throw errorf('invalid escape sequence at position %d', self.cursor)
                 }
             }
         } else {
-            // detect unescaped characters
-            if c == 9 || c == 10 || c == 13 {
+            if c < 0x20 {
                 throw errorf('invalid character in string literal at position %d', self.cursor)
             }
 
-            result.push(c)
+            if c < 0x80 {
+                result.push(c)
+            } else {
+                var rune_len = valid_utf8_len(self.data, self.cursor)
+                result.append(self.data.slice(self.cursor, self.cursor + rune_len))
+                self.cursor += rune_len
+                continue
+            }
         }
         
         self.cursor += 1
@@ -556,6 +633,7 @@ fn deserialize_t.parser_string(&self):string! {
 }
 
 fn deserialize_t.parser_nullable(&self, anyptr p, ref<reflect.type_t> t):void! {
+    self.skip_whitespace()
     if self.cursor >= self.data.len() {
         throw errorf('unexpected end of input at position %d', self.cursor)
     }
@@ -598,11 +676,10 @@ fn deserialize_t.parser_nullable(&self, anyptr p, ref<reflect.type_t> t):void! {
 }
 
 fn deserialize_t.parser_any(&self):any! {
+    self.skip_whitespace()
     if self.cursor >= self.data.len() {
         throw errorf('unexpected end of input at position %d', self.cursor)
     }
-
-    self.skip_whitespace()
     var c = self.data[self.cursor]
 
      match c {
@@ -676,4 +753,570 @@ fn deserialize_t.must(&self, string s):void! {
     if !self.consume(s) {
         throw errorf('expected `%s` at position %d', s, self.cursor)
     }
+}
+
+fn deserialize_t.enter_container(&self):void! {
+    self.depth += 1
+    if self.depth > self.max_depth {
+        throw errorf('JSON nesting exceeds %d at position %d', self.max_depth, self.cursor)
+    }
+}
+
+fn deserialize_t.leave_container(&self) {
+    self.depth -= 1
+}
+
+fn deserialize_t.parser_hex4(&self):int! {
+    if self.cursor + 4 > self.data.len() {
+        throw errorf('incomplete unicode escape at position %d', self.cursor)
+    }
+
+    int value = 0
+    for int i = 0; i < 4; i += 1 {
+        var c = self.data[self.cursor + i]
+        int digit = -1
+        if c >= '0'.char() && c <= '9'.char() {
+            digit = (c - '0'.char()) as int
+        } else if c >= 'a'.char() && c <= 'f'.char() {
+            digit = (c - 'a'.char()) as int + 10
+        } else if c >= 'A'.char() && c <= 'F'.char() {
+            digit = (c - 'A'.char()) as int + 10
+        } else {
+            throw errorf('invalid unicode escape at position %d', self.cursor + i)
+        }
+        value = value * 16 + digit
+    }
+    self.cursor += 4
+    return value
+}
+
+fn append_utf8([u8] result, int codepoint):[u8]! {
+    if codepoint < 0 || codepoint > 0x10FFFF ||
+       (codepoint >= 0xD800 && codepoint <= 0xDFFF) {
+        throw errorf('invalid unicode codepoint U+%x', codepoint)
+    }
+
+    if codepoint <= 0x7F {
+        result.push(codepoint as u8)
+    } else if codepoint <= 0x7FF {
+        result.push((0xC0 | (codepoint >> 6)) as u8)
+        result.push((0x80 | (codepoint & 0x3F)) as u8)
+    } else if codepoint <= 0xFFFF {
+        result.push((0xE0 | (codepoint >> 12)) as u8)
+        result.push((0x80 | ((codepoint >> 6) & 0x3F)) as u8)
+        result.push((0x80 | (codepoint & 0x3F)) as u8)
+    } else {
+        result.push((0xF0 | (codepoint >> 18)) as u8)
+        result.push((0x80 | ((codepoint >> 12) & 0x3F)) as u8)
+        result.push((0x80 | ((codepoint >> 6) & 0x3F)) as u8)
+        result.push((0x80 | (codepoint & 0x3F)) as u8)
+    }
+    return result
+}
+
+fn valid_utf8_len([u8] data, int cursor):int! {
+    var first = data[cursor]
+    int length = 0
+    if first >= 0xC2 && first <= 0xDF {
+        length = 2
+    } else if first >= 0xE0 && first <= 0xEF {
+        length = 3
+    } else if first >= 0xF0 && first <= 0xF4 {
+        length = 4
+    } else {
+        throw errorf('invalid UTF-8 at position %d', cursor)
+    }
+
+    if cursor + length > data.len() {
+        throw errorf('incomplete UTF-8 at position %d', cursor)
+    }
+    for int i = 1; i < length; i += 1 {
+        if data[cursor + i] < 0x80 || data[cursor + i] > 0xBF {
+            throw errorf('invalid UTF-8 continuation at position %d', cursor + i)
+        }
+    }
+
+    var second = data[cursor + 1]
+    if (first == 0xE0 && second < 0xA0) ||
+       (first == 0xED && second > 0x9F) ||
+       (first == 0xF0 && second < 0x90) ||
+       (first == 0xF4 && second > 0x8F) {
+        throw errorf('invalid UTF-8 scalar at position %d', cursor)
+    }
+    return length
+}
+
+const VALUE_NULL = 0
+const VALUE_BOOL = 1
+const VALUE_NUMBER = 2
+const VALUE_STRING = 3
+const VALUE_ARRAY = 4
+const VALUE_OBJECT = 5
+
+// value_t is the lossless dynamic JSON representation. Numbers retain their
+// original token instead of being coerced through f64, which is required for
+// large IDs and exact tool arguments.
+type value_t = struct{
+    u8 kind
+    bool boolean
+    string number
+    string text
+    [ref<value_t>] array
+    {string:ref<value_t>} object
+}
+
+fn null_value():value_t {
+    return value_t{kind: VALUE_NULL}
+}
+
+fn bool_value(bool value):value_t {
+    return value_t{kind: VALUE_BOOL, boolean: value}
+}
+
+fn number_value(string value):value_t! {
+    validate_number_token(value)
+    return value_t{kind: VALUE_NUMBER, number: value}
+}
+
+fn string_value(string value):value_t {
+    return value_t{kind: VALUE_STRING, text: value}
+}
+
+fn array_value([ref<value_t>] value):value_t {
+    return value_t{kind: VALUE_ARRAY, array: value}
+}
+
+fn object_value({string:ref<value_t>} value):value_t {
+    return value_t{kind: VALUE_OBJECT, object: value}
+}
+
+fn parse(string source):value_t! {
+    return parse_with_limits(source, DEFAULT_MAX_DEPTH, DEFAULT_MAX_BYTES)
+}
+
+fn parse_with_limits(string source, int max_depth, int max_bytes):value_t! {
+    if max_depth <= 0 || max_bytes <= 0 {
+        throw errorf('JSON limits must be positive')
+    }
+    if source.len() > max_bytes {
+        throw errorf('JSON input exceeds %d bytes', max_bytes)
+    }
+
+    var parser = new deserialize_t(
+        data = source as [u8],
+        max_depth = max_depth,
+    )
+    var value = parser.parser_value()
+    parser.skip_whitespace()
+    if parser.cursor != parser.data.len() {
+        throw errorf('unexpected trailing data at position %d', parser.cursor)
+    }
+    return value
+}
+
+fn stringify(value_t value):string! {
+    return stringify_value(box_value(value)) as string
+}
+
+fn value_t.stringify(*self):string! {
+    return stringify(*self)
+}
+
+fn value_t.get(*self, string key):ref<value_t>! {
+    if self.kind != VALUE_OBJECT {
+        throw errorf('JSON value is not an object')
+    }
+    if !self.object.contains(key) {
+        throw errorf('JSON object has no key `%s`', key)
+    }
+    return self.object[key]
+}
+
+fn value_t.as_string(*self):string! {
+    if self.kind != VALUE_STRING {
+        throw errorf('JSON value is not a string')
+    }
+    return self.text
+}
+
+fn value_t.as_bool(*self):bool! {
+    if self.kind != VALUE_BOOL {
+        throw errorf('JSON value is not a boolean')
+    }
+    return self.boolean
+}
+
+fn value_t.as_number(*self):string! {
+    if self.kind != VALUE_NUMBER {
+        throw errorf('JSON value is not a number')
+    }
+    return self.number
+}
+
+fn value_t.as_array(*self):[ref<value_t>]! {
+    if self.kind != VALUE_ARRAY {
+        throw errorf('JSON value is not an array')
+    }
+    return self.array
+}
+
+fn value_t.as_object(*self):{string:ref<value_t>}! {
+    if self.kind != VALUE_OBJECT {
+        throw errorf('JSON value is not an object')
+    }
+    return self.object
+}
+
+fn value_t.at(*self, int index):ref<value_t>! {
+    if self.kind != VALUE_ARRAY {
+        throw errorf('JSON value is not an array')
+    }
+    if index < 0 || index >= self.array.len() {
+        throw errorf('JSON array index out of range: %d', index)
+    }
+    return self.array[index]
+}
+
+fn value_t.is_null(*self):bool {
+    return self.kind == VALUE_NULL
+}
+
+fn deserialize_t.parser_value(&self):value_t! {
+    self.skip_whitespace()
+    if self.cursor >= self.data.len() {
+        throw errorf('unexpected end of input at position %d', self.cursor)
+    }
+
+    var c = self.data[self.cursor]
+    match c {
+        'n'.char() -> {
+            self.must('null')
+            return null_value()
+        }
+        't'.char()|'f'.char() -> {
+            return bool_value(self.parser_bool())
+        }
+        '"'.char() -> {
+            return string_value(self.parser_string())
+        }
+        '['.char() -> {
+            return self.parser_value_array()
+        }
+        '{'.char() -> {
+            return self.parser_value_object()
+        }
+        _ -> {
+            return number_value(self.parser_number_token())
+        }
+    }
+}
+
+fn deserialize_t.parser_value_array(&self):value_t! {
+    self.enter_container()
+    self.must('[')
+    [ref<value_t>] values = []
+    if self.consume(']') {
+        self.leave_container()
+        return array_value(values)
+    }
+
+    for true {
+        values.push(box_value(self.parser_value()))
+        if self.consume(']') {
+            break
+        }
+        self.must(',')
+    }
+    self.leave_container()
+    return array_value(values)
+}
+
+fn deserialize_t.parser_value_object(&self):value_t! {
+    self.enter_container()
+    self.must('{')
+    {string:ref<value_t>} values = {}
+    if self.consume('}') {
+        self.leave_container()
+        return object_value(values)
+    }
+
+    for true {
+        var key = self.parser_string()
+        self.must(':')
+        values[key] = box_value(self.parser_value())
+        if self.consume('}') {
+            break
+        }
+        self.must(',')
+    }
+    self.leave_container()
+    return object_value(values)
+}
+
+fn deserialize_t.parser_number_token(&self):string! {
+    self.skip_whitespace()
+    var start = self.cursor
+    var len = self.data.len()
+
+    if self.cursor < len && self.data[self.cursor] == '-'.char() {
+        self.cursor += 1
+    }
+    if self.cursor >= len {
+        throw errorf('invalid number at position %d', self.cursor)
+    }
+
+    if self.data[self.cursor] == '0'.char() {
+        self.cursor += 1
+        if self.cursor < len && self.is_digit(self.data[self.cursor]) {
+            throw errorf('leading zero in number at position %d', self.cursor)
+        }
+    } else if self.data[self.cursor] >= '1'.char() && self.data[self.cursor] <= '9'.char() {
+        for self.cursor < len && self.is_digit(self.data[self.cursor]) {
+            self.cursor += 1
+        }
+    } else {
+        throw errorf('invalid number at position %d', self.cursor)
+    }
+
+    if self.cursor < len && self.data[self.cursor] == '.'.char() {
+        self.cursor += 1
+        if self.cursor >= len || !self.is_digit(self.data[self.cursor]) {
+            throw errorf('expected digit after decimal point at position %d', self.cursor)
+        }
+        for self.cursor < len && self.is_digit(self.data[self.cursor]) {
+            self.cursor += 1
+        }
+    }
+
+    if self.cursor < len &&
+       (self.data[self.cursor] == 'e'.char() || self.data[self.cursor] == 'E'.char()) {
+        self.cursor += 1
+        if self.cursor < len &&
+           (self.data[self.cursor] == '+'.char() || self.data[self.cursor] == '-'.char()) {
+            self.cursor += 1
+        }
+        if self.cursor >= len || !self.is_digit(self.data[self.cursor]) {
+            throw errorf('expected exponent digit at position %d', self.cursor)
+        }
+        for self.cursor < len && self.is_digit(self.data[self.cursor]) {
+            self.cursor += 1
+        }
+    }
+
+    return self.data.slice(start, self.cursor) as string
+}
+
+fn stringify_value(ref<value_t> value):[u8]! {
+    match value.kind {
+        VALUE_NULL -> {
+            return 'null' as [u8]
+        }
+        VALUE_BOOL -> {
+            if value.boolean {
+                return 'true' as [u8]
+            }
+            return 'false' as [u8]
+        }
+        VALUE_NUMBER -> {
+            validate_number_token(value.number)
+            return value.number as [u8]
+        }
+        VALUE_STRING -> {
+            return serialize_string(value.text)
+        }
+        VALUE_ARRAY -> {
+            [u8] result = ['['.char()]
+            for i, item in value.array {
+                result.append(stringify_value(item))
+                if i < value.array.len() - 1 {
+                    result.push(','.char())
+                }
+            }
+            result.push(']'.char())
+            return result
+        }
+        VALUE_OBJECT -> {
+            [u8] result = ['{'.char()]
+            int index = 0
+            for key, item in value.object {
+                result.append(serialize_string(key))
+                result.push(':'.char())
+                result.append(stringify_value(item))
+                if index < value.object.len() - 1 {
+                    result.push(','.char())
+                }
+                index += 1
+            }
+            result.push('}'.char())
+            return result
+        }
+        _ -> {
+            throw errorf('invalid JSON value kind %d', value.kind)
+        }
+    }
+}
+
+fn box_value(value_t value):ref<value_t> {
+    var boxed = new value_t()
+    *boxed = value
+    return boxed
+}
+
+fn validate_number_token(string source):void! {
+    var parser = new deserialize_t(data = source as [u8], max_depth = 1)
+    parser.parser_number_token()
+    if parser.cursor != parser.data.len() {
+        throw errorf('invalid JSON number at position %d', parser.cursor)
+    }
+}
+
+// stream_parser_t incrementally frames one JSON value across arbitrary input
+// chunks. Once framing is complete, value() performs the strict semantic parse.
+type stream_parser_t = struct{
+    [u8] data
+    [u8] containers
+    int scan_cursor
+    int max_depth
+    int max_bytes
+    bool started
+    bool in_string
+    bool escaped
+    bool scalar
+    bool complete
+    bool finished
+}
+
+fn stream_parser():ref<stream_parser_t> {
+    return stream_parser_with_limits(DEFAULT_MAX_DEPTH, DEFAULT_MAX_BYTES)
+}
+
+fn stream_parser_with_limits(int max_depth, int max_bytes):ref<stream_parser_t> {
+    return new stream_parser_t(max_depth = max_depth, max_bytes = max_bytes)
+}
+
+// Returns true as soon as a complete root value has been framed. Additional
+// non-whitespace bytes are rejected, so one parser always represents one value.
+fn stream_parser_t.feed(&self, [u8] chunk):bool! {
+    if self.finished {
+        throw errorf('JSON stream parser is finished')
+    }
+    if self.data.len() + chunk.len() > self.max_bytes {
+        throw errorf('JSON input exceeds %d bytes', self.max_bytes)
+    }
+    self.data.append(chunk)
+
+    for self.scan_cursor < self.data.len() {
+        var c = self.data[self.scan_cursor]
+
+        if self.complete {
+            if !json_space(c) {
+                throw errorf('unexpected trailing data at position %d', self.scan_cursor)
+            }
+            self.scan_cursor += 1
+            continue
+        }
+
+        if !self.started {
+            if json_space(c) {
+                self.scan_cursor += 1
+                continue
+            }
+            self.started = true
+            if c == '"'.char() {
+                self.in_string = true
+                self.scalar = true
+            } else if c == '{'.char() || c == '['.char() {
+                self.containers.push(c)
+            } else {
+                self.scalar = true
+            }
+            self.scan_cursor += 1
+            continue
+        }
+
+        if self.in_string {
+            if self.escaped {
+                self.escaped = false
+            } else if c == '\\'.char() {
+                self.escaped = true
+            } else if c == '"'.char() {
+                self.in_string = false
+                if self.scalar && self.containers.len() == 0 {
+                    self.complete = true
+                }
+            } else if c < 0x20 {
+                throw errorf('invalid character in string literal at position %d', self.scan_cursor)
+            }
+            self.scan_cursor += 1
+            continue
+        }
+
+        if self.scalar {
+            if json_space(c) {
+                self.complete = true
+                self.scan_cursor += 1
+                continue
+            }
+            self.scan_cursor += 1
+            continue
+        }
+
+        if c == '"'.char() {
+            self.in_string = true
+        } else if c == '{'.char() || c == '['.char() {
+            self.containers.push(c)
+            if self.containers.len() > self.max_depth {
+                throw errorf('JSON nesting exceeds %d at position %d', self.max_depth, self.scan_cursor)
+            }
+        } else if c == '}'.char() || c == ']'.char() {
+            if self.containers.len() == 0 {
+                throw errorf('unexpected closing delimiter at position %d', self.scan_cursor)
+            }
+            var opening = self.containers[self.containers.len() - 1]
+            if (opening == '{'.char() && c != '}'.char()) ||
+               (opening == '['.char() && c != ']'.char()) {
+                throw errorf('mismatched closing delimiter at position %d', self.scan_cursor)
+            }
+            self.containers = self.containers.slice(0, self.containers.len() - 1)
+            if self.containers.len() == 0 {
+                self.complete = true
+            }
+        }
+        self.scan_cursor += 1
+    }
+
+    return self.complete
+}
+
+fn stream_parser_t.value(&self):value_t! {
+    if !self.complete {
+        throw errorf('JSON value is incomplete')
+    }
+    return parse_with_limits(self.data as string, self.max_depth, self.max_bytes)
+}
+
+fn stream_parser_t.finish(&self):value_t! {
+    if self.finished {
+        throw errorf('JSON stream parser is already finished')
+    }
+    self.finished = true
+    var value = parse_with_limits(self.data as string, self.max_depth, self.max_bytes)
+    self.complete = true
+    return value
+}
+
+fn stream_parser_t.reset(&self) {
+    self.data = []
+    self.containers = []
+    self.scan_cursor = 0
+    self.started = false
+    self.in_string = false
+    self.escaped = false
+    self.scalar = false
+    self.complete = false
+    self.finished = false
+}
+
+fn json_space(u8 c):bool {
+    return c == ' '.char() || c == '\t'.char() || c == '\r'.char() || c == '\n'.char()
 }

--- a/std/json/json.n
+++ b/std/json/json.n
@@ -7,8 +7,9 @@ import runtime
 
 var null_hash = @reflect_hash(null) 
 
-// number 是无损数字类型（等价 Go 的 json.Number）：JSON 数字以原始文本保留，
-// 不经 f64 转换，避免大整数/长 ID 精度丢失
+// number is the lossless JSON number type (like Go's json.Number): numbers
+// keep their original token instead of being coerced through f64, so large
+// integers and long IDs round-trip exactly.
 type number = string
 
 var number_hash = @reflect_hash(number)
@@ -84,7 +85,7 @@ fn serialize_value(anyptr p, ref<reflect.type_t> t):[u8]! {
 
             var any_type = reflect.typeof_hash(rv.rtype.hash)
 
-            // json.number 按原始数字文本输出，不加引号
+            // json.number is emitted verbatim (no quotes)
             var any_p = &rv.value as anyptr
             if any_type.storage_kind == reflect.storage_kind_t.IND {
                 any_p = rv.value
@@ -143,7 +144,7 @@ fn serialize_string(string s):[u8] {
                 result.push('t'.char())
             }
             _ -> {
-                // 对于控制字符（0-31），使用unicode转义
+                // escape control characters (0-31) as unicode escapes
                 if c < 32 {
                     result.push('\\'.char())
                     result.push('u'.char())
@@ -152,7 +153,7 @@ fn serialize_string(string s):[u8] {
                 } else if c < 0x80 {
                     result.push(c)
                 } else {
-                    // 非法 UTF-8 替换为 \ufffd（与 Go 的 json.Marshal 一致）
+                    // invalid UTF-8 is replaced with \ufffd (like Go's json.Marshal)
                     var rune_len = utf8_len(bytes, i)
                     if rune_len == 0 {
                         result.append(`\ufffd` as [u8])
@@ -602,7 +603,7 @@ fn deserialize_t.parser_string(&self):string! {
                     var codepoint = self.parser_hex4()
 
                     if codepoint >= 0xD800 && codepoint <= 0xDBFF {
-                        // 高代理项: 尝试配对后续的 \uXXXX 低代理项
+                        // high surrogate: try to pair a following \uXXXX low surrogate
                         int low = -1
                         if self.cursor + 6 <= self.data.len() &&
                            self.data[self.cursor] == '\\'.char() &&
@@ -614,11 +615,11 @@ fn deserialize_t.parser_string(&self):string! {
                             self.parser_hex4()
                             codepoint = 0x10000 + ((codepoint - 0xD800) << 10) + (low - 0xDC00)
                         } else {
-                            // 未配对的代理项替换为 U+FFFD（与 Go 一致）
+                            // unpaired surrogate is replaced with U+FFFD (like Go)
                             codepoint = 0xFFFD
                         }
                     } else if codepoint >= 0xDC00 && codepoint <= 0xDFFF {
-                        // 孤立的低代理项替换为 U+FFFD（与 Go 一致）
+                        // lone low surrogate is replaced with U+FFFD (like Go)
                         codepoint = 0xFFFD
                     }
 
@@ -637,7 +638,7 @@ fn deserialize_t.parser_string(&self):string! {
             if c < 0x80 {
                 result.push(c)
             } else {
-                // 非法 UTF-8 字节替换为 U+FFFD（与 Go 的解码行为一致）
+                // invalid raw UTF-8 bytes are replaced with U+FFFD (like Go's decoder)
                 var rune_len = utf8_len(self.data, self.cursor)
                 if rune_len == 0 {
                     result.push(0xEF as u8)
@@ -840,7 +841,7 @@ fn append_utf8([u8] result, int codepoint):[u8] {
     return result
 }
 
-// 返回从 cursor 开始的合法 UTF-8 序列长度; 非法序列返回 0
+// Returns the length of the UTF-8 sequence starting at cursor, or 0 if invalid
 fn utf8_len([u8] data, int cursor):int {
     if cursor >= data.len() {
         return 0
@@ -876,7 +877,7 @@ fn utf8_len([u8] data, int cursor):int {
     return length
 }
 
-// 非推进式读取 4 位十六进制; 非法时返回 -1
+// Non-advancing 4-hex-digit read; returns -1 on invalid input
 fn hex4_peek([u8] data, int cursor):int {
     if cursor + 4 > data.len() {
         return -1
@@ -900,9 +901,9 @@ fn hex4_peek([u8] data, int cursor):int {
     return value
 }
 
-// parse 将 JSON 文本解析为动态值（等价 Go 的 Unmarshal + UseNumber）：
-// 对象 -> {string:any}，数组 -> [any]，字符串 -> string，
-// 布尔 -> bool，null -> null，数字 -> number（无损原始文本）
+// parse parses JSON text into a dynamic value (like Go's Unmarshal + UseNumber):
+// objects -> {string:any}, arrays -> [any], strings -> string,
+// bools -> bool, null -> null, numbers -> number (lossless original token)
 fn parse(string source):any! {
     return parse_with_depth(source, DEFAULT_MAX_DEPTH)
 }
@@ -1064,13 +1065,14 @@ type reader_t = struct{
     bool complete
 }
 
-// reader 创建增量解析器（等价 Go 的 json.Decoder，push 模型）
+// reader creates an incremental parser (like Go's json.Decoder, push model)
 fn reader():ref<reader_t> {
     return new reader_t(max_depth = DEFAULT_MAX_DEPTH)
 }
 
-// write 喂入一个数据块；返回 true 表示一个完整根值已被框架识别。
-// 多余的非空白字节会被拒绝，一个 reader 只消费一个值。
+// write feeds one data chunk; returns true once a complete root value has
+// been framed. Extra non-whitespace bytes are rejected, so one reader
+// always consumes exactly one value.
 fn reader_t.write(&self, [u8] chunk):bool! {
     self.data.append(chunk)
 

--- a/std/json/json.n
+++ b/std/json/json.n
@@ -7,6 +7,12 @@ import runtime
 
 var null_hash = @reflect_hash(null) 
 
+// number 是无损数字类型（等价 Go 的 json.Number）：JSON 数字以原始文本保留，
+// 不经 f64 转换，避免大整数/长 ID 精度丢失
+type number = string
+
+var number_hash = @reflect_hash(number)
+
 const DEFAULT_MAX_DEPTH = 256
 
 // Convert object to json string
@@ -78,10 +84,13 @@ fn serialize_value(anyptr p, ref<reflect.type_t> t):[u8]! {
 
             var any_type = reflect.typeof_hash(rv.rtype.hash)
 
-            // get value p
+            // json.number 按原始数字文本输出，不加引号
             var any_p = &rv.value as anyptr
             if any_type.storage_kind == reflect.storage_kind_t.IND {
                 any_p = rv.value
+            }
+            if rv.rtype.hash == number_hash {
+                return unsafe.ptr_to<string>(any_p) as [u8]
             }
 
             return serialize_value(any_p, any_type)
@@ -891,55 +900,14 @@ fn hex4_peek([u8] data, int cursor):int {
     return value
 }
 
-const VALUE_NULL = 0
-const VALUE_BOOL = 1
-const VALUE_NUMBER = 2
-const VALUE_STRING = 3
-const VALUE_ARRAY = 4
-const VALUE_OBJECT = 5
-
-// value_t is the lossless dynamic JSON representation. Numbers retain their
-// original token instead of being coerced through f64, which is required for
-// large IDs and exact tool arguments.
-type value_t = struct{
-    u8 kind
-    bool boolean
-    string number
-    string text
-    [ref<value_t>] array
-    {string:ref<value_t>} object
+// parse 将 JSON 文本解析为动态值（等价 Go 的 Unmarshal + UseNumber）：
+// 对象 -> {string:any}，数组 -> [any]，字符串 -> string，
+// 布尔 -> bool，null -> null，数字 -> number（无损原始文本）
+fn parse(string source):any! {
+    return parse_with_depth(source, DEFAULT_MAX_DEPTH)
 }
 
-fn null_value():value_t {
-    return value_t{kind: VALUE_NULL}
-}
-
-fn bool_value(bool value):value_t {
-    return value_t{kind: VALUE_BOOL, boolean: value}
-}
-
-fn number_value(string value):value_t! {
-    validate_number_token(value)
-    return value_t{kind: VALUE_NUMBER, number: value}
-}
-
-fn string_value(string value):value_t {
-    return value_t{kind: VALUE_STRING, text: value}
-}
-
-fn array_value([ref<value_t>] value):value_t {
-    return value_t{kind: VALUE_ARRAY, array: value}
-}
-
-fn object_value({string:ref<value_t>} value):value_t {
-    return value_t{kind: VALUE_OBJECT, object: value}
-}
-
-fn parse(string source):value_t! {
-    return parse_with_limits(source, DEFAULT_MAX_DEPTH)
-}
-
-fn parse_with_limits(string source, int max_depth):value_t! {
+fn parse_with_depth(string source, int max_depth):any! {
     if max_depth <= 0 {
         throw errorf('JSON max depth must be positive')
     }
@@ -956,74 +924,7 @@ fn parse_with_limits(string source, int max_depth):value_t! {
     return value
 }
 
-fn stringify(value_t value):string! {
-    return stringify_value(box_value(value)) as string
-}
-
-fn value_t.stringify(*self):string! {
-    return stringify(*self)
-}
-
-fn value_t.get(*self, string key):ref<value_t>! {
-    if self.kind != VALUE_OBJECT {
-        throw errorf('JSON value is not an object')
-    }
-    if !self.object.contains(key) {
-        throw errorf('JSON object has no key `%s`', key)
-    }
-    return self.object[key]
-}
-
-fn value_t.as_string(*self):string! {
-    if self.kind != VALUE_STRING {
-        throw errorf('JSON value is not a string')
-    }
-    return self.text
-}
-
-fn value_t.as_bool(*self):bool! {
-    if self.kind != VALUE_BOOL {
-        throw errorf('JSON value is not a boolean')
-    }
-    return self.boolean
-}
-
-fn value_t.as_number(*self):string! {
-    if self.kind != VALUE_NUMBER {
-        throw errorf('JSON value is not a number')
-    }
-    return self.number
-}
-
-fn value_t.as_array(*self):[ref<value_t>]! {
-    if self.kind != VALUE_ARRAY {
-        throw errorf('JSON value is not an array')
-    }
-    return self.array
-}
-
-fn value_t.as_object(*self):{string:ref<value_t>}! {
-    if self.kind != VALUE_OBJECT {
-        throw errorf('JSON value is not an object')
-    }
-    return self.object
-}
-
-fn value_t.at(*self, int index):ref<value_t>! {
-    if self.kind != VALUE_ARRAY {
-        throw errorf('JSON value is not an array')
-    }
-    if index < 0 || index >= self.array.len() {
-        throw errorf('JSON array index out of range: %d', index)
-    }
-    return self.array[index]
-}
-
-fn value_t.is_null(*self):bool {
-    return self.kind == VALUE_NULL
-}
-
-fn deserialize_t.parser_value(&self):value_t! {
+fn deserialize_t.parser_value(&self):any! {
     self.skip_whitespace()
     if self.cursor >= self.data.len() {
         throw errorf('unexpected end of input at position %d', self.cursor)
@@ -1033,13 +934,13 @@ fn deserialize_t.parser_value(&self):value_t! {
     match c {
         'n'.char() -> {
             self.must('null')
-            return null_value()
+            return null
         }
         't'.char()|'f'.char() -> {
-            return bool_value(self.parser_bool())
+            return self.parser_bool()
         }
         '"'.char() -> {
-            return string_value(self.parser_string())
+            return self.parser_string()
         }
         '['.char() -> {
             return self.parser_value_array()
@@ -1048,51 +949,51 @@ fn deserialize_t.parser_value(&self):value_t! {
             return self.parser_value_object()
         }
         _ -> {
-            return number_value(self.parser_number_token())
+            return self.parser_number_token() as number
         }
     }
 }
 
-fn deserialize_t.parser_value_array(&self):value_t! {
+fn deserialize_t.parser_value_array(&self):[any]! {
     self.enter_container()
     self.must('[')
-    [ref<value_t>] values = []
+    [any] values = []
     if self.consume(']') {
         self.leave_container()
-        return array_value(values)
+        return values
     }
 
     for true {
-        values.push(box_value(self.parser_value()))
+        values.push(self.parser_value())
         if self.consume(']') {
             break
         }
         self.must(',')
     }
     self.leave_container()
-    return array_value(values)
+    return values
 }
 
-fn deserialize_t.parser_value_object(&self):value_t! {
+fn deserialize_t.parser_value_object(&self):{string:any}! {
     self.enter_container()
     self.must('{')
-    {string:ref<value_t>} values = {}
+    {string:any} values = {}
     if self.consume('}') {
         self.leave_container()
-        return object_value(values)
+        return values
     }
 
     for true {
         var key = self.parser_string()
         self.must(':')
-        values[key] = box_value(self.parser_value())
+        values[key] = self.parser_value()
         if self.consume('}') {
             break
         }
         self.must(',')
     }
     self.leave_container()
-    return object_value(values)
+    return values
 }
 
 fn deserialize_t.parser_number_token(&self):string! {
@@ -1148,70 +1049,6 @@ fn deserialize_t.parser_number_token(&self):string! {
     return self.data.slice(start, self.cursor) as string
 }
 
-fn stringify_value(ref<value_t> value):[u8]! {
-    match value.kind {
-        VALUE_NULL -> {
-            return 'null' as [u8]
-        }
-        VALUE_BOOL -> {
-            if value.boolean {
-                return 'true' as [u8]
-            }
-            return 'false' as [u8]
-        }
-        VALUE_NUMBER -> {
-            validate_number_token(value.number)
-            return value.number as [u8]
-        }
-        VALUE_STRING -> {
-            return serialize_string(value.text)
-        }
-        VALUE_ARRAY -> {
-            [u8] result = ['['.char()]
-            for i, item in value.array {
-                result.append(stringify_value(item))
-                if i < value.array.len() - 1 {
-                    result.push(','.char())
-                }
-            }
-            result.push(']'.char())
-            return result
-        }
-        VALUE_OBJECT -> {
-            [u8] result = ['{'.char()]
-            int index = 0
-            for key, item in value.object {
-                result.append(serialize_string(key))
-                result.push(':'.char())
-                result.append(stringify_value(item))
-                if index < value.object.len() - 1 {
-                    result.push(','.char())
-                }
-                index += 1
-            }
-            result.push('}'.char())
-            return result
-        }
-        _ -> {
-            throw errorf('invalid JSON value kind %d', value.kind)
-        }
-    }
-}
-
-fn box_value(value_t value):ref<value_t> {
-    var boxed = new value_t()
-    *boxed = value
-    return boxed
-}
-
-fn validate_number_token(string source):void! {
-    var parser = new deserialize_t(data = source as [u8], max_depth = 1)
-    parser.parser_number_token()
-    if parser.cursor != parser.data.len() {
-        throw errorf('invalid JSON number at position %d', parser.cursor)
-    }
-}
-
 // stream_parser_t incrementally frames one JSON value across arbitrary input
 // chunks. Once framing is complete, value() performs the strict semantic parse.
 type stream_parser_t = struct{
@@ -1224,23 +1061,15 @@ type stream_parser_t = struct{
     bool escaped
     bool scalar
     bool complete
-    bool finished
 }
 
 fn stream_parser():ref<stream_parser_t> {
-    return stream_parser_with_limits(DEFAULT_MAX_DEPTH)
-}
-
-fn stream_parser_with_limits(int max_depth):ref<stream_parser_t> {
-    return new stream_parser_t(max_depth = max_depth)
+    return new stream_parser_t(max_depth = DEFAULT_MAX_DEPTH)
 }
 
 // Returns true as soon as a complete root value has been framed. Additional
 // non-whitespace bytes are rejected, so one parser always represents one value.
 fn stream_parser_t.feed(&self, [u8] chunk):bool! {
-    if self.finished {
-        throw errorf('JSON stream parser is finished')
-    }
     self.data.append(chunk)
 
     for self.scan_cursor < self.data.len() {
@@ -1326,33 +1155,11 @@ fn stream_parser_t.feed(&self, [u8] chunk):bool! {
     return self.complete
 }
 
-fn stream_parser_t.value(&self):value_t! {
+fn stream_parser_t.value(&self):any! {
     if !self.complete {
         throw errorf('JSON value is incomplete')
     }
-    return parse_with_limits(self.data as string, self.max_depth)
-}
-
-fn stream_parser_t.finish(&self):value_t! {
-    if self.finished {
-        throw errorf('JSON stream parser is already finished')
-    }
-    self.finished = true
-    var value = parse_with_limits(self.data as string, self.max_depth)
-    self.complete = true
-    return value
-}
-
-fn stream_parser_t.reset(&self) {
-    self.data = []
-    self.containers = []
-    self.scan_cursor = 0
-    self.started = false
-    self.in_string = false
-    self.escaped = false
-    self.scalar = false
-    self.complete = false
-    self.finished = false
+    return parse_with_depth(self.data as string, self.max_depth)
 }
 
 fn json_space(u8 c):bool {

--- a/std/json/json.n
+++ b/std/json/json.n
@@ -10,11 +10,12 @@ var null_hash = @reflect_hash(null)
 // number is the lossless JSON number type (like Go's json.Number): numbers
 // keep their original token instead of being coerced through f64, so large
 // integers and long IDs round-trip exactly.
-type number = string
+pub type number = string
 
 var number_hash = @reflect_hash(number)
 
 const DEFAULT_MAX_DEPTH = 256
+const DEFAULT_MAX_BYTES = 16777216
 
 // Convert object to json string
 pub fn serialize<T>(T object):string! {
@@ -904,7 +905,7 @@ fn hex4_peek([u8] data, int cursor):int {
 // parse parses JSON text into a dynamic value (like Go's Unmarshal + UseNumber):
 // objects -> {string:any}, arrays -> [any], strings -> string,
 // bools -> bool, null -> null, numbers -> number (lossless original token)
-fn parse(string source):any! {
+pub fn parse(string source):any! {
     return parse_with_depth(source, DEFAULT_MAX_DEPTH)
 }
 
@@ -1066,14 +1067,14 @@ type reader_t = struct{
 }
 
 // reader creates an incremental parser (like Go's json.Decoder, push model)
-fn reader():ref<reader_t> {
+pub fn reader():ref<reader_t> {
     return new reader_t(max_depth = DEFAULT_MAX_DEPTH)
 }
 
 // write feeds one data chunk; returns true once a complete root value has
 // been framed. Extra non-whitespace bytes are rejected, so one reader
 // always consumes exactly one value.
-fn reader_t.write(&self, [u8] chunk):bool! {
+pub fn reader_t.write(&self, [u8] chunk):bool! {
     self.data.append(chunk)
 
     for self.scan_cursor < self.data.len() {
@@ -1159,7 +1160,7 @@ fn reader_t.write(&self, [u8] chunk):bool! {
     return self.complete
 }
 
-fn reader_t.value(&self):any! {
+pub fn reader_t.value(&self):any! {
     if !self.complete {
         throw errorf('JSON value is incomplete')
     }

--- a/std/json/json.n
+++ b/std/json/json.n
@@ -8,7 +8,6 @@ import runtime
 var null_hash = @reflect_hash(null) 
 
 const DEFAULT_MAX_DEPTH = 256
-const DEFAULT_MAX_BYTES = 16777216
 
 // Convert object to json string
 pub fn serialize<T>(T object):string! {
@@ -98,7 +97,7 @@ fn serialize_value(anyptr p, ref<reflect.type_t> t):[u8]! {
     }
 }
 
-fn serialize_string(string s):[u8]! {
+fn serialize_string(string s):[u8] {
     [u8] result = ['\"'.char()]
     
     var bytes = s as [u8]
@@ -144,7 +143,13 @@ fn serialize_string(string s):[u8]! {
                 } else if c < 0x80 {
                     result.push(c)
                 } else {
-                    var rune_len = valid_utf8_len(bytes, i)
+                    // 非法 UTF-8 替换为 \ufffd（与 Go 的 json.Marshal 一致）
+                    var rune_len = utf8_len(bytes, i)
+                    if rune_len == 0 {
+                        result.append(`\ufffd` as [u8])
+                        i += 1
+                        continue
+                    }
                     result.append(bytes.slice(i, i + rune_len))
                     i += rune_len
                     continue
@@ -244,7 +249,6 @@ pub fn deserialize<T>(string s):T! {
     if s.len() > DEFAULT_MAX_BYTES {
         throw errorf('JSON input exceeds %d bytes', DEFAULT_MAX_BYTES)
     }
-
     var val = @default(T)
     var t = reflect.typeof(val)
 
@@ -589,19 +593,24 @@ fn deserialize_t.parser_string(&self):string! {
                     var codepoint = self.parser_hex4()
 
                     if codepoint >= 0xD800 && codepoint <= 0xDBFF {
-                        if self.cursor + 2 > self.data.len() ||
-                           self.data[self.cursor] != '\\'.char() ||
-                           self.data[self.cursor + 1] != 'u'.char() {
-                            throw errorf('missing low surrogate at position %d', self.cursor)
+                        // 高代理项: 尝试配对后续的 \uXXXX 低代理项
+                        int low = -1
+                        if self.cursor + 6 <= self.data.len() &&
+                           self.data[self.cursor] == '\\'.char() &&
+                           self.data[self.cursor + 1] == 'u'.char() {
+                            low = hex4_peek(self.data, self.cursor + 2)
                         }
-                        self.cursor += 2
-                        var low = self.parser_hex4()
-                        if low < 0xDC00 || low > 0xDFFF {
-                            throw errorf('invalid low surrogate at position %d', self.cursor - 4)
+                        if low >= 0xDC00 && low <= 0xDFFF {
+                            self.cursor += 2
+                            self.parser_hex4()
+                            codepoint = 0x10000 + ((codepoint - 0xD800) << 10) + (low - 0xDC00)
+                        } else {
+                            // 未配对的代理项替换为 U+FFFD（与 Go 一致）
+                            codepoint = 0xFFFD
                         }
-                        codepoint = 0x10000 + ((codepoint - 0xD800) << 10) + (low - 0xDC00)
                     } else if codepoint >= 0xDC00 && codepoint <= 0xDFFF {
-                        throw errorf('unexpected low surrogate at position %d', self.cursor - 4)
+                        // 孤立的低代理项替换为 U+FFFD（与 Go 一致）
+                        codepoint = 0xFFFD
                     }
 
                     result = append_utf8(result, codepoint)
@@ -619,7 +628,15 @@ fn deserialize_t.parser_string(&self):string! {
             if c < 0x80 {
                 result.push(c)
             } else {
-                var rune_len = valid_utf8_len(self.data, self.cursor)
+                // 非法 UTF-8 字节替换为 U+FFFD（与 Go 的解码行为一致）
+                var rune_len = utf8_len(self.data, self.cursor)
+                if rune_len == 0 {
+                    result.push(0xEF as u8)
+                    result.push(0xBF as u8)
+                    result.push(0xBD as u8)
+                    self.cursor += 1
+                    continue
+                }
                 result.append(self.data.slice(self.cursor, self.cursor + rune_len))
                 self.cursor += rune_len
                 continue
@@ -790,10 +807,10 @@ fn deserialize_t.parser_hex4(&self):int! {
     return value
 }
 
-fn append_utf8([u8] result, int codepoint):[u8]! {
+fn append_utf8([u8] result, int codepoint):[u8] {
     if codepoint < 0 || codepoint > 0x10FFFF ||
        (codepoint >= 0xD800 && codepoint <= 0xDFFF) {
-        throw errorf('invalid unicode codepoint U+%x', codepoint)
+        codepoint = 0xFFFD
     }
 
     if codepoint <= 0x7F {
@@ -814,7 +831,11 @@ fn append_utf8([u8] result, int codepoint):[u8]! {
     return result
 }
 
-fn valid_utf8_len([u8] data, int cursor):int! {
+// 返回从 cursor 开始的合法 UTF-8 序列长度; 非法序列返回 0
+fn utf8_len([u8] data, int cursor):int {
+    if cursor >= data.len() {
+        return 0
+    }
     var first = data[cursor]
     int length = 0
     if first >= 0xC2 && first <= 0xDF {
@@ -824,15 +845,15 @@ fn valid_utf8_len([u8] data, int cursor):int! {
     } else if first >= 0xF0 && first <= 0xF4 {
         length = 4
     } else {
-        throw errorf('invalid UTF-8 at position %d', cursor)
+        return 0
     }
 
     if cursor + length > data.len() {
-        throw errorf('incomplete UTF-8 at position %d', cursor)
+        return 0
     }
     for int i = 1; i < length; i += 1 {
         if data[cursor + i] < 0x80 || data[cursor + i] > 0xBF {
-            throw errorf('invalid UTF-8 continuation at position %d', cursor + i)
+            return 0
         }
     }
 
@@ -841,9 +862,33 @@ fn valid_utf8_len([u8] data, int cursor):int! {
        (first == 0xED && second > 0x9F) ||
        (first == 0xF0 && second < 0x90) ||
        (first == 0xF4 && second > 0x8F) {
-        throw errorf('invalid UTF-8 scalar at position %d', cursor)
+        return 0
     }
     return length
+}
+
+// 非推进式读取 4 位十六进制; 非法时返回 -1
+fn hex4_peek([u8] data, int cursor):int {
+    if cursor + 4 > data.len() {
+        return -1
+    }
+
+    int value = 0
+    for int i = 0; i < 4; i += 1 {
+        var c = data[cursor + i]
+        int digit = -1
+        if c >= '0'.char() && c <= '9'.char() {
+            digit = (c - '0'.char()) as int
+        } else if c >= 'a'.char() && c <= 'f'.char() {
+            digit = (c - 'a'.char()) as int + 10
+        } else if c >= 'A'.char() && c <= 'F'.char() {
+            digit = (c - 'A'.char()) as int + 10
+        } else {
+            return -1
+        }
+        value = value * 16 + digit
+    }
+    return value
 }
 
 const VALUE_NULL = 0
@@ -891,15 +936,12 @@ fn object_value({string:ref<value_t>} value):value_t {
 }
 
 fn parse(string source):value_t! {
-    return parse_with_limits(source, DEFAULT_MAX_DEPTH, DEFAULT_MAX_BYTES)
+    return parse_with_limits(source, DEFAULT_MAX_DEPTH)
 }
 
-fn parse_with_limits(string source, int max_depth, int max_bytes):value_t! {
-    if max_depth <= 0 || max_bytes <= 0 {
-        throw errorf('JSON limits must be positive')
-    }
-    if source.len() > max_bytes {
-        throw errorf('JSON input exceeds %d bytes', max_bytes)
+fn parse_with_limits(string source, int max_depth):value_t! {
+    if max_depth <= 0 {
+        throw errorf('JSON max depth must be positive')
     }
 
     var parser = new deserialize_t(
@@ -1177,7 +1219,6 @@ type stream_parser_t = struct{
     [u8] containers
     int scan_cursor
     int max_depth
-    int max_bytes
     bool started
     bool in_string
     bool escaped
@@ -1187,11 +1228,11 @@ type stream_parser_t = struct{
 }
 
 fn stream_parser():ref<stream_parser_t> {
-    return stream_parser_with_limits(DEFAULT_MAX_DEPTH, DEFAULT_MAX_BYTES)
+    return stream_parser_with_limits(DEFAULT_MAX_DEPTH)
 }
 
-fn stream_parser_with_limits(int max_depth, int max_bytes):ref<stream_parser_t> {
-    return new stream_parser_t(max_depth = max_depth, max_bytes = max_bytes)
+fn stream_parser_with_limits(int max_depth):ref<stream_parser_t> {
+    return new stream_parser_t(max_depth = max_depth)
 }
 
 // Returns true as soon as a complete root value has been framed. Additional
@@ -1199,9 +1240,6 @@ fn stream_parser_with_limits(int max_depth, int max_bytes):ref<stream_parser_t> 
 fn stream_parser_t.feed(&self, [u8] chunk):bool! {
     if self.finished {
         throw errorf('JSON stream parser is finished')
-    }
-    if self.data.len() + chunk.len() > self.max_bytes {
-        throw errorf('JSON input exceeds %d bytes', self.max_bytes)
     }
     self.data.append(chunk)
 
@@ -1292,7 +1330,7 @@ fn stream_parser_t.value(&self):value_t! {
     if !self.complete {
         throw errorf('JSON value is incomplete')
     }
-    return parse_with_limits(self.data as string, self.max_depth, self.max_bytes)
+    return parse_with_limits(self.data as string, self.max_depth)
 }
 
 fn stream_parser_t.finish(&self):value_t! {
@@ -1300,7 +1338,7 @@ fn stream_parser_t.finish(&self):value_t! {
         throw errorf('JSON stream parser is already finished')
     }
     self.finished = true
-    var value = parse_with_limits(self.data as string, self.max_depth, self.max_bytes)
+    var value = parse_with_limits(self.data as string, self.max_depth)
     self.complete = true
     return value
 }

--- a/tests/features/20260729_00_json_stream.c
+++ b/tests/features/20260729_00_json_stream.c
@@ -1,0 +1,5 @@
+#include "tests/test.h"
+
+int main(void) {
+    feature_testar_test(NULL);
+}

--- a/tests/features/cases/20260729_00_json_stream.testar
+++ b/tests/features/cases/20260729_00_json_stream.testar
@@ -1,0 +1,88 @@
+=== test_unicode_and_surrogate_pairs
+--- main.n
+import json
+
+fn main() {
+    var decoded = json.deserialize<string>(`"A\u4F60\u597D \uD83D\uDE00"`)
+    assert(decoded == 'A你好 😀')
+
+    var value = json.parse(`{"emoji":"\uD83D\uDE00","cjk":"\u4F60\u597D"}`)
+    assert(value.get('emoji').as_string() == '😀')
+    assert(value.get('cjk').as_string() == '你好')
+}
+
+=== test_invalid_unicode_and_numbers
+--- main.n
+import json
+
+fn rejects(string source):bool {
+    var value = json.parse(source) catch e {
+        return true
+    }
+    return false
+}
+
+fn main() {
+    assert(rejects(`"\uD83D"`))
+    assert(rejects(`"\uDE00"`))
+    assert(rejects(`"\uD83D\u0041"`))
+    assert(rejects(`"\x"`))
+    assert(rejects('"line\nbreak"'))
+    assert(rejects('01'))
+    assert(rejects('1.'))
+    assert(rejects('1e'))
+    assert(rejects('+1'))
+    assert(rejects('true false'))
+}
+
+=== test_lossless_dynamic
+--- main.n
+import json
+
+fn main() {
+    var value = json.parse('{"big":9007199254740993,"emoji":"\\uD83D\\uDE00","items":[true,null]}')
+    assert(value.get('big').as_number() == '9007199254740993')
+    assert(value.get('emoji').as_string() == '😀')
+    var items = value.get('items')
+    assert(items.at(0).as_bool())
+    assert(items.at(1).is_null())
+
+    var encoded = value.stringify()
+    var reparsed = json.parse(encoded)
+    assert(reparsed.get('big').as_number() == '9007199254740993')
+    assert(reparsed.get('emoji').as_string() == '😀')
+}
+
+=== test_limits
+--- main.n
+import json
+
+fn main() {
+    bool rejected = false
+    var value = json.parse_with_limits('[[0]]', 1, 100) catch e {
+        rejected = true
+        json.null_value()
+    }
+    assert(rejected)
+
+    rejected = false
+    value = json.parse_with_limits('[]', 10, 1) catch e {
+        rejected = true
+        json.null_value()
+    }
+    assert(rejected)
+}
+
+=== test_invalid_utf8_serialize
+--- main.n
+import json
+
+fn main() {
+    var invalid = [0xC0 as u8, 0x80 as u8] as string
+    bool rejected = false
+    var encoded = json.serialize(invalid) catch e {
+        rejected = true
+        ''
+    }
+    assert(rejected)
+}

--- a/tests/features/cases/20260729_00_json_stream.testar
+++ b/tests/features/cases/20260729_00_json_stream.testar
@@ -6,9 +6,9 @@ fn main() {
     var decoded = json.deserialize<string>(`"A\u4F60\u597D \uD83D\uDE00"`)
     assert(decoded == 'A你好 😀')
 
-    var value = json.parse(`{"emoji":"\uD83D\uDE00","cjk":"\u4F60\u597D"}`)
-    assert(value.get('emoji').as_string() == '😀')
-    assert(value.get('cjk').as_string() == '你好')
+    var value = json.parse(`{"emoji":"\uD83D\uDE00","cjk":"\u4F60\u597D"}`) as {string:any}
+    assert(value['emoji'] as string == '😀')
+    assert(value['cjk'] as string == '你好')
 }
 
 === test_unpaired_surrogates_and_bad_utf8_replaced
@@ -17,17 +17,17 @@ import json
 
 fn main() {
     // Go replaces unpaired surrogates with U+FFFD instead of erroring
-    var lone_high = json.parse(`"\uD83D"`)
-    assert(lone_high.as_string() == '�')
-    var lone_low = json.parse(`"\uDE00"`)
-    assert(lone_low.as_string() == '�')
-    var high_ascii = json.parse(`"\uD83D\u0041"`)
-    assert(high_ascii.as_string() == '�A')
+    var lone_high = json.parse(`"\uD83D"`) as string
+    assert(lone_high == '�')
+    var lone_low = json.parse(`"\uDE00"`) as string
+    assert(lone_low == '�')
+    var high_ascii = json.parse(`"\uD83D\u0041"`) as string
+    assert(high_ascii == '�A')
 
     // Go replaces invalid raw UTF-8 with U+FFFD instead of erroring
     var invalid = [0xC0 as u8, 0x80 as u8] as string
-    var raw = json.parse('"' + invalid + '"')
-    assert(raw.as_string() == '��')
+    var raw = json.parse('"' + invalid + '"') as string
+    assert(raw == '��')
 
     // Go replaces invalid UTF-8 with escaped \ufffd during marshal, no error
     var encoded = json.serialize(invalid) catch e {
@@ -63,28 +63,42 @@ fn main() {
 import json
 
 fn main() {
-    var value = json.parse('{"big":9007199254740993,"emoji":"\\uD83D\\uDE00","items":[true,null]}')
-    assert(value.get('big').as_number() == '9007199254740993')
-    assert(value.get('emoji').as_string() == '😀')
-    var items = value.get('items')
-    assert(items.at(0).as_bool())
-    assert(items.at(1).is_null())
+    // 无损数字: 9007199254740993 超出 f64 精度，number 保留原始文本
+    var value = json.parse('{"big":9007199254740993,"emoji":"\\uD83D\\uDE00","items":[true,null]}') as {string:any}
+    assert(value['big'] as json.number == '9007199254740993' as json.number)
+    assert(value['emoji'] as string == '😀')
+    var items = value['items'] as [any]
+    assert(items[0] as bool)
+    assert(json.serialize(items[1]) == 'null')
 
-    var encoded = value.stringify()
-    var reparsed = json.parse(encoded)
-    assert(reparsed.get('big').as_number() == '9007199254740993')
-    assert(reparsed.get('emoji').as_string() == '😀')
+    // round-trip: serialize 后重新 parse 仍无损
+    var encoded = json.serialize(value)
+    var reparsed = json.parse(encoded) as {string:any}
+    assert(reparsed['big'] as json.number == '9007199254740993' as json.number)
+    assert(reparsed['emoji'] as string == '😀')
 }
 
 === test_limits
 --- main.n
 import json
 
-fn main() {
-    bool rejected = false
-    var value = json.parse_with_limits('[[0]]', 1) catch e {
-        rejected = true
-        json.null_value()
+fn rejects(string source):bool {
+    var value = json.parse(source) catch e {
+        return true
     }
-    assert(rejected)
+    return false
+}
+
+fn main() {
+    // 嵌套深度超过 256 时拒绝（Go 同样有硬编码深度限制）
+    string deep = ''
+    for int i = 0; i < 300; i += 1 {
+        deep += '['
+    }
+    deep += '0'
+    for int i = 0; i < 300; i += 1 {
+        deep += ']'
+    }
+
+    assert(rejects(deep))
 }

--- a/tests/features/cases/20260729_00_json_stream.testar
+++ b/tests/features/cases/20260729_00_json_stream.testar
@@ -63,7 +63,7 @@ fn main() {
 import json
 
 fn main() {
-    // 无损数字: 9007199254740993 超出 f64 精度，number 保留原始文本
+    // lossless number: 9007199254740993 exceeds f64 precision, number keeps the raw token
     var value = json.parse('{"big":9007199254740993,"emoji":"\\uD83D\\uDE00","items":[true,null]}') as {string:any}
     assert(value['big'] as json.number == '9007199254740993' as json.number)
     assert(value['emoji'] as string == '😀')
@@ -71,7 +71,7 @@ fn main() {
     assert(items[0] as bool)
     assert(json.serialize(items[1]) == 'null')
 
-    // round-trip: serialize 后重新 parse 仍无损
+    // round-trip: parse -> serialize -> parse stays lossless
     var encoded = json.serialize(value)
     var reparsed = json.parse(encoded) as {string:any}
     assert(reparsed['big'] as json.number == '9007199254740993' as json.number)
@@ -90,7 +90,7 @@ fn rejects(string source):bool {
 }
 
 fn main() {
-    // 嵌套深度超过 256 时拒绝（Go 同样有硬编码深度限制）
+    // nesting deeper than 256 is rejected (Go has a hardcoded limit too)
     string deep = ''
     for int i = 0; i < 300; i += 1 {
         deep += '['
@@ -108,20 +108,20 @@ fn main() {
 import json
 
 fn main() {
-    // 分块喂入，最后一块返回 true
+    // chunked feeding; the final chunk returns true
     var r = json.reader()
     assert(!r.write('{"a":' as [u8]))
     assert(r.write('1}' as [u8]))
     var v = r.value() as {string:any}
     assert(v['a'] as json.number == '1' as json.number)
 
-    // 单块完整喂入
+    // single-chunk input
     var r2 = json.reader()
     assert(r2.write('[1,2]' as [u8]))
     var arr = r2.value() as [any]
     assert(arr[1] as json.number == '2' as json.number)
 
-    // 尾随非空白数据 → write 抛错
+    // trailing non-whitespace data -> write errors
     var r3 = json.reader()
     bool trailing = false
     var ok = r3.write('{} x' as [u8]) catch e {
@@ -130,7 +130,7 @@ fn main() {
     }
     assert(trailing)
 
-    // 框架未完成时 value() 抛错
+    // value() errors while framing is incomplete
     var r4 = json.reader()
     r4.write('[1' as [u8])
     var incomplete = false

--- a/tests/features/cases/20260729_00_json_stream.testar
+++ b/tests/features/cases/20260729_00_json_stream.testar
@@ -102,3 +102,41 @@ fn main() {
 
     assert(rejects(deep))
 }
+
+=== test_stream_reader
+--- main.n
+import json
+
+fn main() {
+    // 分块喂入，最后一块返回 true
+    var r = json.reader()
+    assert(!r.write('{"a":' as [u8]))
+    assert(r.write('1}' as [u8]))
+    var v = r.value() as {string:any}
+    assert(v['a'] as json.number == '1' as json.number)
+
+    // 单块完整喂入
+    var r2 = json.reader()
+    assert(r2.write('[1,2]' as [u8]))
+    var arr = r2.value() as [any]
+    assert(arr[1] as json.number == '2' as json.number)
+
+    // 尾随非空白数据 → write 抛错
+    var r3 = json.reader()
+    bool trailing = false
+    var ok = r3.write('{} x' as [u8]) catch e {
+        trailing = true
+        false
+    }
+    assert(trailing)
+
+    // 框架未完成时 value() 抛错
+    var r4 = json.reader()
+    r4.write('[1' as [u8])
+    var incomplete = false
+    var v4 = r4.value() catch e {
+        incomplete = true
+        false
+    }
+    assert(incomplete)
+}

--- a/tests/features/cases/20260729_00_json_stream.testar
+++ b/tests/features/cases/20260729_00_json_stream.testar
@@ -11,7 +11,33 @@ fn main() {
     assert(value.get('cjk').as_string() == '你好')
 }
 
-=== test_invalid_unicode_and_numbers
+=== test_unpaired_surrogates_and_bad_utf8_replaced
+--- main.n
+import json
+
+fn main() {
+    // Go replaces unpaired surrogates with U+FFFD instead of erroring
+    var lone_high = json.parse(`"\uD83D"`)
+    assert(lone_high.as_string() == '�')
+    var lone_low = json.parse(`"\uDE00"`)
+    assert(lone_low.as_string() == '�')
+    var high_ascii = json.parse(`"\uD83D\u0041"`)
+    assert(high_ascii.as_string() == '�A')
+
+    // Go replaces invalid raw UTF-8 with U+FFFD instead of erroring
+    var invalid = [0xC0 as u8, 0x80 as u8] as string
+    var raw = json.parse('"' + invalid + '"')
+    assert(raw.as_string() == '��')
+
+    // Go replaces invalid UTF-8 with escaped \ufffd during marshal, no error
+    var encoded = json.serialize(invalid) catch e {
+        assert(false)
+        ''
+    }
+    assert(encoded == `"\ufffd\ufffd"`)
+}
+
+=== test_invalid_and_strict_numbers
 --- main.n
 import json
 
@@ -23,9 +49,6 @@ fn rejects(string source):bool {
 }
 
 fn main() {
-    assert(rejects(`"\uD83D"`))
-    assert(rejects(`"\uDE00"`))
-    assert(rejects(`"\uD83D\u0041"`))
     assert(rejects(`"\x"`))
     assert(rejects('"line\nbreak"'))
     assert(rejects('01'))
@@ -59,30 +82,9 @@ import json
 
 fn main() {
     bool rejected = false
-    var value = json.parse_with_limits('[[0]]', 1, 100) catch e {
+    var value = json.parse_with_limits('[[0]]', 1) catch e {
         rejected = true
         json.null_value()
-    }
-    assert(rejected)
-
-    rejected = false
-    value = json.parse_with_limits('[]', 10, 1) catch e {
-        rejected = true
-        json.null_value()
-    }
-    assert(rejected)
-}
-
-=== test_invalid_utf8_serialize
---- main.n
-import json
-
-fn main() {
-    var invalid = [0xC0 as u8, 0x80 as u8] as string
-    bool rejected = false
-    var encoded = json.serialize(invalid) catch e {
-        rejected = true
-        ''
     }
     assert(rejected)
 }


### PR DESCRIPTION
## Summary

Enhances `std/json` with Go-style dynamic parsing, strict spec-compliant validation, and incremental stream parsing — aligned with Go's `encoding/json` (verified against Go 1.26.1 source and behavior).

## Design: Go-style minimal API

Dynamic JSON is represented with the language's `any` type (exactly like Go's `any`), not a custom value type. Numbers are kept lossless via a distinct `json.number` type — an alias of `string`, analogous to Go's `json.Number`.

```nature
// parse: dynamic parse, lossless numbers (Go: json.Unmarshal + Decoder.UseNumber)
var v = json.parse(`{"big":9007199254740993,"emoji":"😀"}`) as {string:any}
var big = v['big'] as json.number   // '9007199254740993', exact
var emoji = v['emoji'] as string

// serialize: reuses the existing serialize<T>, emits number tokens verbatim
var out = json.serialize(v)

// stream parse (Go: json.Decoder.Decode, push-style)
var p = json.reader()
p.write(chunk1)
if p.write(chunk2) {
    var value = p.value()  // any
}
```

## API surface (all of it)

- `type number` — lossless number (alias of string, distinct at runtime, like `json.Number`)
- `parse(string source):any!` — dynamic parse; objects -> `{string:any}`, arrays -> `[any]`, strings -> `string`, bools -> `bool`, null -> `null`, numbers -> `number`
- `reader()` / `reader_t.write([u8] chunk):bool!` / `reader_t.value():any!`
- Existing `serialize<T>` / `deserialize<T>` extended with the `number` case

Removed (compared to the earlier draft): `value_t` type, 6 constructors (`null_value`/`bool_value`/...), 9 accessors (`get`/`as_*`/`at`/`is_null`), `stringify`, `parse_with_limits`, `stream_parser_with_limits`, `finish`/`reset` — 25+ symbols down to 4 (final: `parse`, `reader`/`write`/`value`, `number`). Depth limit (256) is hardcoded like Go's `maxNestingDepth` (10000); no size limit (Go has none built-in).

## Behavior aligned with Go (verified against Go 1.26.1)

- Unpaired surrogates and invalid raw UTF-8 decode to U+FFFD, no error (Go's `unquoteBytes`)
- Marshal of invalid UTF-8 emits escaped `\ufffd`, no error (Go's `appendString`)
- Strict rejections matching Go's scanner: trailing data, `01`, `1.`, `1e`, `+1`, control chars, bad escapes, over-deep nesting

## Tests

5 feature cases (`20260729_00_json_stream.*`): unicode & surrogate pairs, U+FFFD replacement, strict number/escape rejections, lossless round-trip (parse -> serialize -> parse), depth limit.

- `ctest -R json` -> 5/5 passed (4 pre-existing + 1 new)
- Full `ctest`: only 3 network tests fail in the local environment (external hosts unreachable, e.g. ifconfig.me DNS-poisoned to 223.73.148.1) — unrelated, same failures on master
