### PR TITLE
feat(compiler): add pub module visibility control

### DIFF
--- a/.github/workflows/test-local.yml
+++ b/.github/workflows/test-local.yml
@@ -49,6 +49,10 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Test NLS
+        working-directory: nls
+        run: cargo test --all --locked
+
       - name: Setup Musl for Linux
         if: ${{ contains(matrix.target, 'linux') }}
         run: sudo apt-get install musl-tools

--- a/.github/workflows/test-local.yml
+++ b/.github/workflows/test-local.yml
@@ -51,6 +51,8 @@ jobs:
 
       - name: Test NLS
         working-directory: nls
+        env:
+          NATURE_ROOT: ${{ github.workspace }}
         run: cargo test --all --locked
 
       - name: Setup Musl for Linux

--- a/.github/workflows/test-local.yml
+++ b/.github/workflows/test-local.yml
@@ -33,9 +33,16 @@ jobs:
 
       - name: Setup Go for package
         uses: actions/setup-go@v5
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
         with:
           go-version: stable
           cache-dependency-path: package/go.sum
+
+      - name: Setup Rust for nls
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -43,11 +50,6 @@ jobs:
           workspaces: nls
           prefix-key: nls
           cache-on-failure: true
-
-      - name: Setup Rust for nls
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
 
       - name: Test NLS
         working-directory: nls

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -26,17 +26,17 @@ jobs:
           go-version: stable
           cache-dependency-path: package/go.sum
 
+      - name: Setup Rust for nls
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: nls
           prefix-key: nls
           cache-on-failure: true
-
-      - name: Setup Rust for nls
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
 
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2

--- a/.github/workflows/test-ubi.yml
+++ b/.github/workflows/test-ubi.yml
@@ -34,17 +34,17 @@ jobs:
           go-version: stable
           cache-dependency-path: package/go.sum
 
+      - name: Setup Rust for nls
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: nls
           prefix-key: nls
           cache-on-failure: true
-
-      - name: Setup Rust for nls
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
 
       - name: Setup Musl for Linux
         run: sudo apt-get install musl-tools

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -1,0 +1,111 @@
+name: Test Windows
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: test-windows
+  cancel-in-progress: true
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  test-windows:
+    name: Test (windows-amd64)
+    runs-on: windows-latest
+    timeout-minutes: 90
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          submodules: true
+
+      - name: Setup Go for package
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache-dependency-path: package/go.sum
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: nls
+          prefix-key: nls
+          cache-on-failure: true
+
+      - name: Setup Rust for nls
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+
+      - name: Setup MSYS2 for Windows
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          path-type: inherit
+          update: true
+          install: >-
+            git
+            mingw-w64-ucrt-x86_64-binutils
+            mingw-w64-ucrt-x86_64-cmake
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-ninja
+            mingw-w64-ucrt-x86_64-python
+
+      - name: Setup Zig for Windows runtime
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.14.1
+
+      - name: Cache LLaMA model files
+        uses: actions/cache@v4
+        with:
+          path: tests/features/cases/20250324_00_llama/stories15M.bin
+          key: llama-model-stories15M-${{ hashFiles('tests/features/cases/20250324_00_llama/README.md') }}
+          restore-keys: |
+            llama-model-stories15M-
+
+      - name: Download LLaMA model file
+        run: |
+          cd tests/features/cases/20250324_00_llama
+          if [ ! -f "stories15M.bin" ]; then
+            curl --fail --location --retry 3 \
+              --output stories15M.bin \
+              https://huggingface.co/karpathy/tinyllamas/resolve/main/stories15M.bin
+          fi
+
+      - name: Set job parallelism
+        id: parallelism
+        run: echo "j_flag=2" >> "$GITHUB_OUTPUT"
+
+      - name: Build Runtime
+        run: |
+          export ZIG_GLOBAL_CACHE_DIR="$PWD/build-zig-global-cache"
+          export ZIG_LOCAL_CACHE_DIR="$PWD/build-zig-local-cache"
+          test "$(zig version)" = 0.14.1
+          cmake -S runtime -B build-runtime -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_TOOLCHAIN_FILE="$(cygpath -m "$PWD/cmake/windows-amd64-toolchain.cmake")" \
+            -DCMAKE_SYSTEM_PROCESSOR=amd64
+          cmake --build build-runtime \
+            --target runtime \
+            --parallel "${{ steps.parallelism.outputs.j_flag }}"
+          test -s lib/windows_amd64/libruntime.a
+
+      - name: Build Project
+        run: |
+          cmake -S . -B build-release -G Ninja \
+            -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+            -DCMAKE_SYSTEM_PROCESSOR=amd64
+          cmake --build build-release \
+            --parallel "${{ steps.parallelism.outputs.j_flag }}"
+
+      - name: Test
+        run: |
+          drive="$(pwd -W | cut -c1 | tr '[:upper:]' '[:lower:]')"
+          mkdir -p "/${drive}/tmp"
+          ctest --test-dir build-release/tests --output-on-failure --timeout 120

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -30,17 +30,17 @@ jobs:
           go-version: stable
           cache-dependency-path: package/go.sum
 
+      - name: Setup Rust for nls
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: nls
           prefix-key: nls
           cache-on-failure: true
-
-      - name: Setup Rust for nls
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
 
       - name: Setup MSYS2 for Windows
         uses: msys2/setup-msys2@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,17 +37,17 @@ jobs:
           go-version: stable
           cache-dependency-path: package/go.sum
 
+      - name: Setup Rust for nls
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: nls
           prefix-key: nls
           cache-on-failure: true
-
-      - name: Setup Rust for nls
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
 
       - name: Setup Musl for Linux
         if: ${{ contains(matrix.target, 'linux') }}
@@ -142,17 +142,17 @@ jobs:
           go-version: stable
           cache-dependency-path: package/go.sum
 
+      - name: Setup Rust for nls
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: nls
           prefix-key: nls
           cache-on-failure: true
-
-      - name: Setup Rust for nls
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
 
       - name: Setup MSYS2 for Windows
         uses: msys2/setup-msys2@v2

--- a/nls/src/analyzer.rs
+++ b/nls/src/analyzer.rs
@@ -525,11 +525,12 @@ pub fn register_global_symbol(m: &mut Module, symbol_table: &mut SymbolTable, st
                 // 构造全局唯一标识符
                 var_decl.ident = format_global_ident(m.ident.clone(), var_decl.ident.clone());
 
-                match symbol_table.define_symbol_in_scope(
+                match symbol_table.define_symbol_in_scope_with_visibility(
                     var_decl.ident.clone(),
                     SymbolKind::Var(var_decl_mutex.clone()),
                     var_decl.symbol_start,
                     m.module_scope_id,
+                    var_decl.is_pub,
                 ) {
                     Ok(symbol_id) => {
                         var_decl.symbol_id = symbol_id;
@@ -549,11 +550,12 @@ pub fn register_global_symbol(m: &mut Module, symbol_table: &mut SymbolTable, st
                 }
 
                 // 注册到全局符号表
-                if let Ok(symbol_id) = symbol_table.define_global_symbol(
+                if let Ok(symbol_id) = symbol_table.define_global_symbol_with_visibility(
                     var_decl.ident.clone(),
                     SymbolKind::Var(var_decl_mutex.clone()),
                     var_decl.symbol_start,
                     m.module_scope_id,
+                    var_decl.is_pub,
                 ) {
                     symbol_table.set_symbol_source_path(symbol_id, &m.path);
                 }
@@ -562,11 +564,12 @@ pub fn register_global_symbol(m: &mut Module, symbol_table: &mut SymbolTable, st
                 let mut constdef = constdef_mutex.lock().unwrap();
                 constdef.ident = format_global_ident(m.ident.clone(), constdef.ident.clone());
 
-                match symbol_table.define_symbol_in_scope(
+                match symbol_table.define_symbol_in_scope_with_visibility(
                     constdef.ident.clone(),
                     SymbolKind::Const(constdef_mutex.clone()),
                     constdef.symbol_start,
                     m.module_scope_id,
+                    constdef.is_pub,
                 ) {
                     Ok(symbol_id) => {
                         constdef.symbol_id = symbol_id;
@@ -586,11 +589,12 @@ pub fn register_global_symbol(m: &mut Module, symbol_table: &mut SymbolTable, st
                 }
 
                 // Register in global symbol table (needed for selective imports)
-                if let Ok(symbol_id) = symbol_table.define_global_symbol(
+                if let Ok(symbol_id) = symbol_table.define_global_symbol_with_visibility(
                     constdef.ident.clone(),
                     SymbolKind::Const(constdef_mutex.clone()),
                     constdef.symbol_start,
                     m.module_scope_id,
+                    constdef.is_pub,
                 ) {
                     symbol_table.set_symbol_source_path(symbol_id, &m.path);
                 }
@@ -599,7 +603,13 @@ pub fn register_global_symbol(m: &mut Module, symbol_table: &mut SymbolTable, st
                 let mut typedef = typedef_mutex.lock().unwrap();
                 typedef.ident = format_global_ident(m.ident.clone(), typedef.ident.clone());
 
-                match symbol_table.define_symbol_in_scope(typedef.ident.clone(), SymbolKind::Type(typedef_mutex.clone()), typedef.symbol_start, m.module_scope_id) {
+                match symbol_table.define_symbol_in_scope_with_visibility(
+                    typedef.ident.clone(),
+                    SymbolKind::Type(typedef_mutex.clone()),
+                    typedef.symbol_start,
+                    m.module_scope_id,
+                    typedef.is_pub,
+                ) {
                     Ok(symbol_id) => {
                         typedef.symbol_id = symbol_id;
                         symbol_table.set_symbol_source_path(symbol_id, &m.path);
@@ -618,7 +628,13 @@ pub fn register_global_symbol(m: &mut Module, symbol_table: &mut SymbolTable, st
                     }
                 }
 
-                if let Ok(symbol_id) = symbol_table.define_global_symbol(typedef.ident.clone(), SymbolKind::Type(typedef_mutex.clone()), typedef.symbol_start, m.module_scope_id) {
+                if let Ok(symbol_id) = symbol_table.define_global_symbol_with_visibility(
+                    typedef.ident.clone(),
+                    SymbolKind::Type(typedef_mutex.clone()),
+                    typedef.symbol_start,
+                    m.module_scope_id,
+                    typedef.is_pub,
+                ) {
                     symbol_table.set_symbol_source_path(symbol_id, &m.path);
                 }
             }
@@ -629,7 +645,13 @@ pub fn register_global_symbol(m: &mut Module, symbol_table: &mut SymbolTable, st
                 if fndef.impl_type.kind.is_unknown() {
                     fndef.symbol_name = format_global_ident(m.ident.clone(), symbol_name.clone());
 
-                    match symbol_table.define_symbol_in_scope(fndef.symbol_name.clone(), SymbolKind::Fn(fndef_mutex.clone()), fndef.symbol_start, m.module_scope_id) {
+                    match symbol_table.define_symbol_in_scope_with_visibility(
+                        fndef.symbol_name.clone(),
+                        SymbolKind::Fn(fndef_mutex.clone()),
+                        fndef.symbol_start,
+                        m.module_scope_id,
+                        fndef.is_pub,
+                    ) {
                         Ok(symbol_id) => {
                             fndef.symbol_id = symbol_id;
                             symbol_table.set_symbol_source_path(symbol_id, &m.path);
@@ -647,7 +669,13 @@ pub fn register_global_symbol(m: &mut Module, symbol_table: &mut SymbolTable, st
                         }
                     }
 
-                    if let Ok(symbol_id) = symbol_table.define_global_symbol(fndef.symbol_name.clone(), SymbolKind::Fn(fndef_mutex.clone()), fndef.symbol_start, m.module_scope_id) {
+                    if let Ok(symbol_id) = symbol_table.define_global_symbol_with_visibility(
+                        fndef.symbol_name.clone(),
+                        SymbolKind::Fn(fndef_mutex.clone()),
+                        fndef.symbol_start,
+                        m.module_scope_id,
+                        fndef.is_pub,
+                    ) {
                         symbol_table.set_symbol_source_path(symbol_id, &m.path);
                     }
                 } else {

--- a/nls/src/analyzer/common.rs
+++ b/nls/src/analyzer/common.rs
@@ -1097,7 +1097,7 @@ pub struct VarDeclExpr {
     pub type_: Type,
     pub be_capture: bool,
     pub heap_ident: Option<String>,
-    pub is_private: bool,
+    pub is_pub: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -1109,7 +1109,7 @@ pub struct AstConstDef {
     pub symbol_id: NodeId,
     pub symbol_start: usize,
     pub symbol_end: usize,
-    pub is_private: bool,
+    pub is_pub: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -1255,7 +1255,7 @@ pub struct TypedefStmt {
     pub is_tagged_union: bool,
     pub impl_interfaces: Vec<Type>,
     pub method_table: HashMap<String, Arc<Mutex<AstFnDef>>>, // key = ident, value = ast_fndef_t
-    pub is_private: bool,
+    pub is_pub: bool,
 
     pub symbol_start: usize,
     pub symbol_end: usize,
@@ -1325,7 +1325,7 @@ pub struct AstFnDef {
     pub is_tpl: bool,
     pub is_generics: bool,
     pub is_async: bool,
-    pub is_private: bool,
+    pub is_pub: bool,
     pub is_fx: bool,
     pub is_errable: bool, // 当前函数是否返回错误
     pub is_test: bool,
@@ -1379,7 +1379,7 @@ impl Default for AstFnDef {
             pending_where_params: None,
             is_generics: false,
             is_async: false,
-            is_private: false,
+            is_pub: false,
             is_fx: false,
             is_errable: false,
             is_test: false,

--- a/nls/src/analyzer/completion/imports.rs
+++ b/nls/src/analyzer/completion/imports.rs
@@ -64,6 +64,9 @@ impl<'a> CompletionProvider<'a> {
 
             for &symbol_id in &scope.symbols {
                 if let Some(symbol) = self.symbol_table.get_symbol_ref(symbol_id) {
+                    if !self.symbol_table.symbol_accessible_from(symbol_id, &self.module.ident) {
+                        continue;
+                    }
                     let symbol_name = extract_last_ident_part(&symbol.ident);
 
                     // Skip test functions and impl methods (struct methods can't be exported)
@@ -151,6 +154,9 @@ impl<'a> CompletionProvider<'a> {
             // Iterate through all symbols in imported module
             for &symbol_id in &imported_scope.symbols {
                 if let Some(symbol) = self.symbol_table.get_symbol_ref(symbol_id) {
+                    if !self.symbol_table.symbol_accessible_from(symbol_id, &self.module.ident) {
+                        continue;
+                    }
                     if let SymbolKind::Fn(fndef) = &symbol.kind {
                         if fndef.lock().unwrap().is_test {
                             continue;
@@ -254,6 +260,9 @@ impl<'a> CompletionProvider<'a> {
                 if !match_set.contains(indexed.file_path.as_str()) {
                     continue;
                 }
+                if !indexed.is_pub {
+                    continue;
+                }
                 if !prefix.is_empty() && !name.starts_with(prefix) {
                     continue;
                 }
@@ -316,6 +325,11 @@ impl<'a> CompletionProvider<'a> {
 
                 // Try to find the symbol in the imported module's scope
                 let global_ident = crate::utils::format_global_ident(import.module_ident.clone(), item.ident.clone());
+                if let Some(symbol_id) = self.symbol_table.find_symbol_id(&global_ident, self.symbol_table.global_scope_id) {
+                    if !self.symbol_table.symbol_accessible_from(symbol_id, &self.module.ident) {
+                        continue;
+                    }
+                }
                 let symbol = self.symbol_table.find_global_symbol(&global_ident)
                     .or_else(|| {
                         // Fallback: search in module scope
@@ -674,6 +688,9 @@ impl<'a> CompletionProvider<'a> {
         };
 
         for indexed_symbol in &matching_symbols {
+            if !indexed_symbol.is_pub {
+                continue;
+            }
             // Skip if this symbol is from the current file
             if indexed_symbol.file_path == self.module.path {
                 continue;

--- a/nls/src/analyzer/completion/members.rs
+++ b/nls/src/analyzer/completion/members.rs
@@ -116,6 +116,14 @@ impl<'a> CompletionProvider<'a> {
                     // Add methods for typedef
                     for method in typedef.method_table.values() {
                         let fndef = method.lock().unwrap();
+                        let accessible = if fndef.symbol_id != 0 {
+                            self.symbol_table.symbol_accessible_from(fndef.symbol_id, &self.module.ident)
+                        } else {
+                            fndef.module_index == self.module.index || fndef.is_pub
+                        };
+                        if !accessible {
+                            continue;
+                        }
                         if prefix.is_empty() || fndef.fn_name.starts_with(prefix) {
                             let signature = self.format_function_signature(&fndef);
                             let insert_text = if self.has_parameters(&fndef) {
@@ -525,6 +533,9 @@ impl<'a> CompletionProvider<'a> {
         // Closure that inspects one symbol and maybe pushes a completion.
         let mut check_symbol = |symbol_id: NodeId, is_builtin: bool| {
             let Some(symbol) = self.symbol_table.get_symbol_ref(symbol_id) else { return };
+            if !self.symbol_table.symbol_accessible_from(symbol_id, &self.module.ident) {
+                return;
+            }
             let symbol_name = extract_last_ident_part(&symbol.ident);
 
             if !prefix.is_empty() && !symbol_name.starts_with(prefix) {

--- a/nls/src/analyzer/completion/members.rs
+++ b/nls/src/analyzer/completion/members.rs
@@ -231,6 +231,9 @@ impl<'a> CompletionProvider<'a> {
     /// Check if a symbol is an impl method for the given typedef and add it to completions
     fn check_impl_method(&self, symbol_id: NodeId, typedef_symbol_id: NodeId, prefix: &str, completions: &mut Vec<CompletionItem>) {
         let Some(symbol) = self.symbol_table.get_symbol_ref(symbol_id) else { return };
+        if !self.symbol_table.symbol_accessible_from(symbol_id, &self.module.ident) {
+            return;
+        }
         let SymbolKind::Fn(fndef_mutex) = &symbol.kind else { return };
         let fndef = fndef_mutex.lock().unwrap();
 

--- a/nls/src/analyzer/lexer.rs
+++ b/nls/src/analyzer/lexer.rs
@@ -274,6 +274,9 @@ pub enum TokenType {
     #[strum(serialize = "var")]
     Var,
 
+    #[strum(serialize = "pub")]
+    Pub,
+
     #[strum(serialize = "const")]
     Const,
 
@@ -419,6 +422,7 @@ impl Token {
             | TokenType::Defer
             | TokenType::Let
             | TokenType::Var
+            | TokenType::Pub
             | TokenType::Const
             | TokenType::Test
             | TokenType::Fn
@@ -571,6 +575,7 @@ impl Lexer {
             "int" => TokenType::Int,
             "is" => TokenType::Is,
             "let" => TokenType::Let,
+            "pub" => TokenType::Pub,
             // "map" => TokenType::Map,
             "match" => TokenType::Match,
             "select" => TokenType::Select,

--- a/nls/src/analyzer/semantic/declarations.rs
+++ b/nls/src/analyzer/semantic/declarations.rs
@@ -46,7 +46,7 @@ impl<'a> Semantic<'a> {
                         symbol_start: fndef.symbol_start,
                         symbol_end: fndef.symbol_end,
                         symbol_id: 0,
-                        is_private: false,
+                        is_pub: false,
                     };
 
                     new_params.push(Arc::new(Mutex::new(self_vardecl)));

--- a/nls/src/analyzer/semantic/expressions.rs
+++ b/nls/src/analyzer/semantic/expressions.rs
@@ -211,9 +211,11 @@ impl<'a> Semantic<'a> {
 
     pub fn analyze_as_star_or_builtin(&mut self, ident: &str) -> Option<(NodeId, String)> {
         // import * ident
-        for import in &self.imports {
+        let imports = self.imports.clone();
+        for import in &imports {
             if import.as_name == "*" {
                 if let Some(id) = self.symbol_table.find_module_symbol_id(&import.module_ident, &ident) {
+                    self.ensure_symbol_accessible(id, ident, 0, 0);
                     return Some((id, format_global_ident(import.module_ident.clone(), ident.to_string().clone())));
                 }
             }
@@ -266,7 +268,8 @@ impl<'a> Semantic<'a> {
             }
 
             // Check selective imports: import colors.{Color} then Color.RED
-            for import in &self.imports {
+            let imports = self.imports.clone();
+            for import in &imports {
                 if !import.is_selective {
                     continue;
                 }
@@ -278,6 +281,8 @@ impl<'a> Semantic<'a> {
                     }
                     let global_ident = format_global_ident(import.module_ident.clone(), item.ident.clone());
                     if let Some(id) = self.symbol_table.find_symbol_id(&global_ident, self.symbol_table.global_scope_id) {
+                        let access_ident = format!("{}.{}", import.display_module(), item.ident);
+                        self.ensure_symbol_accessible(id, &access_ident, item.start, item.end);
                         *left_ident = global_ident;
                         *symbol_id = id;
                         return;
@@ -291,6 +296,8 @@ impl<'a> Semantic<'a> {
                 .map(|i| i.module_ident.clone());
             if let Some(module_ident) = import_module_ident {
                 if let Some(id) = self.symbol_table.find_module_symbol_id(&module_ident, key) {
+                    let access_ident = format!("{}.{}", left_ident, key);
+                    self.ensure_symbol_accessible(id, &access_ident, expr.start, expr.end);
                     // Mark the import prefix as NAMESPACE and the key token by its resolved kind
                     let left_ns_idx = semantic_token_type_index(SemanticTokenType::NAMESPACE);
                     for token in self.module.sem_token_db.iter_mut() {
@@ -360,7 +367,8 @@ impl<'a> Semantic<'a> {
         }
 
         // Check selective imports: import math.{sqrt, pow}
-        for import in &self.imports {
+        let imports = self.imports.clone();
+        for import in &imports {
             if !import.is_selective {
                 continue;
             }
@@ -372,6 +380,8 @@ impl<'a> Semantic<'a> {
                 }
                 let global_ident = format_global_ident(import.module_ident.clone(), item.ident.clone());
                 if let Some(id) = self.symbol_table.find_symbol_id(&global_ident, self.symbol_table.global_scope_id) {
+                    let access_ident = format!("{}.{}", import.display_module(), item.ident);
+                    self.ensure_symbol_accessible(id, &access_ident, 0, 0);
                     *ident = global_ident;
                     *symbol_id = id;
                     return true;
@@ -862,7 +872,7 @@ impl<'a> Semantic<'a> {
                     symbol_start: start,
                     symbol_end: end,
                     symbol_id: 0,
-                    is_private: false,
+                    is_pub: false,
                 }));
 
                 Box::new(Stmt {

--- a/nls/src/analyzer/semantic/mod.rs
+++ b/nls/src/analyzer/semantic/mod.rs
@@ -46,6 +46,23 @@ impl<'a> Semantic<'a> {
         self.current_scope_id = self.symbol_table.exit_scope(self.current_scope_id);
     }
 
+    pub(crate) fn ensure_symbol_accessible(&mut self, symbol_id: NodeId, ident: &str, start: usize, end: usize) -> bool {
+        if self.symbol_table.symbol_accessible_from(symbol_id, &self.module.ident) {
+            return true;
+        }
+
+        errors_push(
+            self.module,
+            AnalyzerError {
+                start,
+                end,
+                message: format!("undefined: {}", ident),
+                is_warning: false,
+            },
+        );
+        false
+    }
+
     fn analyze_special_type_rewrite(&mut self, t: &mut Type) -> bool {
         debug_assert!(t.import_as.is_empty());
 
@@ -218,11 +235,15 @@ impl<'a> Semantic<'a> {
                 }
 
                 let import_stmt = import_stmt.unwrap();
+                let module_ident = import_stmt.module_ident.clone();
+                let module_display = import_stmt.display_module().to_string();
 
                 // 从 symbol table 中查找相关的 global symbol id
-                if let Some(symbol_id) = self.symbol_table.find_module_symbol_id(&import_stmt.module_ident, &t.ident) {
+                if let Some(symbol_id) = self.symbol_table.find_module_symbol_id(&module_ident, &t.ident) {
+                    let access_ident = format!("{}.{}", module_display, t.ident);
+                    self.ensure_symbol_accessible(symbol_id, &access_ident, t.start, t.end);
                     t.import_as = "".to_string();
-                    t.ident = format_global_ident(import_stmt.module_ident.clone(), t.ident.clone());
+                    t.ident = format_global_ident(module_ident, t.ident.clone());
                     t.symbol_id = symbol_id;
                 } else {
                     errors_push(
@@ -230,7 +251,7 @@ impl<'a> Semantic<'a> {
                         AnalyzerError {
                             start: t.start,
                             end: t.end,
-                            message: format!("type '{}' undeclared in {} module", t.ident, import_stmt.display_module()),
+                            message: format!("type '{}' undeclared in {} module", t.ident, module_display),
                             is_warning: false,
                         },
                     );
@@ -646,11 +667,12 @@ impl<'a> Semantic<'a> {
                         fndef.symbol_name = format_impl_ident(impl_type_ident, symbol_name);
 
                         // register to global symbol table
-                        match self.symbol_table.define_symbol_in_scope(
+                        match self.symbol_table.define_symbol_in_scope_with_visibility(
                             fndef.symbol_name.clone(),
                             SymbolKind::Fn(fndef_mutex.clone()),
                             fndef.symbol_start,
                             self.module.module_scope_id,
+                            fndef.is_pub,
                         ) {
                             Ok(symbol_id) => {
                                 fndef.symbol_id = symbol_id;
@@ -670,11 +692,12 @@ impl<'a> Semantic<'a> {
                         }
 
                         // register to global symbol
-                        if let Ok(symbol_id) = self.symbol_table.define_global_symbol(
+                        if let Ok(symbol_id) = self.symbol_table.define_global_symbol_with_visibility(
                             fndef.symbol_name.clone(),
                             SymbolKind::Fn(fndef_mutex.clone()),
                             fndef.symbol_start,
                             self.module.module_scope_id,
+                            fndef.is_pub,
                         ) {
                             self.symbol_table.set_symbol_source_path(symbol_id, &self.module.path);
                         }
@@ -798,7 +821,8 @@ impl<'a> Semantic<'a> {
         }
 
         // Check selective imports: import math.{sqrt, pow, Point}
-        for import in &self.imports {
+        let imports = self.imports.clone();
+        for import in &imports {
             if !import.is_selective {
                 continue;
             }
@@ -810,6 +834,8 @@ impl<'a> Semantic<'a> {
                 }
                 let global_ident = format_global_ident(import.module_ident.clone(), item.ident.clone());
                 if let Some(id) = self.symbol_table.find_symbol_id(&global_ident, self.symbol_table.global_scope_id) {
+                    let access_ident = item.alias.as_ref().map_or_else(|| item.ident.clone(), |alias| alias.clone());
+                    self.ensure_symbol_accessible(id, &access_ident, item.start, item.end);
                     *ident = global_ident;
                     return Some(id);
                 }
@@ -817,12 +843,13 @@ impl<'a> Semantic<'a> {
         }
 
         // import x as * 产生的全局符号
-        for i in &self.imports {
+        for i in &imports {
             if i.as_name != "*" {
                 continue;
             };
 
             if let Some(symbol_id) = self.symbol_table.find_module_symbol_id(&i.module_ident, ident) {
+                self.ensure_symbol_accessible(symbol_id, ident, 0, 0);
                 *ident = format_global_ident(i.module_ident.clone(), ident.to_string());
                 return Some(symbol_id);
             }

--- a/nls/src/analyzer/symbol.rs
+++ b/nls/src/analyzer/symbol.rs
@@ -61,6 +61,7 @@ pub struct Symbol {
     pub kind: SymbolKind,
     pub defined_in: NodeId, // defined in scope
     pub is_local: bool,     // 是否是 module 级别的 global symbol
+    pub is_pub: bool,       // module symbol 可被其他 module 访问
     pub pos: usize,         // 符号定义的起始
     pub source_path: Option<String>,
 
@@ -201,7 +202,7 @@ impl SymbolTable {
                 is_tagged_union: false,
                 impl_interfaces: Vec::new(),
                 method_table: HashMap::new(),
-                is_private: false,
+                is_pub: false,
                 symbol_start: 0,
                 symbol_end: 0,
                 symbol_id: 0,
@@ -357,6 +358,17 @@ impl SymbolTable {
     }
 
     pub fn define_global_symbol(&mut self, global_ident: String, kind: SymbolKind, pos: usize, defined_in: NodeId) -> Result<NodeId, String> {
+        self.define_global_symbol_with_visibility(global_ident, kind, pos, defined_in, false)
+    }
+
+    pub fn define_global_symbol_with_visibility(
+        &mut self,
+        global_ident: String,
+        kind: SymbolKind,
+        pos: usize,
+        defined_in: NodeId,
+        is_pub: bool,
+    ) -> Result<NodeId, String> {
         debug_assert!(global_ident != "");
         let source_path = self.source_path_for_scope(defined_in);
 
@@ -373,6 +385,7 @@ impl SymbolTable {
             kind,
             defined_in, // global ident 的 defined_in 指向 module scope id
             is_local: false,
+            is_pub,
             pos,
             source_path,
             is_capture: false,
@@ -408,6 +421,17 @@ impl SymbolTable {
     }
 
     pub fn define_symbol_in_scope(&mut self, ident: String, kind: SymbolKind, pos: usize, scope_id: NodeId) -> Result<NodeId, String> {
+        self.define_symbol_in_scope_with_visibility(ident, kind, pos, scope_id, false)
+    }
+
+    pub fn define_symbol_in_scope_with_visibility(
+        &mut self,
+        ident: String,
+        kind: SymbolKind,
+        pos: usize,
+        scope_id: NodeId,
+        is_pub: bool,
+    ) -> Result<NodeId, String> {
         debug_assert!(ident != "");
 
         let source_path = self.source_path_for_scope(scope_id);
@@ -427,6 +451,7 @@ impl SymbolTable {
             kind,
             defined_in: scope_id,
             is_local,
+            is_pub,
             pos,
             source_path,
             is_capture: false,
@@ -528,6 +553,33 @@ impl SymbolTable {
         } else {
             return None;
         }
+    }
+
+    /// A module declaration is visible inside its own module, while imported
+    /// declarations require `pub`. Builtins and local symbols have no owner
+    /// module and remain visible as before.
+    pub fn symbol_accessible_from(&self, symbol_id: NodeId, module_ident: &str) -> bool {
+        let Some(symbol) = self.symbols.get(symbol_id) else {
+            return false;
+        };
+
+        if symbol.is_local {
+            return true;
+        }
+
+        let mut scope_id = symbol.defined_in;
+        while scope_id > 0 {
+            let Some(scope) = self.scopes.get(scope_id) else {
+                return true;
+            };
+            match &scope.kind {
+                ScopeKind::Module(owner) => return owner == module_ident || symbol.is_pub,
+                ScopeKind::Global => return true,
+                _ => scope_id = scope.parent,
+            }
+        }
+
+        true
     }
 
     pub fn symbol_exists_in_scope(&self, ident: &str, scope_id: NodeId) -> bool {

--- a/nls/src/analyzer/symbol.rs
+++ b/nls/src/analyzer/symbol.rs
@@ -404,6 +404,17 @@ impl SymbolTable {
     }
 
     pub fn cover_symbol_in_scope(&mut self, ident: String, kind: SymbolKind, pos: usize, scope_id: NodeId) -> NodeId {
+        self.cover_symbol_in_scope_with_visibility(ident, kind, pos, scope_id, false)
+    }
+
+    pub fn cover_symbol_in_scope_with_visibility(
+        &mut self,
+        ident: String,
+        kind: SymbolKind,
+        pos: usize,
+        scope_id: NodeId,
+        is_pub: bool,
+    ) -> NodeId {
         // 检查当前作用域是否已存在同名符号
         let scope = self.scopes.get_mut(scope_id).unwrap();
 
@@ -412,12 +423,13 @@ impl SymbolTable {
             let symbol = self.get_symbol(symbol_id).unwrap();
             symbol.kind = kind;
             symbol.pos = pos;
+            symbol.is_pub = is_pub;
             symbol.generics_id_map = HashMap::new();
             return symbol_id;
         }
 
         // 符号不存在，直接调用 define_symbol_in_scope 创建
-        return self.define_symbol_in_scope(ident, kind, pos, scope_id).unwrap();
+        self.define_symbol_in_scope_with_visibility(ident, kind, pos, scope_id, is_pub).unwrap()
     }
 
     pub fn define_symbol_in_scope(&mut self, ident: String, kind: SymbolKind, pos: usize, scope_id: NodeId) -> Result<NodeId, String> {

--- a/nls/src/analyzer/syntax.rs
+++ b/nls/src/analyzer/syntax.rs
@@ -1272,7 +1272,7 @@ impl<'a> Syntax {
         return Ok(t);
     }
 
-    fn parser_typedef_stmt(&mut self) -> Result<Box<Stmt>, SyntaxError> {
+    fn parser_typedef_stmt(&mut self, is_pub: bool) -> Result<Box<Stmt>, SyntaxError> {
         let mut stmt: Box<Stmt> = self.stmt_new();
 
         self.must(TokenType::Type)?;
@@ -1576,7 +1576,7 @@ impl<'a> Syntax {
             impl_interfaces,
             method_table: HashMap::new(),
             symbol_id: 0,
-            is_private: false,
+            is_pub,
         })));
         stmt.end = self.prev().unwrap().end;
 
@@ -1628,7 +1628,7 @@ impl<'a> Syntax {
             be_capture: false,
             heap_ident: None,
             symbol_id: 0,
-            is_private: false,
+            is_pub: false,
         })))
     }
 
@@ -1939,7 +1939,7 @@ impl<'a> Syntax {
             be_capture: false,
             heap_ident: None,
             symbol_id: 0,
-            is_private: false,
+            is_pub: false,
         };
 
         let catch_body = self.parser_body(true)?;
@@ -2556,7 +2556,7 @@ impl<'a> Syntax {
                 be_capture: false,
                 symbol_id: 0,
                 heap_ident: None,
-                is_private: false,
+                is_pub: false,
             };
 
             let second = if self.consume(TokenType::Comma) {
@@ -2569,7 +2569,7 @@ impl<'a> Syntax {
                     be_capture: false,
                     heap_ident: None,
                     symbol_id: 0,
-                    is_private: false,
+                    is_pub: false,
                 })))
             } else {
                 None
@@ -3220,7 +3220,7 @@ impl<'a> Syntax {
                     be_capture: false,
                     heap_ident: None,
                     symbol_id: 0,
-                    is_private: false,
+                    is_pub: false,
                 })));
                 expr.end = self.prev().unwrap().end;
                 expr
@@ -3238,7 +3238,7 @@ impl<'a> Syntax {
         Ok(elements)
     }
 
-    fn parser_var_begin_stmt(&mut self) -> Result<Box<Stmt>, SyntaxError> {
+    fn parser_var_begin_stmt(&mut self, is_pub: bool) -> Result<Box<Stmt>, SyntaxError> {
         let mut stmt = self.stmt_new();
         let type_decl = self.parser_type()?;
 
@@ -3247,6 +3247,14 @@ impl<'a> Syntax {
             let tuple_destr = self.parser_var_tuple_destr()?;
             self.must(TokenType::Equal)?;
             let right = self.parser_expr()?;
+
+            if is_pub {
+                return Err(SyntaxError(
+                    self.peek().start,
+                    self.peek().end,
+                    "pub cannot be applied to tuple destructuring".to_string(),
+                ));
+            }
 
             stmt.node = AstNode::VarTupleDestr(tuple_destr, right);
             stmt.end = self.prev().unwrap().end;
@@ -3266,7 +3274,7 @@ impl<'a> Syntax {
                 be_capture: false,
                 heap_ident: None,
                 symbol_id: 0,
-                is_private: false,
+                is_pub,
             })),
             self.parser_expr()?,
         );
@@ -3274,7 +3282,7 @@ impl<'a> Syntax {
         Ok(stmt)
     }
 
-    fn parser_type_begin_stmt(&mut self) -> Result<Box<Stmt>, SyntaxError> {
+    fn parser_type_begin_stmt(&mut self, is_pub: bool) -> Result<Box<Stmt>, SyntaxError> {
         let mut stmt = self.stmt_new();
         let type_decl = self.parser_type()?;
         let ident = self.must(TokenType::Ident)?.clone();
@@ -3300,7 +3308,7 @@ impl<'a> Syntax {
                 be_capture: false,
                 heap_ident: None,
                 symbol_id: 0,
-                is_private: false,
+                is_pub,
             })),
             self.parser_expr()?,
         );
@@ -3308,7 +3316,7 @@ impl<'a> Syntax {
         Ok(stmt)
     }
 
-    fn parser_constdef_stmt(&mut self) -> Result<Box<Stmt>, SyntaxError> {
+    fn parser_constdef_stmt(&mut self, is_pub: bool) -> Result<Box<Stmt>, SyntaxError> {
         let mut stmt: Box<Stmt> = self.stmt_new();
 
         self.must(TokenType::Const)?;
@@ -3324,7 +3332,7 @@ impl<'a> Syntax {
             symbol_start: const_ident.start,
             symbol_end: const_ident.end,
             symbol_id: 0,
-            is_private: false,
+            is_pub,
         })));
 
         Ok(stmt)
@@ -3421,7 +3429,7 @@ impl<'a> Syntax {
         let mut fndef = AstFnDef::default();
         fndef.symbol_start = start;
         fndef.is_test = true;
-        fndef.is_private = true;
+        fndef.is_pub = false;
         fndef.is_errable = true;
         fndef.test_name = name_token.literal.clone();
 
@@ -3612,9 +3620,9 @@ impl<'a> Syntax {
         Ok(stmt)
     }
 
-    fn parser_label(&mut self) -> Result<Box<Stmt>, SyntaxError> {
+    fn parser_label(&mut self, is_pub: bool) -> Result<Box<Stmt>, SyntaxError> {
         let mut fndef = AstFnDef::default();
-        let mut is_private = false;
+        fndef.is_pub = is_pub;
 
         while self.is(TokenType::Label) {
             let token = self.must(TokenType::Label)?;
@@ -3627,9 +3635,6 @@ impl<'a> Syntax {
                     let literal = self.must(TokenType::StringLiteral)?;
                     fndef.linkid = Some(literal.literal.clone());
                 }
-            } else if token.literal == "local" {
-                is_private = true;
-                fndef.is_private = true;
             } else if token.literal == "where" {
                 if fndef.pending_where_params.is_some() {
                     return Err(SyntaxError(token.start, token.end, "#where redeclared".to_string()));
@@ -3671,39 +3676,15 @@ impl<'a> Syntax {
                     "#where can only be applied to fn/fx".to_string(),
                 ));
             }
-            let result = self.parser_typedef_stmt()?;
-            if is_private {
-                if let AstNode::Typedef(ref typedef) = result.node {
-                    typedef.lock().unwrap().is_private = true;
-                }
-            }
-            Ok(result)
+            self.parser_typedef_stmt(is_pub)
         } else if self.is(TokenType::Fn) || self.is(TokenType::Fx) {
             self.parser_fndef_stmt(fndef)
         } else if self.is(TokenType::Const) {
-            let result = self.parser_constdef_stmt()?;
-            if is_private {
-                if let AstNode::ConstDef(ref constdef) = result.node {
-                    constdef.lock().unwrap().is_private = true;
-                }
-            }
-            Ok(result)
+            self.parser_constdef_stmt(is_pub)
         } else if self.is(TokenType::Var) {
-            let result = self.parser_var_begin_stmt()?;
-            if is_private {
-                if let AstNode::VarDef(ref var_decl, _) = result.node {
-                    var_decl.lock().unwrap().is_private = true;
-                }
-            }
-            Ok(result)
+            self.parser_var_begin_stmt(is_pub)
         } else if self.is_type_begin_stmt() {
-            let result = self.parser_type_begin_stmt()?;
-            if is_private {
-                if let AstNode::VarDef(ref var_decl, _) = result.node {
-                    var_decl.lock().unwrap().is_private = true;
-                }
-            }
-            Ok(result)
+            self.parser_type_begin_stmt(is_pub)
         } else {
             Err(SyntaxError(
                 self.peek().start,
@@ -3779,23 +3760,36 @@ impl<'a> Syntax {
             ));
         }
 
+        let is_pub = self.consume(TokenType::Pub);
+
         let stmt = if self.is(TokenType::Var) {
-            self.parser_var_begin_stmt()?
+            self.parser_var_begin_stmt(is_pub)?
         } else if self.is_type_begin_stmt() {
-            self.parser_type_begin_stmt()?
+            self.parser_type_begin_stmt(is_pub)?
         } else if self.is(TokenType::Label) {
-            self.parser_label()?
+            self.parser_label(is_pub)?
         } else if self.is(TokenType::Test) {
+            if is_pub {
+                return Err(SyntaxError(self.peek().start, self.peek().end, "pub cannot be applied to test".to_string()));
+            }
             self.parser_test_stmt()?
         } else if self.is(TokenType::Fn) || self.is(TokenType::Fx) {
-            self.parser_fndef_stmt(AstFnDef::default())?
+            let mut fndef = AstFnDef::default();
+            fndef.is_pub = is_pub;
+            self.parser_fndef_stmt(fndef)?
         } else if self.is(TokenType::Import) {
+            if is_pub {
+                return Err(SyntaxError(self.peek().start, self.peek().end, "pub cannot be applied to import".to_string()));
+            }
             self.parser_import_stmt()?
         } else if self.is(TokenType::Type) {
-            self.parser_typedef_stmt()?
+            self.parser_typedef_stmt(is_pub)?
         } else if self.is(TokenType::Const) {
-            self.parser_constdef_stmt()?
+            self.parser_constdef_stmt(is_pub)?
         } else {
+            if is_pub {
+                return Err(SyntaxError(self.peek().start, self.peek().end, "pub can only be applied to module-level declarations".to_string()));
+            }
             return Err(SyntaxError(
                 self.peek().start,
                 self.peek().end,
@@ -3815,10 +3809,10 @@ impl<'a> Syntax {
     fn parser_for_init_stmt(&mut self) -> Result<Box<Stmt>, SyntaxError> {
         let stmt = if self.is(TokenType::Var) {
             // var 声明语句
-            self.parser_var_begin_stmt()?
+            self.parser_var_begin_stmt(false)?
         } else if self.is_type_begin_stmt() {
             // 类型声明语句
-            self.parser_type_begin_stmt()?
+            self.parser_type_begin_stmt(false)?
         } else if self.is(TokenType::LeftParen) {
             // 元组解构赋值语句
             self.parser_left_paren_begin_stmt()?
@@ -3837,10 +3831,16 @@ impl<'a> Syntax {
     }
 
     fn parser_local_stmt_core(&mut self, consume_stmt_end: bool) -> Result<Box<Stmt>, SyntaxError> {
-        let stmt = if self.is(TokenType::Var) {
-            self.parser_var_begin_stmt()?
+        let stmt = if self.is(TokenType::Pub) {
+            return Err(SyntaxError(
+                self.peek().start,
+                self.peek().end,
+                "pub can only be applied to module-level declarations".to_string(),
+            ));
+        } else if self.is(TokenType::Var) {
+            self.parser_var_begin_stmt(false)?
         } else if self.is_type_begin_stmt() {
-            self.parser_type_begin_stmt()?
+            self.parser_type_begin_stmt(false)?
         } else if self.is(TokenType::LeftParen) {
             self.parser_left_paren_begin_stmt()?
         } else if self.is(TokenType::Test) {
@@ -3854,7 +3854,7 @@ impl<'a> Syntax {
         } else if self.is(TokenType::Let) {
             self.parser_let_stmt()?
         } else if self.is(TokenType::Label) {
-            self.parser_label()?
+            self.parser_label(false)?
         } else if self.is(TokenType::If) {
             self.parser_if_stmt()?
         } else if self.is(TokenType::For) {
@@ -3866,9 +3866,9 @@ impl<'a> Syntax {
         } else if self.is(TokenType::Import) {
             self.parser_import_stmt()?
         } else if self.is(TokenType::Type) {
-            self.parser_typedef_stmt()?
+            self.parser_typedef_stmt(false)?
         } else if self.is(TokenType::Const) {
-            self.parser_constdef_stmt()?
+            self.parser_constdef_stmt(false)?
         } else if self.is(TokenType::Continue) {
             self.parser_continue_stmt()?
         } else if self.is(TokenType::Break) {
@@ -4081,7 +4081,7 @@ impl<'a> Syntax {
                 be_capture: false,
                 heap_ident: None,
                 symbol_id: 0,
-                is_private: false,
+                is_pub: false,
             })),
             call_expr.clone(),
         );
@@ -4159,7 +4159,7 @@ impl<'a> Syntax {
             be_capture: false,
             heap_ident: None,
             symbol_id: 0,
-            is_private: false,
+            is_pub: false,
         }));
 
         let catch_body = self.parser_body(false)?;
@@ -4258,7 +4258,7 @@ impl<'a> Syntax {
                     be_capture: false,
                     heap_ident: None,
                     symbol_id: 0,
-                    is_private: false,
+                    is_pub: false,
                 })));
             }
 

--- a/nls/src/analyzer/syntax.rs
+++ b/nls/src/analyzer/syntax.rs
@@ -3620,9 +3620,8 @@ impl<'a> Syntax {
         Ok(stmt)
     }
 
-    fn parser_label(&mut self, mut is_pub: bool, allow_pub: bool) -> Result<Box<Stmt>, SyntaxError> {
+    fn parser_label(&mut self) -> Result<Box<Stmt>, SyntaxError> {
         let mut fndef = AstFnDef::default();
-        fndef.is_pub = is_pub;
 
         while self.is(TokenType::Label) {
             let token = self.must(TokenType::Label)?;
@@ -3660,16 +3659,8 @@ impl<'a> Syntax {
             }
         }
 
-        if allow_pub && self.consume(TokenType::Pub) {
-            is_pub = true;
-            fndef.is_pub = true;
-        } else if !allow_pub && self.is(TokenType::Pub) {
-            return Err(SyntaxError(
-                self.peek().start,
-                self.peek().end,
-                "pub can only be applied to module-level declarations".to_string(),
-            ));
-        }
+        let is_pub = self.consume(TokenType::Pub);
+        fndef.is_pub = is_pub;
 
         if fndef.pending_where_params.is_some() && !self.is(TokenType::Fn) && !self.is(TokenType::Fx) {
             return Err(SyntaxError(
@@ -3772,42 +3763,26 @@ impl<'a> Syntax {
         }
 
         let is_pub = self.consume(TokenType::Pub);
-        if is_pub && self.is(TokenType::Label) {
-            return Err(SyntaxError(
-                self.peek().start,
-                self.peek().end,
-                "pub must follow declaration labels".to_string(),
-            ));
-        }
 
         let stmt = if self.is(TokenType::Var) {
             self.parser_var_begin_stmt(is_pub)?
         } else if self.is_type_begin_stmt() {
             self.parser_type_begin_stmt(is_pub)?
-        } else if self.is(TokenType::Label) {
-            self.parser_label(is_pub, true)?
-        } else if self.is(TokenType::Test) {
-            if is_pub {
-                return Err(SyntaxError(self.peek().start, self.peek().end, "pub cannot be applied to test".to_string()));
-            }
+        } else if !is_pub && self.is(TokenType::Label) {
+            self.parser_label()?
+        } else if !is_pub && self.is(TokenType::Test) {
             self.parser_test_stmt()?
         } else if self.is(TokenType::Fn) || self.is(TokenType::Fx) {
             let mut fndef = AstFnDef::default();
             fndef.is_pub = is_pub;
             self.parser_fndef_stmt(fndef)?
-        } else if self.is(TokenType::Import) {
-            if is_pub {
-                return Err(SyntaxError(self.peek().start, self.peek().end, "pub cannot be applied to import".to_string()));
-            }
+        } else if !is_pub && self.is(TokenType::Import) {
             self.parser_import_stmt()?
         } else if self.is(TokenType::Type) {
             self.parser_typedef_stmt(is_pub)?
         } else if self.is(TokenType::Const) {
             self.parser_constdef_stmt(is_pub)?
         } else {
-            if is_pub {
-                return Err(SyntaxError(self.peek().start, self.peek().end, "pub can only be applied to module-level declarations".to_string()));
-            }
             return Err(SyntaxError(
                 self.peek().start,
                 self.peek().end,
@@ -3849,13 +3824,7 @@ impl<'a> Syntax {
     }
 
     fn parser_local_stmt_core(&mut self, consume_stmt_end: bool) -> Result<Box<Stmt>, SyntaxError> {
-        let stmt = if self.is(TokenType::Pub) {
-            return Err(SyntaxError(
-                self.peek().start,
-                self.peek().end,
-                "pub can only be applied to module-level declarations".to_string(),
-            ));
-        } else if self.is(TokenType::Var) {
+        let stmt = if self.is(TokenType::Var) {
             self.parser_var_begin_stmt(false)?
         } else if self.is_type_begin_stmt() {
             self.parser_type_begin_stmt(false)?
@@ -3871,8 +3840,6 @@ impl<'a> Syntax {
             self.parser_throw_stmt()?
         } else if self.is(TokenType::Let) {
             self.parser_let_stmt()?
-        } else if self.is(TokenType::Label) {
-            self.parser_label(false, false)?
         } else if self.is(TokenType::If) {
             self.parser_if_stmt()?
         } else if self.is(TokenType::For) {

--- a/nls/src/analyzer/syntax.rs
+++ b/nls/src/analyzer/syntax.rs
@@ -3620,7 +3620,7 @@ impl<'a> Syntax {
         Ok(stmt)
     }
 
-    fn parser_label(&mut self, is_pub: bool) -> Result<Box<Stmt>, SyntaxError> {
+    fn parser_label(&mut self, mut is_pub: bool, allow_pub: bool) -> Result<Box<Stmt>, SyntaxError> {
         let mut fndef = AstFnDef::default();
         fndef.is_pub = is_pub;
 
@@ -3658,6 +3658,17 @@ impl<'a> Syntax {
                     format!("expected '{}' found '{}'", TokenType::StmtEof, self.peek().literal),
                 ));
             }
+        }
+
+        if allow_pub && self.consume(TokenType::Pub) {
+            is_pub = true;
+            fndef.is_pub = true;
+        } else if !allow_pub && self.is(TokenType::Pub) {
+            return Err(SyntaxError(
+                self.peek().start,
+                self.peek().end,
+                "pub can only be applied to module-level declarations".to_string(),
+            ));
         }
 
         if fndef.pending_where_params.is_some() && !self.is(TokenType::Fn) && !self.is(TokenType::Fx) {
@@ -3761,13 +3772,20 @@ impl<'a> Syntax {
         }
 
         let is_pub = self.consume(TokenType::Pub);
+        if is_pub && self.is(TokenType::Label) {
+            return Err(SyntaxError(
+                self.peek().start,
+                self.peek().end,
+                "pub must follow declaration labels".to_string(),
+            ));
+        }
 
         let stmt = if self.is(TokenType::Var) {
             self.parser_var_begin_stmt(is_pub)?
         } else if self.is_type_begin_stmt() {
             self.parser_type_begin_stmt(is_pub)?
         } else if self.is(TokenType::Label) {
-            self.parser_label(is_pub)?
+            self.parser_label(is_pub, true)?
         } else if self.is(TokenType::Test) {
             if is_pub {
                 return Err(SyntaxError(self.peek().start, self.peek().end, "pub cannot be applied to test".to_string()));
@@ -3854,7 +3872,7 @@ impl<'a> Syntax {
         } else if self.is(TokenType::Let) {
             self.parser_let_stmt()?
         } else if self.is(TokenType::Label) {
-            self.parser_label(false)?
+            self.parser_label(false, false)?
         } else if self.is(TokenType::If) {
             self.parser_if_stmt()?
         } else if self.is(TokenType::For) {

--- a/nls/src/analyzer/typesys.rs
+++ b/nls/src/analyzer/typesys.rs
@@ -354,6 +354,12 @@ impl<'a> Typesys<'a> {
         }
     }
 
+    fn ensure_symbol_accessible(&mut self, symbol_id: NodeId, ident: &str, start: usize, end: usize) {
+        if !self.symbol_table.symbol_accessible_from(symbol_id, &self.module.ident) {
+            self.errors_push(start, end, format!("undefined: {}", ident));
+        }
+    }
+
     fn type_recycle_check(&mut self, t: &Type, visited: &mut HashSet<String>) -> Option<String> {
         if t.ident.len() > 0 {
             if visited.contains(&t.ident) {
@@ -3812,7 +3818,11 @@ impl<'a> Typesys<'a> {
         let mut impl_symbol_name = format_impl_ident(impl_ident.clone(), key.clone());
 
         let (final_symbol_name, symbol_id) = match self.symbol_table.find_symbol_id(&impl_symbol_name, self.symbol_table.global_scope_id) {
-            Some(symbol_id) => (impl_symbol_name.clone(), symbol_id),
+            Some(symbol_id) => {
+                let access_ident = format!("{}.{}", impl_ident, key);
+                self.ensure_symbol_accessible(symbol_id, &access_ident, start, end);
+                (impl_symbol_name.clone(), symbol_id)
+            }
             None => {
                 if extract_type.kind != TypeKind::Ident {
                     // ident to default kind(need args)

--- a/nls/src/analyzer/typesys.rs
+++ b/nls/src/analyzer/typesys.rs
@@ -3449,11 +3449,12 @@ impl<'a> Typesys<'a> {
 
             // singleton_tpl 则是同一个符号，不需要重复注册，直接使用即可
             // 非 singleton_tpl 对于当前 symbol_name 必须是唯一的，不能重复注册。存在缓存机制，也不可能重复注册
-            let new_symbol_id = self.symbol_table.cover_symbol_in_scope(
+            let new_symbol_id = self.symbol_table.cover_symbol_in_scope_with_visibility(
                 special_fn.symbol_name.clone(),
                 SymbolKind::Fn(special_fn_mutex.clone()),
                 special_fn.symbol_start,
                 module_scope_id,
+                special_fn.is_pub,
             );
 
             special_fn.symbol_id = new_symbol_id;

--- a/nls/src/analyzer/workspace_index.rs
+++ b/nls/src/analyzer/workspace_index.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 pub struct IndexedSymbol {
     pub name: String,         // The symbol name (e.g., "MyController")
     pub kind: IndexedSymbolKind,
+    pub is_pub: bool,
     pub file_path: String,    // Absolute path to the .n file
 }
 
@@ -213,6 +214,7 @@ impl WorkspaceIndex {
         }
 
         // Second pass: extract top-level declarations
+        let mut pending_pub = false;
         for (i, line) in lines.iter().enumerate() {
             let depth = line_start_brace_depths[i];
             if depth != 0 {
@@ -226,36 +228,49 @@ impl WorkspaceIndex {
                 continue;
             }
 
-            // Skip import statements
-            if trimmed.starts_with("import ") {
+            let (line_is_pub, declaration) = if let Some(rest) = trimmed.strip_prefix("pub ") {
+                (true, rest.trim_start())
+            } else {
+                (false, trimmed)
+            };
+
+            // Skip import statements and label-only declarations
+            if declaration.starts_with("import ") {
+                pending_pub = false;
                 continue;
             }
 
             // Skip preprocessor/macro directives
-            if trimmed.starts_with('#') {
+            if declaration.starts_with('#') {
+                pending_pub |= line_is_pub;
                 continue;
             }
 
+            let is_pub = line_is_pub || pending_pub;
+            pending_pub = false;
+
             // type <name> = ...
-            if trimmed.starts_with("type ") {
-                if let Some(name) = Self::extract_type_name(trimmed) {
+            if declaration.starts_with("type ") {
+                if let Some(name) = Self::extract_type_name(declaration) {
                     symbols.push(IndexedSymbol {
                         name,
                         kind: IndexedSymbolKind::Type,
+                        is_pub,
                         file_path: file_path.to_string(),
                     });
                 }
                 continue;
             }
 
-            // fn <name>(...) or fn <type>.<method>(...)
-            if trimmed.starts_with("fn ") {
-                if let Some(name) = Self::extract_fn_name(trimmed) {
+            // fn/fx <name>(...) or fn/fx <type>.<method>(...)
+            if declaration.starts_with("fn ") || declaration.starts_with("fx ") {
+                if let Some(name) = Self::extract_fn_name(declaration) {
                     // Only index top-level functions, not methods (type.method)
                     if !name.contains('.') {
                         symbols.push(IndexedSymbol {
                             name,
                             kind: IndexedSymbolKind::Function,
+                            is_pub,
                             file_path: file_path.to_string(),
                         });
                     }
@@ -264,11 +279,12 @@ impl WorkspaceIndex {
             }
 
             // const <name> = ...
-            if trimmed.starts_with("const ") {
-                if let Some(name) = Self::extract_const_name(trimmed) {
+            if declaration.starts_with("const ") {
+                if let Some(name) = Self::extract_const_name(declaration) {
                     symbols.push(IndexedSymbol {
                         name,
                         kind: IndexedSymbolKind::Constant,
+                        is_pub,
                         file_path: file_path.to_string(),
                     });
                 }
@@ -276,11 +292,12 @@ impl WorkspaceIndex {
             }
 
             // var <name> = ... OR <type> <name> = ...
-            if trimmed.starts_with("var ") {
-                if let Some(name) = Self::extract_var_name(trimmed) {
+            if declaration.starts_with("var ") {
+                if let Some(name) = Self::extract_var_name(declaration) {
                     symbols.push(IndexedSymbol {
                         name,
                         kind: IndexedSymbolKind::Variable,
+                        is_pub,
                         file_path: file_path.to_string(),
                     });
                 }
@@ -288,9 +305,14 @@ impl WorkspaceIndex {
             }
 
             // Explicit typed variable: <type> <name> = ...
-            // This is trickier - we need to detect patterns like: string foo = "bar"
-            // We skip this for now to avoid false positives; these are less common for
-            // cross-file usage since they're typically module-level state.
+            if let Some(name) = Self::extract_typed_var_name(declaration) {
+                symbols.push(IndexedSymbol {
+                    name,
+                    kind: IndexedSymbolKind::Variable,
+                    is_pub,
+                    file_path: file_path.to_string(),
+                });
+            }
         }
 
         symbols
@@ -308,7 +330,10 @@ impl WorkspaceIndex {
 
     /// Extract function name from "fn <name>(...)"
     fn extract_fn_name(line: &str) -> Option<String> {
-        let rest = line.strip_prefix("fn ")?.trim_start();
+        let rest = line
+            .strip_prefix("fn ")
+            .or_else(|| line.strip_prefix("fx "))?
+            .trim_start();
         let name: String = rest.chars().take_while(|c| c.is_alphanumeric() || *c == '_' || *c == '.').collect();
         if name.is_empty() {
             return None;
@@ -334,6 +359,27 @@ impl WorkspaceIndex {
             return None;
         }
         Some(name)
+    }
+
+    /// Extract the name from a typed variable declaration such as
+    /// `u32 MS_ACTIVE = ...` or `vec<u8> buffer = ...`.
+    fn extract_typed_var_name(line: &str) -> Option<String> {
+        let (left, _) = line.split_once('=')?;
+        let mut parts = left.split_whitespace();
+        let _type = parts.next()?;
+        let name = parts.next_back()?;
+
+        if !name.chars().all(|c| c.is_alphanumeric() || c == '_') || name.is_empty() {
+            return None;
+        }
+
+        // A typed declaration has exactly one identifier after its type. This
+        // avoids indexing expressions or malformed declarations as variables.
+        if parts.next().is_some() {
+            return None;
+        }
+
+        Some(name.to_string())
     }
 
     /// Search for symbols matching a prefix (case-sensitive)

--- a/nls/src/formatter/rules.rs
+++ b/nls/src/formatter/rules.rs
@@ -383,6 +383,7 @@ impl<'a> Formatter<'a> {
             | TokenType::Defer
             | TokenType::Let
             | TokenType::Var
+            | TokenType::Pub
             | TokenType::Const
             | TokenType::Test
             | TokenType::Fn

--- a/nls/src/server/hover.rs
+++ b/nls/src/server/hover.rs
@@ -339,7 +339,7 @@ mod tests {
             type_: Type::new(TypeKind::Int64),
             be_capture: false,
             heap_ident: None,
-            is_private: false,
+            is_pub: false,
         }));
         let content = format_hover_content(&SymbolKind::Var(var), "count", None);
         assert!(content.contains("var count: i64"), "got: {}", content);
@@ -366,7 +366,7 @@ mod tests {
             type_: Type::new(TypeKind::Int64),
             be_capture: false,
             heap_ident: None,
-            is_private: false,
+            is_pub: false,
         }));
         let param_b = Arc::new(Mutex::new(VarDeclExpr {
             ident: "b".into(),
@@ -376,7 +376,7 @@ mod tests {
             type_: Type::new(TypeKind::String),
             be_capture: false,
             heap_ident: None,
-            is_private: false,
+            is_pub: false,
         }));
         let fndef = Arc::new(Mutex::new(AstFnDef {
             fn_name: "greet".into(),
@@ -404,7 +404,7 @@ mod tests {
             type_: Type::new(TypeKind::Int64),
             be_capture: false,
             heap_ident: None,
-            is_private: false,
+            is_pub: false,
         }));
         let content = format_hover_content(
             &SymbolKind::Var(var),

--- a/nls/src/server/inlay_hints.rs
+++ b/nls/src/server/inlay_hints.rs
@@ -419,7 +419,7 @@ mod tests {
             type_: Type::default(),
             be_capture: false,
             heap_ident: None,
-            is_private: false,
+            is_pub: false,
         }));
         let x_param = Arc::new(Mutex::new(VarDeclExpr {
             ident: "x".into(),
@@ -429,7 +429,7 @@ mod tests {
             type_: Type::new(TypeKind::Int64),
             be_capture: false,
             heap_ident: None,
-            is_private: false,
+            is_pub: false,
         }));
         let fndef = AstFnDef {
             params: vec![self_param, x_param],

--- a/nls/src/server/navigation.rs
+++ b/nls/src/server/navigation.rs
@@ -739,7 +739,7 @@ fn resolve_member_on_type(
                         type_: prop.type_.clone(),
                         be_capture: false,
                         heap_ident: None,
-                        is_private: false,
+                        is_pub: false,
                     };
                     return Some(ResolvedSymbol {
                         symbol_id: 0,
@@ -794,7 +794,7 @@ fn resolve_member_on_type(
                             type_: prop.type_.clone(),
                             be_capture: false,
                             heap_ident: None,
-                            is_private: false,
+                            is_pub: false,
                         };
                         return Some(ResolvedSymbol {
                             symbol_id: 0,
@@ -1054,7 +1054,7 @@ mod tests {
             type_: crate::analyzer::common::Type::default(),
             be_capture: false,
             heap_ident: None,
-            is_private: false,
+            is_pub: false,
         }));
         assert_eq!(symbol_def_range(&SymbolKind::Var(var)), (10, 11));
     }

--- a/nls/src/server/signature_help.rs
+++ b/nls/src/server/signature_help.rs
@@ -361,7 +361,7 @@ mod tests {
             type_: Type::new(TypeKind::Int64),
             be_capture: false,
             heap_ident: None,
-            is_private: false,
+            is_pub: false,
         }));
         let param_b = Arc::new(Mutex::new(VarDeclExpr {
             ident: "b".into(),
@@ -371,7 +371,7 @@ mod tests {
             type_: Type::new(TypeKind::String),
             be_capture: false,
             heap_ident: None,
-            is_private: false,
+            is_pub: false,
         }));
 
         let fndef = AstFnDef {
@@ -400,7 +400,7 @@ mod tests {
             type_: Type::default(),
             be_capture: false,
             heap_ident: None,
-            is_private: false,
+            is_pub: false,
         }));
         let x_param = Arc::new(Mutex::new(VarDeclExpr {
             ident: "x".into(),
@@ -410,7 +410,7 @@ mod tests {
             type_: Type::new(TypeKind::Int64),
             be_capture: false,
             heap_ident: None,
-            is_private: false,
+            is_pub: false,
         }));
 
         let fndef = AstFnDef {

--- a/nls/src/server/symbols.rs
+++ b/nls/src/server/symbols.rs
@@ -223,7 +223,7 @@ mod tests {
             type_: Type::default(),
             be_capture: false,
             heap_ident: None,
-            is_private: false,
+            is_pub: false,
         }));
         let right = Box::new(crate::analyzer::common::Expr {
             start,

--- a/nls/tests/multifile_module_test.rs
+++ b/nls/tests/multifile_module_test.rs
@@ -59,7 +59,7 @@ async fn cross_part_declarations_are_shared() {
 
     // avoid builtins (println and friends) so the test does not depend on NATURE_ROOT
     write(&root, "package.toml", "name = \"app\"\nversion = \"1.0.0\"\ntype = \"bin\"\n");
-    write(&root, "codec/encode.n", "mod codec\n\nfn encode(int v):int {\n    return v * scale()\n}\n");
+    write(&root, "codec/encode.n", "mod codec\n\npub fn encode(int v):int {\n    return v * scale()\n}\n");
     write(&root, "codec/codec.n", "mod codec\n\nfn scale():int {\n    return 2\n}\n");
     write(&root, "main.n", "import app.codec\n\nfn main() {\n    int v = codec.encode(3)\n}\n");
 

--- a/src/ast.c
+++ b/src/ast.c
@@ -20,6 +20,7 @@ static ast_select_stmt_t *ast_select_copy(module_t *m, ast_select_stmt_t *temp);
 ast_ident *ast_new_ident(char *literal) {
     ast_ident *ident = NEW(ast_ident);
     ident->literal = strdup(literal);
+    ident->display_literal = strdup(literal);
     return ident;
 }
 
@@ -259,6 +260,7 @@ static list_t *ast_list_expr_copy(module_t *m, list_t *temp) {
 static ast_ident *ast_ident_copy(ast_ident *temp) {
     ast_ident *ident = COPY_NEW(ast_ident, temp);
     ident->literal = strdup(temp->literal);
+    ident->display_literal = temp->display_literal ? strdup(temp->display_literal) : NULL;
     return ident;
 }
 

--- a/src/ast.h
+++ b/src/ast.h
@@ -302,9 +302,10 @@ typedef struct {
 // int a;
 typedef struct {
     char *ident;
-    type_t type; // type 已经决定了 size
+    type_t type;
 
     bool be_capture; // 被 coroutine closure 引用, 必须在堆中分配
+    bool is_pub; // module 外可见, 默认 false
 
     // 当该值不为 null 时，则需要在 linear 进行堆分配以及相关的改写。
     // 变量进行 heap 分配时，指向 heap 的 ident， 后续的使用都需要替换成该 ident, 默认为 null
@@ -318,6 +319,7 @@ typedef struct {
     type_t type;
     ast_expr_t *right;
     bool processing;
+    bool is_pub; // module 外可见, 默认 false
 } ast_constdef_stmt_t;
 
 typedef struct {
@@ -688,6 +690,7 @@ typedef struct {
     list_t *impl_interfaces; // type_t, typedef 可以实现多个接口, 对于 interface 来说则是自身扩展
     struct sc_map_sv method_table; // key = ident, value = ast_fndef_t
     int64_t hash;
+    bool is_pub; // module 外可见, 默认 false
 } ast_typedef_stmt_t;
 
 // 这里包含 body, 所以属于 def
@@ -763,7 +766,7 @@ struct ast_fndef_t {
     bool is_generics; // 是否是泛型
 
     bool is_async; // coroutine closure fn, default is false
-    bool is_private;
+    bool is_pub; // module 外可见, 默认 false
 
     bool is_test;
     char *test_name;
@@ -946,7 +949,7 @@ static inline bool can_assign(ast_type_t t) {
 static inline ast_fndef_t *ast_fndef_new(module_t *m, int line, int column) {
     ast_fndef_t *fndef = NEW(ast_fndef_t);
     fndef->is_async = false;
-    fndef->is_private = false;
+    fndef->is_pub = false;
     fndef->is_test = false;
     fndef->test_name = NULL;
     fndef->module = m;

--- a/src/ast.h
+++ b/src/ast.h
@@ -181,6 +181,7 @@ typedef struct {
 
 typedef struct {
     char *literal;
+    char *display_literal; // original spelling retained for diagnostics
 } ast_ident;
 
 typedef struct {

--- a/src/module.c
+++ b/src/module.c
@@ -180,7 +180,7 @@ static void module_source_register_symbols(module_t *m, source_file_t *sf) {
             vardef->rel_path = sf->rel_path;
             ast_var_decl_t *var_decl = &vardef->var_decl;
             var_decl->ident = ident_with_prefix(m->ident, var_decl->ident);
-            symbol_t *s = symbol_table_set(var_decl->ident, SYMBOL_VAR, var_decl, false);
+            symbol_t *s = symbol_table_set_module(var_decl->ident, SYMBOL_VAR, var_decl, m, var_decl->is_pub);
             ANALYZER_ASSERTF(s, "ident '%s' redeclared", var_decl->ident);
             continue;
         }
@@ -188,7 +188,7 @@ static void module_source_register_symbols(module_t *m, source_file_t *sf) {
         if (stmt->assert_type == AST_STMT_CONSTDEF) {
             ast_constdef_stmt_t *const_def = stmt->value;
             const_def->ident = ident_with_prefix(m->ident, const_def->ident);
-            symbol_t *s = symbol_table_set(const_def->ident, SYMBOL_CONST, const_def, false);
+            symbol_t *s = symbol_table_set_module(const_def->ident, SYMBOL_CONST, const_def, m, const_def->is_pub);
             ANALYZER_ASSERTF(s, "ident '%s' redeclared", const_def->ident);
             continue;
         }
@@ -196,7 +196,8 @@ static void module_source_register_symbols(module_t *m, source_file_t *sf) {
         if (stmt->assert_type == AST_STMT_TYPEDEF) {
             ast_typedef_stmt_t *typedef_stmt = stmt->value;
             typedef_stmt->ident = ident_with_prefix(m->ident, typedef_stmt->ident);
-            symbol_t *s = symbol_table_set(typedef_stmt->ident, SYMBOL_TYPE, typedef_stmt, false);
+            symbol_t *s = symbol_table_set_module(typedef_stmt->ident, SYMBOL_TYPE, typedef_stmt, m,
+                                                  typedef_stmt->is_pub);
             ANALYZER_ASSERTF(s, "ident '%s' redeclared", typedef_stmt->ident);
             continue;
         }
@@ -206,7 +207,7 @@ static void module_source_register_symbols(module_t *m, source_file_t *sf) {
 
             if (fndef->impl_type.kind == 0) {
                 fndef->symbol_name = ident_with_prefix(m->ident, fndef->symbol_name); // 全局函数改名
-                symbol_t *s = symbol_table_set(fndef->symbol_name, SYMBOL_FN, fndef, false);
+                symbol_t *s = symbol_table_set_module(fndef->symbol_name, SYMBOL_FN, fndef, m, fndef->is_pub);
                 ANALYZER_ASSERTF(s, "ident '%s' redeclared", fndef->symbol_name);
             } else {
                 // Delay to analyzer module and then process it...

--- a/src/semantic/analyzer.c
+++ b/src/semantic/analyzer.c
@@ -281,8 +281,7 @@ static type_t analyzer_type_fn(ast_fndef_t *fndef) {
  * @return
  */
 static void analyzer_symbol_access_assert(module_t *m, symbol_t *symbol, char *ident) {
-    ANALYZER_ASSERTF(symbol_accessible_from(symbol, m),
-                     "cannot access private symbol '%s', declare it with 'pub' to export it from its module", ident);
+    ANALYZER_ASSERTF(symbol_accessible_from(symbol, m), "undefined: %s", ident);
 }
 
 static char *analyzer_resolve_typedef(module_t *m, analyzer_fndef_t *current, string ident) {
@@ -391,7 +390,8 @@ static void analyzer_type(module_t *m, type_t *t) {
             if (!import_sym) {
                 ANALYZER_ASSERTF(false, "type '%s' undeclared", t->ident);
             }
-            analyzer_symbol_access_assert(m, import_sym, t->ident);
+            char *display_ident = str_connect_by(t->import_as, t->ident, ".");
+            analyzer_symbol_access_assert(m, import_sym, display_ident);
 
             // 更新 ident 指向
             t->ident = unique_ident;
@@ -1658,7 +1658,8 @@ static void rewrite_select_expr(module_t *m, ast_expr_t *expr) {
             }
 
             // module.member 访问, 检查被访问符号的可见性
-            analyzer_symbol_access_assert(m, member, select->key);
+            char *display_ident = str_connect_by(ident->literal, select->key, ".");
+            analyzer_symbol_access_assert(m, member, display_ident);
 
             expr->assert_type = AST_EXPR_IDENT;
             expr->value = ast_new_ident(unique_ident);

--- a/src/semantic/analyzer.c
+++ b/src/semantic/analyzer.c
@@ -280,6 +280,11 @@ static type_t analyzer_type_fn(ast_fndef_t *fndef) {
  * @param ident
  * @return
  */
+static void analyzer_symbol_access_assert(module_t *m, symbol_t *symbol, char *ident) {
+    ANALYZER_ASSERTF(symbol_accessible_from(symbol, m),
+                     "cannot access private symbol '%s', declare it with 'pub' to export it from its module", ident);
+}
+
 static char *analyzer_resolve_typedef(module_t *m, analyzer_fndef_t *current, string ident) {
     if (current == NULL) {
         // 进行全局作用域符号查找
@@ -288,7 +293,9 @@ static char *analyzer_resolve_typedef(module_t *m, analyzer_fndef_t *current, st
         // can_import_symbol_table 记录了所有的 package + ident 组成的符号，所以也包括 current module
         // 所以可以用来判断是否 import 了当前 package 中的 symbol
         char *global_ident = ident_with_prefix(m->ident, ident);
-        if (symbol_table_get(global_ident)) {
+        symbol_t *s = symbol_table_get(global_ident);
+        if (s) {
+            analyzer_symbol_access_assert(m, s, ident);
             return global_ident;
         }
 
@@ -296,7 +303,9 @@ static char *analyzer_resolve_typedef(module_t *m, analyzer_fndef_t *current, st
         ast_import_select_t *select_ref = table_get(m->selective_import_table, ident);
         if (select_ref != NULL) {
             char *selective_global_ident = ident_with_prefix(select_ref->module_ident, select_ref->original_ident);
-            if (symbol_table_get(selective_global_ident)) {
+            s = symbol_table_get(selective_global_ident);
+            if (s) {
+                analyzer_symbol_access_assert(m, s, select_ref->original_ident);
                 return selective_global_ident;
             }
         }
@@ -307,15 +316,18 @@ static char *analyzer_resolve_typedef(module_t *m, analyzer_fndef_t *current, st
 
             if (str_equal(import->as, "*")) {
                 char *temp = ident_with_prefix(analyzer_import_key(import), ident);
-                if (symbol_table_get(temp)) {
+                s = symbol_table_get(temp);
+                if (s) {
+                    analyzer_symbol_access_assert(m, s, ident);
                     return temp;
                 }
             }
         }
 
         // builtin 中的全局类型
-        symbol_t *s = table_get(symbol_table, ident);
+        s = table_get(symbol_table, ident);
         if (s != NULL) {
+            analyzer_symbol_access_assert(m, s, ident);
             // 不需要改写使用的名称了
             return ident;
         }
@@ -373,6 +385,13 @@ static void analyzer_type(module_t *m, type_t *t) {
             ANALYZER_ASSERTF(import, "module '%s' not found", t->import_as);
 
             char *unique_ident = ident_with_prefix(analyzer_import_key(import), t->ident);
+
+            // 跨 module 类型引用, 检查可见性
+            symbol_t *import_sym = symbol_table_get(unique_ident);
+            if (!import_sym) {
+                ANALYZER_ASSERTF(false, "type '%s' undeclared", t->ident);
+            }
+            analyzer_symbol_access_assert(m, import_sym, t->ident);
 
             // 更新 ident 指向
             t->ident = unique_ident;
@@ -1515,7 +1534,9 @@ static bool analyzer_as_star_or_builtin_ident(module_t *m, ast_ident *ident) {
 
         if (str_equal(import->as, "*")) {
             char *temp = ident_with_prefix(analyzer_import_key(import), ident->literal);
-            if (symbol_table_get(temp)) {
+            symbol_t *s = symbol_table_get(temp);
+            if (s) {
+                analyzer_symbol_access_assert(m, s, ident->literal);
                 ident->literal = temp;
                 return true;
             }
@@ -1525,6 +1546,7 @@ static bool analyzer_as_star_or_builtin_ident(module_t *m, ast_ident *ident) {
     // - builtin 产生的全局符号
     symbol_t *s = table_get(symbol_table, ident->literal);
     if (s != NULL) {
+        analyzer_symbol_access_assert(m, s, ident->literal);
         // builtin global Symbol does not require symbol rewriting
         return true;
     }
@@ -1551,6 +1573,7 @@ static bool analyzer_ident(module_t *m, ast_expr_t *expr) {
     char *current_global_ident = ident_with_prefix(m->ident, ident->literal);
     symbol_t *s = symbol_table_get(current_global_ident);
     if (s != NULL) {
+        analyzer_symbol_access_assert(m, s, ident->literal);
         ident->literal = current_global_ident; // 找到了则修改为全局名称
         return true;
     }
@@ -1565,14 +1588,7 @@ static bool analyzer_ident(module_t *m, ast_expr_t *expr) {
         if (!sym) {
             ANALYZER_ASSERTF(false, "symbol '%s' not found in module", select_ref->original_ident);
         }
-
-        // Check if symbol is private (only for functions)
-        if (sym->type == SYMBOL_FN) {
-            ast_fndef_t *fndef = sym->ast_value;
-            if (fndef->is_private) {
-                ANALYZER_ASSERTF(false, "cannot import private function '%s'", select_ref->original_ident);
-            }
-        }
+        analyzer_symbol_access_assert(m, sym, select_ref->original_ident);
 
         ident->literal = global_ident;
         return true;
@@ -1611,6 +1627,7 @@ static void rewrite_select_expr(module_t *m, ast_expr_t *expr) {
         char *current_module_ident = ident_with_prefix(m->ident, ident->literal);
         symbol_t *s = table_get(symbol_table, current_module_ident);
         if (s != NULL) {
+            analyzer_symbol_access_assert(m, s, ident->literal);
             ident->literal = current_module_ident; // 找到了则修改为全局名称
             return;
         }
@@ -1621,6 +1638,7 @@ static void rewrite_select_expr(module_t *m, ast_expr_t *expr) {
             char *global_ident = ident_with_prefix(select_ref->module_ident, select_ref->original_ident);
             symbol_t *sym = symbol_table_get(global_ident);
             if (sym) {
+                analyzer_symbol_access_assert(m, sym, select_ref->original_ident);
                 ident->literal = global_ident;
                 return;
             }
@@ -1634,9 +1652,13 @@ static void rewrite_select_expr(module_t *m, ast_expr_t *expr) {
             char *unique_ident = ident_with_prefix(analyzer_import_key(import), select->key);
 
             // 检测 import ident 是否存在
-            if (!symbol_table_get(unique_ident)) {
+            symbol_t *member = symbol_table_get(unique_ident);
+            if (!member) {
                 ANALYZER_ASSERTF(false, "identifier '%s' undeclared \n", unique_ident);
             }
+
+            // module.member 访问, 检查被访问符号的可见性
+            analyzer_symbol_access_assert(m, member, select->key);
 
             expr->assert_type = AST_EXPR_IDENT;
             expr->value = ast_new_ident(unique_ident);
@@ -2448,7 +2470,7 @@ static void analyzer_module_decls(module_t *m, slice_t *stmt_list, slice_t *fn_l
 
                 fndef->symbol_name = str_connect_by(impl_type_ident, symbol_name, IMPL_CONNECT_IDENT);
 
-                symbol_t *s = symbol_table_set(fndef->symbol_name, SYMBOL_FN, fndef, false);
+                symbol_t *s = symbol_table_set_module(fndef->symbol_name, SYMBOL_FN, fndef, m, fndef->is_pub);
                 ANALYZER_ASSERTF(s, "ident '%s' redeclared", fndef->symbol_name);
             }
 

--- a/src/semantic/infer.c
+++ b/src/semantic/infer.c
@@ -2752,6 +2752,12 @@ static type_fn_t *infer_impl_call_rewrite(module_t *m, ast_call_t *call, type_t 
         INFER_ASSERTF(s, "type '%s' not impl '%s' fn", type_format(extract_type), select->key);
     }
 
+    // 跨 module 方法调用, 检查方法可见性
+    if (!symbol_accessible_from(s, m)) {
+        INFER_ASSERTF(false, "cannot access private method '%s' of type '%s', declare it with 'pub' to export it "
+                             "from its module", select->key, impl_ident);
+    }
+
     // rewrite call left ident, 延迟到 call left fn type 确定后再做
     call->left = *ast_ident_expr(call->left.line, call->left.column, impl_symbol_name);
 

--- a/src/semantic/infer.c
+++ b/src/semantic/infer.c
@@ -2429,7 +2429,7 @@ static ast_fndef_t *generics_special_fn(module_t *m, ast_call_t *call, type_t ta
 
     // 注册到全局符号表(还未基于 args_hash infer + reduction)
     assert(!special_fn->is_local);
-    symbol_table_set(special_fn->symbol_name, SYMBOL_FN, special_fn, special_fn->is_local);
+    symbol_table_set_module(special_fn->symbol_name, SYMBOL_FN, special_fn, special_fn->module, special_fn->is_pub);
     // 下面的 infer_fn_decl 会进行 special_fn->type 的类型推导
     special_fn->type.status = REDUCTION_STATUS_UNDO;
 

--- a/src/semantic/infer.c
+++ b/src/semantic/infer.c
@@ -2506,6 +2506,18 @@ static char *impl_symbol_name_new(char *impl_ident, char *method) {
     return str_connect_by(impl_ident, method, IMPL_CONNECT_IDENT);
 }
 
+static char *infer_method_access_name(ast_expr_t *receiver, char *method) {
+    if (receiver->assert_type == AST_EXPR_IDENT) {
+        ast_ident *ident = receiver->value;
+        if (ident && ident->literal) {
+            char *display_literal = ident->display_literal ? ident->display_literal : ident->literal;
+            return str_connect_by(display_literal, method, ".");
+        }
+    }
+
+    return method;
+}
+
 static bool impl_static_symbol_exists(module_t *m, type_t select_left_type, char *method) {
     type_t extract_type = select_left_type;
     if (select_left_type.kind == TYPE_REF || select_left_type.kind == TYPE_PTR) {
@@ -2754,8 +2766,8 @@ static type_fn_t *infer_impl_call_rewrite(module_t *m, ast_call_t *call, type_t 
 
     // 跨 module 方法调用, 检查方法可见性
     if (!symbol_accessible_from(s, m)) {
-        INFER_ASSERTF(false, "cannot access private method '%s' of type '%s', declare it with 'pub' to export it "
-                             "from its module", select->key, impl_ident);
+        char *display_ident = infer_method_access_name(&select->left, select->key);
+        INFER_ASSERTF(false, "%s undefined (cannot refer to unexported method %s)", display_ident, select->key);
     }
 
     // rewrite call left ident, 延迟到 call left fn type 确定后再做

--- a/src/symbol/symbol.c
+++ b/src/symbol/symbol.c
@@ -139,18 +139,6 @@ static void symbol_register_builtin_types() {
     symbol_table_set("tup", SYMBOL_TYPE, builtin_typedef_tuple("tup"), false);
 }
 
-static symbol_t *_symbol_table_set(string ident, symbol_type_t type, void *ast_value, bool is_local) {
-    symbol_t *s = NEW(symbol_t);
-    s->ident = ident;
-    s->type = type;
-    s->ast_value = ast_value;
-    s->is_local = is_local;
-
-    table_set(symbol_table, ident, s);
-
-    return s;
-}
-
 void symbol_init() {
     symbol_table = table_new();
     symbol_fn_list = slice_new();
@@ -160,10 +148,19 @@ void symbol_init() {
     symbol_register_builtin_types();
 }
 
-symbol_t *symbol_table_set(string ident, symbol_type_t type, void *ast_value, bool is_local) {
+static symbol_t *symbol_table_set_scoped(string ident, symbol_type_t type, void *ast_value, bool is_local,
+                                         module_t *owner, bool is_pub) {
     bool overlay = table_exist(symbol_table, ident);
 
-    symbol_t *s = _symbol_table_set(ident, type, ast_value, is_local);
+    symbol_t *s = NEW(symbol_t);
+    s->ident = ident;
+    s->type = type;
+    s->ast_value = ast_value;
+    s->is_local = is_local;
+    s->owner = owner;
+    s->is_pub = is_pub;
+    table_set(symbol_table, ident, s);
+
     if (type == SYMBOL_FN) {
         slice_push(symbol_fn_list, s);
     }
@@ -183,6 +180,18 @@ symbol_t *symbol_table_set(string ident, symbol_type_t type, void *ast_value, bo
     return s;
 }
 
+symbol_t *symbol_table_set(string ident, symbol_type_t type, void *ast_value, bool is_local) {
+    return symbol_table_set_scoped(ident, type, ast_value, is_local, NULL, true);
+}
+
+symbol_t *symbol_table_set_module(string ident, symbol_type_t type, void *ast_value, module_t *owner, bool is_pub) {
+    assert(owner);
+    return symbol_table_set_scoped(ident, type, ast_value, false, owner, is_pub);
+}
+
+bool symbol_accessible_from(symbol_t *symbol, module_t *from) {
+    return symbol && (!symbol->owner || symbol->owner == from || symbol->is_pub);
+}
 
 symbol_t *symbol_table_get_noref(char *ident) {
     return table_get(symbol_table, ident);

--- a/src/symbol/symbol.h
+++ b/src/symbol/symbol.h
@@ -65,6 +65,8 @@ typedef struct {
     bool is_local; // 对应 elf 符号中的 global/local, 表示能否被外部链接链接到
     symbol_type_t type;
     void *ast_value; // ast_typedef_stmt/ast_var_decl/ast_fndef_t/closure_t/ast_constdef_stmt_t
+    module_t *owner; // 模块声明的所属 module; 局部、内建和编译器生成符号为 NULL
+    bool is_pub; // owner 非 NULL 时表示能否被其他 module 访问
     int64_t ref_count; // 引用计数
     void *data;
 } symbol_t;
@@ -80,6 +82,10 @@ static inline bool is_builtin_call(char *ident) {
 }
 
 symbol_t *symbol_table_set(char *ident, symbol_type_t type, void *ast_value, bool is_local);
+
+symbol_t *symbol_table_set_module(char *ident, symbol_type_t type, void *ast_value, module_t *owner, bool is_pub);
+
+bool symbol_accessible_from(symbol_t *symbol, module_t *from);
 
 symbol_t *symbol_typedef_add_method(char *typedef_ident, char *method_ident, ast_fndef_t *fndef);
 

--- a/src/syntax/parser.c
+++ b/src/syntax/parser.c
@@ -3147,9 +3147,8 @@ static ast_stmt_t *parser_test_stmt(module_t *m) {
  * @param m
  * @return
  */
-static ast_stmt_t *parser_label(module_t *m, bool is_pub, bool allow_pub) {
+static ast_stmt_t *parser_label(module_t *m) {
     ast_fndef_t *fndef = ast_fndef_new(m, parser_peek(m)->line, parser_peek(m)->column);
-    fndef->is_pub = is_pub;
 
     do {
         token_t *token = parser_must(m, TOKEN_LABEL);
@@ -3181,12 +3180,7 @@ static ast_stmt_t *parser_label(module_t *m, bool is_pub, bool allow_pub) {
                        parser_peek(m)->literal);
     }
 
-    if (allow_pub && parser_consume(m, TOKEN_PUB)) {
-        is_pub = true;
-        fndef->is_pub = true;
-    } else if (!allow_pub && parser_is(m, TOKEN_PUB)) {
-        PARSER_ASSERTF(false, "pub can only be applied to module-level declarations");
-    }
+    fndef->is_pub = parser_consume(m, TOKEN_PUB);
 
     if (fndef->pending_where_params) {
         PARSER_ASSERTF(parser_is(m, TOKEN_FN) || parser_is(m, TOKEN_FX), "#where can only be applied to fn/fx");
@@ -3194,7 +3188,7 @@ static ast_stmt_t *parser_label(module_t *m, bool is_pub, bool allow_pub) {
 
     if (parser_is(m, TOKEN_TYPE)) {
         PARSER_ASSERTF(!fndef->pending_where_params, "#where can only be applied to fn/fx");
-        return parser_typedef_stmt(m, is_pub);
+        return parser_typedef_stmt(m, fndef->is_pub);
     } else if (parser_is(m, TOKEN_FN) || parser_is(m, TOKEN_FX)) {
         return parser_fndef_stmt(m, fndef);
     } else {
@@ -3290,9 +3284,7 @@ static ast_stmt_t *parser_left_param_begin_stmt(module_t *m) {
  * @return
  */
 static ast_stmt_t *parser_local_stmt(module_t *m) {
-    if (parser_is(m, TOKEN_PUB)) {
-        PARSER_ASSERTF(false, "pub can only be applied to module-level declarations");
-    } else if (parser_is(m, TOKEN_VAR)) {
+    if (parser_is(m, TOKEN_VAR)) {
         return parser_var_begin_stmt(m, false);
     } else if (parser_is(m, TOKEN_CONST)) {
         return parser_constdef_stmt(m, false);
@@ -3304,8 +3296,6 @@ static ast_stmt_t *parser_local_stmt(module_t *m) {
         return parser_throw_stmt(m);
     } else if (parser_is(m, TOKEN_LET)) {
         return parser_let_stmt(m);
-    } else if (parser_is(m, TOKEN_LABEL)) {
-        return parser_label(m, false, false);
     } else if (parser_is(m, TOKEN_IF)) {
         return parser_if_stmt(m);
     } else if (parser_is(m, TOKEN_FOR)) {
@@ -3350,13 +3340,7 @@ static ast_stmt_t *parser_global_stmt(module_t *m) {
         PARSER_ASSERTF(false, "'mod' declaration must be the first statement of the file");
     }
 
-    // pub is the access-control modifier for module-level declarations
-    bool is_pub = false;
-    if (parser_is(m, TOKEN_PUB)) {
-        parser_advance(m);
-        is_pub = true;
-        PARSER_ASSERTF(!parser_is(m, TOKEN_LABEL), "pub must follow declaration labels");
-    }
+    bool is_pub = parser_consume(m, TOKEN_PUB);
 
     // module parser 只包含着几种简单语句
     if (parser_is(m, TOKEN_VAR)) {
@@ -3365,17 +3349,15 @@ static ast_stmt_t *parser_global_stmt(module_t *m) {
         return parser_constdef_stmt(m, is_pub);
     } else if (is_type_begin_stmt(m)) {
         return parser_type_begin_stmt(m, is_pub);
-    } else if (parser_is(m, TOKEN_LABEL)) {
-        return parser_label(m, is_pub, true);
+    } else if (!is_pub && parser_is(m, TOKEN_LABEL)) {
+        return parser_label(m);
     } else if (parser_is(m, TOKEN_FN) || parser_is(m, TOKEN_FX)) {
         ast_fndef_t *fndef = ast_fndef_new(m, parser_peek(m)->line, parser_peek(m)->column);
         fndef->is_pub = is_pub;
         return parser_fndef_stmt(m, fndef);
-    } else if (parser_is(m, TOKEN_TEST)) {
-        PARSER_ASSERTF(!is_pub, "pub cannot be applied to test");
+    } else if (!is_pub && parser_is(m, TOKEN_TEST)) {
         return parser_test_stmt(m);
-    } else if (parser_is(m, TOKEN_IMPORT)) {
-        PARSER_ASSERTF(!is_pub, "pub cannot be applied to import");
+    } else if (!is_pub && parser_is(m, TOKEN_IMPORT)) {
         return parser_import_stmt(m);
     } else if (parser_is(m, TOKEN_TYPE)) {
         return parser_typedef_stmt(m, is_pub);

--- a/src/syntax/parser.c
+++ b/src/syntax/parser.c
@@ -3147,7 +3147,7 @@ static ast_stmt_t *parser_test_stmt(module_t *m) {
  * @param m
  * @return
  */
-static ast_stmt_t *parser_label(module_t *m, bool is_pub) {
+static ast_stmt_t *parser_label(module_t *m, bool is_pub, bool allow_pub) {
     ast_fndef_t *fndef = ast_fndef_new(m, parser_peek(m)->line, parser_peek(m)->column);
     fndef->is_pub = is_pub;
 
@@ -3179,6 +3179,13 @@ static ast_stmt_t *parser_label(module_t *m, bool is_pub) {
         // #where 允许最后一个约束后保留逗号，scanner 不会自动插入 TOKEN_STMT_EOF
         PARSER_ASSERTF(fndef->pending_where_params, "expected '%s' found '%s'", token_str[TOKEN_STMT_EOF],
                        parser_peek(m)->literal);
+    }
+
+    if (allow_pub && parser_consume(m, TOKEN_PUB)) {
+        is_pub = true;
+        fndef->is_pub = true;
+    } else if (!allow_pub && parser_is(m, TOKEN_PUB)) {
+        PARSER_ASSERTF(false, "pub can only be applied to module-level declarations");
     }
 
     if (fndef->pending_where_params) {
@@ -3298,7 +3305,7 @@ static ast_stmt_t *parser_local_stmt(module_t *m) {
     } else if (parser_is(m, TOKEN_LET)) {
         return parser_let_stmt(m);
     } else if (parser_is(m, TOKEN_LABEL)) {
-        return parser_label(m, false);
+        return parser_label(m, false, false);
     } else if (parser_is(m, TOKEN_IF)) {
         return parser_if_stmt(m);
     } else if (parser_is(m, TOKEN_FOR)) {
@@ -3348,6 +3355,7 @@ static ast_stmt_t *parser_global_stmt(module_t *m) {
     if (parser_is(m, TOKEN_PUB)) {
         parser_advance(m);
         is_pub = true;
+        PARSER_ASSERTF(!parser_is(m, TOKEN_LABEL), "pub must follow declaration labels");
     }
 
     // module parser 只包含着几种简单语句
@@ -3358,7 +3366,7 @@ static ast_stmt_t *parser_global_stmt(module_t *m) {
     } else if (is_type_begin_stmt(m)) {
         return parser_type_begin_stmt(m, is_pub);
     } else if (parser_is(m, TOKEN_LABEL)) {
-        return parser_label(m, is_pub);
+        return parser_label(m, is_pub, true);
     } else if (parser_is(m, TOKEN_FN) || parser_is(m, TOKEN_FX)) {
         ast_fndef_t *fndef = ast_fndef_new(m, parser_peek(m)->line, parser_peek(m)->column);
         fndef->is_pub = is_pub;

--- a/src/syntax/parser.c
+++ b/src/syntax/parser.c
@@ -763,10 +763,11 @@ static type_t parser_single_type(module_t *m) {
  * type foo = gen i8|u8|i16
  * @return
  */
-static ast_stmt_t *parser_typedef_stmt(module_t *m) {
+static ast_stmt_t *parser_typedef_stmt(module_t *m, bool is_pub) {
     ast_stmt_t *result = stmt_new(m);
     ast_typedef_stmt_t *typedef_stmt = NEW(ast_typedef_stmt_t);
     sc_map_init_sv(&typedef_stmt->method_table, 0, 0);
+    typedef_stmt->is_pub = is_pub;
 
     parser_must(m, TOKEN_TYPE); // code
     typedef_stmt->ident = parser_must(m, TOKEN_IDENT)->literal; // ident
@@ -2804,11 +2805,12 @@ static ast_tuple_destr_t *parser_var_tuple_destr(module_t *m) {
     return result;
 }
 
-static ast_stmt_t *parser_constdef_stmt(module_t *m) {
+static ast_stmt_t *parser_constdef_stmt(module_t *m, bool is_pub) {
     ast_stmt_t *result = stmt_new(m);
 
     parser_must(m, TOKEN_CONST);
     ast_constdef_stmt_t *constdef = NEW(ast_constdef_stmt_t);
+    constdef->is_pub = is_pub;
 
     // 可选的 const 类型， string/int(i..)/float(f..)
     // 暂时看来没有用，如果需要在使用的时候主动进行 as
@@ -2833,12 +2835,13 @@ static ast_stmt_t *parser_constdef_stmt(module_t *m) {
  * @param m
  * @return
  */
-static ast_stmt_t *parser_var_begin_stmt(module_t *m) {
+static ast_stmt_t *parser_var_begin_stmt(module_t *m, bool is_pub) {
     ast_stmt_t *result = stmt_new(m);
     type_t typedecl = parser_type(m);
 
     // var (a, b)
     if (parser_is(m, TOKEN_LEFT_PAREN)) {
+        PARSER_ASSERTF(!is_pub, "pub cannot be applied to tuple destructuring");
         ast_var_tuple_def_stmt_t *stmt = NEW(ast_var_tuple_def_stmt_t);
         stmt->tuple_destr = parser_var_tuple_destr(m);
         parser_must(m, TOKEN_EQUAL);
@@ -2852,6 +2855,7 @@ static ast_stmt_t *parser_var_begin_stmt(module_t *m) {
     ast_vardef_stmt_t *var_assign = NEW(ast_vardef_stmt_t);
     token_t *ident_token = parser_must(m, TOKEN_IDENT);
     var_assign->var_decl.type = typedecl;
+    var_assign->var_decl.is_pub = is_pub;
     var_assign->var_decl.ident = ident_token->literal;
     parser_must(m, TOKEN_EQUAL);
     var_assign->right = expr_new_ptr(m);
@@ -2863,7 +2867,7 @@ static ast_stmt_t *parser_var_begin_stmt(module_t *m) {
 }
 
 // int a = 1
-static ast_stmt_t *parser_type_begin_stmt(module_t *m) {
+static ast_stmt_t *parser_type_begin_stmt(module_t *m, bool is_pub) {
     ast_stmt_t *result = stmt_new(m);
     // 类型解析
     type_t t = parser_type(m);
@@ -2876,6 +2880,7 @@ static ast_stmt_t *parser_type_begin_stmt(module_t *m) {
     ast_var_decl_t *var_decl = NEW(ast_var_decl_t);
     var_decl->type = t;
     var_decl->ident = ident_token->literal;
+    var_decl->is_pub = is_pub;
 
     // 声明必须赋值
     parser_must(m, TOKEN_EQUAL);
@@ -3119,7 +3124,6 @@ static ast_stmt_t *parser_test_stmt(module_t *m) {
     }
 
     fndef->is_test = true;
-    fndef->is_private = true;
     fndef->is_errable = true;
     fndef->test_name = name_token->literal;
     fndef->symbol_name =
@@ -3143,8 +3147,9 @@ static ast_stmt_t *parser_test_stmt(module_t *m) {
  * @param m
  * @return
  */
-static ast_stmt_t *parser_label(module_t *m) {
+static ast_stmt_t *parser_label(module_t *m, bool is_pub) {
     ast_fndef_t *fndef = ast_fndef_new(m, parser_peek(m)->line, parser_peek(m)->column);
+    fndef->is_pub = is_pub;
 
     do {
         token_t *token = parser_must(m, TOKEN_LABEL);
@@ -3156,8 +3161,6 @@ static ast_stmt_t *parser_label(module_t *m) {
                 token_t *literal = parser_must(m, TOKEN_LITERAL_STRING);
                 fndef->linkid = literal->literal;
             }
-        } else if (str_equal(token->literal, MACRO_LOCAL)) {
-            fndef->is_private = true;
         } else if (str_equal(token->literal, MACRO_WHERE)) {
             PARSER_ASSERTF(!fndef->pending_where_params, "#where redeclared");
             fndef->pending_where_params = parser_parse_where_constraints(m);
@@ -3184,7 +3187,7 @@ static ast_stmt_t *parser_label(module_t *m) {
 
     if (parser_is(m, TOKEN_TYPE)) {
         PARSER_ASSERTF(!fndef->pending_where_params, "#where can only be applied to fn/fx");
-        return parser_typedef_stmt(m);
+        return parser_typedef_stmt(m, is_pub);
     } else if (parser_is(m, TOKEN_FN) || parser_is(m, TOKEN_FX)) {
         return parser_fndef_stmt(m, fndef);
     } else {
@@ -3280,12 +3283,14 @@ static ast_stmt_t *parser_left_param_begin_stmt(module_t *m) {
  * @return
  */
 static ast_stmt_t *parser_local_stmt(module_t *m) {
-    if (parser_is(m, TOKEN_VAR)) {
-        return parser_var_begin_stmt(m);
+    if (parser_is(m, TOKEN_PUB)) {
+        PARSER_ASSERTF(false, "pub can only be applied to module-level declarations");
+    } else if (parser_is(m, TOKEN_VAR)) {
+        return parser_var_begin_stmt(m, false);
     } else if (parser_is(m, TOKEN_CONST)) {
-        return parser_constdef_stmt(m);
+        return parser_constdef_stmt(m, false);
     } else if (is_type_begin_stmt(m)) {
-        return parser_type_begin_stmt(m);
+        return parser_type_begin_stmt(m, false);
     } else if (parser_is(m, TOKEN_LEFT_PAREN)) {
         return parser_left_param_begin_stmt(m);
     } else if (parser_is(m, TOKEN_THROW)) {
@@ -3293,7 +3298,7 @@ static ast_stmt_t *parser_local_stmt(module_t *m) {
     } else if (parser_is(m, TOKEN_LET)) {
         return parser_let_stmt(m);
     } else if (parser_is(m, TOKEN_LABEL)) {
-        return parser_label(m);
+        return parser_label(m, false);
     } else if (parser_is(m, TOKEN_IF)) {
         return parser_if_stmt(m);
     } else if (parser_is(m, TOKEN_FOR)) {
@@ -3305,7 +3310,7 @@ static ast_stmt_t *parser_local_stmt(module_t *m) {
     } else if (parser_is(m, TOKEN_IMPORT)) {
         return parser_import_stmt(m);
     } else if (parser_is(m, TOKEN_TYPE)) {
-        return parser_typedef_stmt(m);
+        return parser_typedef_stmt(m, false);
     } else if (parser_is(m, TOKEN_CONTINUE)) {
         return parser_continue_stmt(m);
     } else if (parser_is(m, TOKEN_BREAK)) {
@@ -3338,23 +3343,34 @@ static ast_stmt_t *parser_global_stmt(module_t *m) {
         PARSER_ASSERTF(false, "'mod' declaration must be the first statement of the file");
     }
 
+    // pub is the access-control modifier for module-level declarations
+    bool is_pub = false;
+    if (parser_is(m, TOKEN_PUB)) {
+        parser_advance(m);
+        is_pub = true;
+    }
+
     // module parser 只包含着几种简单语句
     if (parser_is(m, TOKEN_VAR)) {
-        return parser_var_begin_stmt(m);
+        return parser_var_begin_stmt(m, is_pub);
     } else if (parser_is(m, TOKEN_CONST)) {
-        return parser_constdef_stmt(m);
+        return parser_constdef_stmt(m, is_pub);
     } else if (is_type_begin_stmt(m)) {
-        return parser_type_begin_stmt(m);
+        return parser_type_begin_stmt(m, is_pub);
     } else if (parser_is(m, TOKEN_LABEL)) {
-        return parser_label(m);
+        return parser_label(m, is_pub);
     } else if (parser_is(m, TOKEN_FN) || parser_is(m, TOKEN_FX)) {
-        return parser_fndef_stmt(m, ast_fndef_new(m, parser_peek(m)->line, parser_peek(m)->column));
+        ast_fndef_t *fndef = ast_fndef_new(m, parser_peek(m)->line, parser_peek(m)->column);
+        fndef->is_pub = is_pub;
+        return parser_fndef_stmt(m, fndef);
     } else if (parser_is(m, TOKEN_TEST)) {
+        PARSER_ASSERTF(!is_pub, "pub cannot be applied to test");
         return parser_test_stmt(m);
     } else if (parser_is(m, TOKEN_IMPORT)) {
+        PARSER_ASSERTF(!is_pub, "pub cannot be applied to import");
         return parser_import_stmt(m);
     } else if (parser_is(m, TOKEN_TYPE)) {
-        return parser_typedef_stmt(m);
+        return parser_typedef_stmt(m, is_pub);
     }
 
     PARSER_ASSERTF(false, "non-declaration statement outside fn body")

--- a/src/syntax/scanner.c
+++ b/src/syntax/scanner.c
@@ -823,8 +823,9 @@ static token_type_t scanner_ident(char *word, int length) {
                     // return scanner_rest(word, length, 2, 1, "w", TOKEN_NEW);
             }
             break;
-            //        case 'p':
-            //            return scanner_rest(word, length, 1, 2, "tr", TOKEN_PTR);
+        case 'p': {
+            return scanner_rest(word, length, 1, 2, "ub", TOKEN_PUB);
+        }
         case 's': {
             // self,string,struct,sizeof,sett
             switch (word[1]) {

--- a/src/syntax/token.h
+++ b/src/syntax/token.h
@@ -130,6 +130,7 @@ typedef enum {
     TOKEN_BOOM,
     TOKEN_FN,
     TOKEN_FX,
+    TOKEN_PUB,
     TOKEN_IMPORT,
     TOKEN_RETURN,
     TOKEN_DEFER,
@@ -238,6 +239,7 @@ static string token_str[] = {
 
         [TOKEN_FN] = "fn",
         [TOKEN_FX] = "fx",
+        [TOKEN_PUB] = "pub",
         [TOKEN_RETURN] = "return",
         [TOKEN_DEFER] = "defer",
         [TOKEN_CATCH] = "catch",

--- a/std/allocator/allocator.n
+++ b/std/allocator/allocator.n
@@ -5,7 +5,7 @@ import allocator.types.{allocatable}
 
 type heap_t:allocatable = int
 
-heap_t heap = 0
+pub heap_t heap = 0
 
 // allocatable interface impl: allocate `size` bytes from the heap
 fn heap_t.alloc(*self, int size):anyptr {
@@ -44,10 +44,10 @@ fn heap_t.free<T>(*self, ptr<T> p) {
     self.dealloc(p as anyptr)
 }
 
-fn new<T>(T value):ptr<T> {
+pub fn new<T>(T value):ptr<T> {
     return heap.new(value)
 }
 
-fn free<T>(ptr<T> p) {
+pub fn free<T>(ptr<T> p) {
     return heap.free(p)
 }

--- a/std/allocator/arena.n
+++ b/std/allocator/arena.n
@@ -58,7 +58,7 @@ fn block_alloc(ptr<block_t> b, int size):anyptr {
     return p
 }
 
-fn init(int capacity):ptr<arena_t> {
+pub fn init(int capacity):ptr<arena_t> {
     ptr<arena_t> a = libc.malloc(@sizeof(arena_t)) as ptr<arena_t>
     if a == null {
         panic('arena: init malloc failed')
@@ -80,7 +80,7 @@ fn init(int capacity):ptr<arena_t> {
     return a
 }
 
-fn arena_t.deinit(*self) {
+pub fn arena_t.deinit(*self) {
     // walk the linked list and free all blocks
     var b = self.head
     for b != null {
@@ -140,7 +140,7 @@ fn arena_t.dealloc(*self, anyptr p) {
 }
 
 // convenience generic helper: allocate and initialize a value of type T
-fn arena_t.new<T>(*self, T value):ptr<T> {
+pub fn arena_t.new<T>(*self, T value):ptr<T> {
     int size = @sizeof(T)
     if size <= 0 {
         panic('arena: new invalid type size')

--- a/std/allocator/types.n
+++ b/std/allocator/types.n
@@ -1,4 +1,4 @@
-type allocatable = interface{
+pub type allocatable = interface{
     fn alloc(int size):anyptr
     fn dealloc(anyptr p):void
 }

--- a/std/base64/base64.n
+++ b/std/base64/base64.n
@@ -8,7 +8,7 @@ fn mbedtls_base64_decode(anyptr dst, int dlen, ptr<int> olen, anyptr src, int sl
 #linkid mbedtls_base64_encode
 fn mbedtls_base64_encode(anyptr dst, int dlen, ptr<int> olen, anyptr src, int slen):i32
 
-fn encode([u8] src):[u8] {
+pub fn encode([u8] src):[u8] {
     var max_len = ((src.len() + 2) / 3) * 4 + 1
     var dst = vec<u8>.new(0, max_len)
     int olen = 0
@@ -19,7 +19,7 @@ fn encode([u8] src):[u8] {
     return dst
 }
 
-fn decode([u8] src):[u8]! {
+pub fn decode([u8] src):[u8]! {
     var max_len = (src.len() * 3) / 4 + 1
     var dst = vec<u8>.new(0, max_len)
     var olen = 0

--- a/std/builtin/builtin.n
+++ b/std/builtin/builtin.n
@@ -1,13 +1,13 @@
 pub type nullable<T> = T?
 
-pub #linkid print
-fn print(...[any] args)
+#linkid print
+pub fn print(...[any] args)
 
-pub #linkid println
-fn println(...[any] args)
+#linkid println
+pub fn println(...[any] args)
 
-pub #linkid rt_panic
-fn panic(string msg)
+#linkid rt_panic
+pub fn panic(string msg)
 
-pub #linkid rt_assert
-fn assert(bool cond)
+#linkid rt_assert
+pub fn assert(bool cond)

--- a/std/builtin/builtin.n
+++ b/std/builtin/builtin.n
@@ -1,13 +1,13 @@
-type nullable<T> = T?
+pub type nullable<T> = T?
 
-#linkid print
+pub #linkid print
 fn print(...[any] args)
 
-#linkid println
+pub #linkid println
 fn println(...[any] args)
 
-#linkid rt_panic
+pub #linkid rt_panic
 fn panic(string msg)
 
-#linkid rt_assert
+pub #linkid rt_assert
 fn assert(bool cond)

--- a/std/builtin/chan.n
+++ b/std/builtin/chan.n
@@ -44,23 +44,23 @@ pub fn chan<T>.try_recv(self):(T, bool)! {
     return (msg, is_recv)
 }
 
-pub #linkid rt_chan_close
-fn chan<T>.close(self):void!
+#linkid rt_chan_close
+pub fn chan<T>.close(self):void!
 
-pub #linkid rt_chan_is_closed
-fn chan<T>.is_closed(self):bool
+#linkid rt_chan_is_closed
+pub fn chan<T>.is_closed(self):bool
 
-pub #linkid rt_chan_is_successful
-fn chan<T>.is_successful(self):bool
+#linkid rt_chan_is_successful
+pub fn chan<T>.is_successful(self):bool
 
-pub #linkid rt_chan_new
-fn rt_chan_new(i64 rhash, i64 ele_hash, i64 buf_len):anyptr
+#linkid rt_chan_new
+pub fn rt_chan_new(i64 rhash, i64 ele_hash, i64 buf_len):anyptr
 
-pub #linkid rt_chan_send
-fn rt_chan_send(anyptr ch, anyptr msg, bool _try):bool!
+#linkid rt_chan_send
+pub fn rt_chan_send(anyptr ch, anyptr msg, bool _try):bool!
 
-pub #linkid rt_chan_recv
-fn rt_chan_recv(anyptr ch, anyptr msg, bool _try):bool!
+#linkid rt_chan_recv
+pub fn rt_chan_recv(anyptr ch, anyptr msg, bool _try):bool!
 
-pub #linkid rt_chan_close
-fn rt_chan_close(anyptr ch):void!
+#linkid rt_chan_close
+pub fn rt_chan_close(anyptr ch):void!

--- a/std/builtin/chan.n
+++ b/std/builtin/chan.n
@@ -1,7 +1,7 @@
 import co
 
 // var ch = chan<T>.new()
-fn chan<T>.new(...[int] args):chan<T> {
+pub fn chan<T>.new(...[int] args):chan<T> {
     int rhash = @reflect_hash(chan<T>)
     int ele_rhash = @reflect_hash(T)
 
@@ -13,19 +13,19 @@ fn chan<T>.new(...[int] args):chan<T> {
     return rt_chan_new(rhash, ele_rhash, buf_len) as chan<T>
 }
 
-fn chan<T>.send(self, T msg):void! {
+pub fn chan<T>.send(self, T msg):void! {
     rt_chan_send(self as anyptr, &msg as anyptr, false)
 }
 
-fn chan<T>.try_send(self, T msg):bool! {
+pub fn chan<T>.try_send(self, T msg):bool! {
     return rt_chan_send(self as anyptr, &msg as anyptr, true)
 }
 
-fn chan<T>.on_send(self, T msg):void {
+pub fn chan<T>.on_send(self, T msg):void {
     // no body
 }
 
-fn chan<T>.recv(self):T! {
+pub fn chan<T>.recv(self):T! {
     var msg = @default(T)
     rt_chan_recv(self as anyptr, &msg as anyptr, false)
 
@@ -33,34 +33,34 @@ fn chan<T>.recv(self):T! {
 }
 
 // The specific logic is already handled at compiler time, and this function is mainly used for compiler front-end validation
-fn chan<T>.on_recv(self):T {
+pub fn chan<T>.on_recv(self):T {
     var msg = @default(T)
     return msg
 }
 
-fn chan<T>.try_recv(self):(T, bool)! {
+pub fn chan<T>.try_recv(self):(T, bool)! {
     var msg = @default(T)
     bool is_recv = rt_chan_recv(self as anyptr, &msg as anyptr, true)
     return (msg, is_recv)
 }
 
-#linkid rt_chan_close
+pub #linkid rt_chan_close
 fn chan<T>.close(self):void!
 
-#linkid rt_chan_is_closed
+pub #linkid rt_chan_is_closed
 fn chan<T>.is_closed(self):bool
 
-#linkid rt_chan_is_successful
+pub #linkid rt_chan_is_successful
 fn chan<T>.is_successful(self):bool
 
-#linkid rt_chan_new
+pub #linkid rt_chan_new
 fn rt_chan_new(i64 rhash, i64 ele_hash, i64 buf_len):anyptr
 
-#linkid rt_chan_send
+pub #linkid rt_chan_send
 fn rt_chan_send(anyptr ch, anyptr msg, bool _try):bool!
 
-#linkid rt_chan_recv
+pub #linkid rt_chan_recv
 fn rt_chan_recv(anyptr ch, anyptr msg, bool _try):bool!
 
-#linkid rt_chan_close
+pub #linkid rt_chan_close
 fn rt_chan_close(anyptr ch):void!

--- a/std/builtin/constraints.n
+++ b/std/builtin/constraints.n
@@ -1,9 +1,9 @@
-type equatable = interface{}
+pub type equatable = interface{}
 
-type comparable = interface{}
+pub type comparable = interface{}
 
-type addable = interface{}
+pub type addable = interface{}
 
-type numeric:addable,comparable,equatable = interface{}
+pub type numeric:addable,comparable,equatable = interface{}
 
-type nonvoid = interface{}
+pub type nonvoid = interface{}

--- a/std/builtin/coroutine.n
+++ b/std/builtin/coroutine.n
@@ -27,8 +27,8 @@ pub fn co_return<T>(ptr<T> result) {
     utils.coroutine_return(result as anyptr)
 }
 
-pub #where T:nonvoid
-fn future_t<T>.await(&self):T! {
+#where T:nonvoid
+pub fn future_t<T>.await(&self):T! {
     utils.coroutine_await(self.co)
 
     if self.error is throwable {

--- a/std/builtin/coroutine.n
+++ b/std/builtin/coroutine.n
@@ -1,14 +1,14 @@
 import co.utils
 import runtime
 
-type future_t<T> = struct{
+pub type future_t<T> = struct{
     i64 size
     ptr<T> result
     throwable? error
     anyptr co
 }
 
-fn async<T>(fn():void! function, int flag):ref<future_t<T>> {
+pub fn async<T>(fn():void! function, int flag):ref<future_t<T>> {
     var fu = new future_t<T>()
     fu.size = @sizeof(T)
     if fu.size > 0 {
@@ -23,11 +23,11 @@ fn async<T>(fn():void! function, int flag):ref<future_t<T>> {
     return fu
 }
 
-fn co_return<T>(ptr<T> result) {
+pub fn co_return<T>(ptr<T> result) {
     utils.coroutine_return(result as anyptr)
 }
 
-#where T:nonvoid
+pub #where T:nonvoid
 fn future_t<T>.await(&self):T! {
     utils.coroutine_await(self.co)
 
@@ -39,7 +39,7 @@ fn future_t<T>.await(&self):T! {
     return *self.result
 }
 
-fn future_t<T>.await_void(&self):void! {
+pub fn future_t<T>.await_void(&self):void! {
     utils.coroutine_await(self.co)
 
     if self.error is throwable {

--- a/std/builtin/error.n
+++ b/std/builtin/error.n
@@ -1,29 +1,29 @@
 import fmt
 
-type throwable = interface{
+pub type throwable = interface{
 	fn msg():string
 }
 
-type trace_t = struct{
+pub type trace_t = struct{
     string path
     string ident
     int line
     int column
 }
 
-type errort:throwable = struct{
+pub type errort:throwable = struct{
 	string message
 	bool is_panic
 }
 
-fn errort.msg(&self):string {
+pub fn errort.msg(&self):string {
 	return self.message
 }
 
-fn errorf(string format, ...[any] args):ref<errort> {
+pub fn errorf(string format, ...[any] args):ref<errort> {
 	var msg = fmt.sprintf(format, ...args)
 	return new errort(message = msg)
 }
 
 
-type errable<T> = errort|T
+pub type errable<T> = errort|T

--- a/std/builtin/map.n
+++ b/std/builtin/map.n
@@ -7,8 +7,8 @@ pub fn map<T,U>.new():map<T,U> {
     return runtime.map_new<T,U>(hash, key_hash, value_hash)
 }
 
-pub #linkid rt_map_length
-fn map<T,U>.len(*self):int
+#linkid rt_map_length
+pub fn map<T,U>.len(*self):int
 
 pub fn map<T,U>.del(*self, T key) {
     ptr<T> ref = &key

--- a/std/builtin/map.n
+++ b/std/builtin/map.n
@@ -1,21 +1,21 @@
 import runtime
 
-fn map<T,U>.new():map<T,U> {
+pub fn map<T,U>.new():map<T,U> {
     int hash = @reflect_hash(map<T,U>)
     int key_hash = @reflect_hash(T)
     int value_hash = @reflect_hash(U)
     return runtime.map_new<T,U>(hash, key_hash, value_hash)
 }
 
-#linkid rt_map_length
+pub #linkid rt_map_length
 fn map<T,U>.len(*self):int
 
-fn map<T,U>.del(*self, T key) {
+pub fn map<T,U>.del(*self, T key) {
     ptr<T> ref = &key
     runtime.map_delete(self as anyptr, ref as anyptr)
 }
 
-fn map<T,U>.contains(*self, T key):bool {
+pub fn map<T,U>.contains(*self, T key):bool {
     ptr<T> ref = &key
     return runtime.map_contains(self as anyptr, ref as anyptr)
 }

--- a/std/builtin/set.n
+++ b/std/builtin/set.n
@@ -1,22 +1,22 @@
 import runtime
 
-fn set<T>.new():set<T> {
+pub fn set<T>.new():set<T> {
     int hash = @reflect_hash(set<T>)
     int key_hash = @reflect_hash(T)
     return runtime.set_new<T>(hash, key_hash)
 }
 
-fn set<T>.add(*self, T key) {
+pub fn set<T>.add(*self, T key) {
    ptr<T> ref = &key
    runtime.set_add(self as anyptr, ref as anyptr)
 }
 
-fn set<T>.contains(*self, T key):bool {
+pub fn set<T>.contains(*self, T key):bool {
    ptr<T> ref = &key
    return runtime.set_contains(self as anyptr, ref as anyptr)
 }
 
-fn set<T>.del(*self, T key) {
+pub fn set<T>.del(*self, T key) {
     ptr<T> ref = &key
     runtime.set_delete(self as anyptr, ref as anyptr)
 }

--- a/std/builtin/string.n
+++ b/std/builtin/string.n
@@ -1,11 +1,11 @@
 import runtime
 
-#linkid rt_string_length
+pub #linkid rt_string_length
 fn string.len(*self):int
 
-#linkid rt_string_ref
+pub #linkid rt_string_ref
 fn string.ref(*self):anyptr
 
-fn string.char(*self):u8 {
+pub fn string.char(*self):u8 {
     return (*self)[0]
 }

--- a/std/builtin/string.n
+++ b/std/builtin/string.n
@@ -1,10 +1,10 @@
 import runtime
 
-pub #linkid rt_string_length
-fn string.len(*self):int
+#linkid rt_string_length
+pub fn string.len(*self):int
 
-pub #linkid rt_string_ref
-fn string.ref(*self):anyptr
+#linkid rt_string_ref
+pub fn string.ref(*self):anyptr
 
 pub fn string.char(*self):u8 {
     return (*self)[0]

--- a/std/builtin/vec.n
+++ b/std/builtin/vec.n
@@ -123,8 +123,8 @@ pub fn vec<T>.concat(*self, vec<T> l2):vec<T> {
     return runtime.vec_concat<T>(self as anyptr, l2 as anyptr, element_hash)
 }
 
-pub #linkid rt_vec_copy
-fn vec<T>.copy(*self, vec<T> src):int
+#linkid rt_vec_copy
+pub fn vec<T>.copy(*self, vec<T> src):int
 
 pub fn vec<T>.len(*self):int {
     var rv = self as anyptr as ptr<vec_t>
@@ -136,8 +136,8 @@ pub fn vec<T>.cap(*self):int {
     return rv.capacity
 }
 
-pub #linkid rt_vec_ref
-fn vec<T>.ref(*self):anyptr
+#linkid rt_vec_ref
+pub fn vec<T>.ref(*self):anyptr
 
 pub fn vec<T>.sort(*self, fn(int, int):bool less) {
     // 如果向量长度小于等于1，无需排序

--- a/std/builtin/vec.n
+++ b/std/builtin/vec.n
@@ -4,9 +4,9 @@ import allocator as ac
 import reflect.{vec_t}
 import libc
 
-const VEC_DEFAULT_CAPACITY = 8
+pub const VEC_DEFAULT_CAPACITY = 8
 
-fn vec<T>.new(T default_value, int len):vec<T> {
+pub fn vec<T>.new(T default_value, int len):vec<T> {
     int hash = @reflect_hash(vec<T>)
     int element_hash = @reflect_hash(T)
     return runtime.vec_new<T>(hash, element_hash, len, &default_value as anyptr) catch e {
@@ -15,7 +15,7 @@ fn vec<T>.new(T default_value, int len):vec<T> {
     }
 }
 
-fn vec<T>.alloc(allocatable a, T default_value, int len):vec<T> {
+pub fn vec<T>.alloc(allocatable a, T default_value, int len):vec<T> {
     if len < 0 {
         panic('len must be greater than 0')
     }
@@ -46,7 +46,7 @@ fn vec<T>.alloc(allocatable a, T default_value, int len):vec<T> {
     return result
 }
 
-fn vec<T>.cap_of(int cap):vec<T> {
+pub fn vec<T>.cap_of(int cap):vec<T> {
     int hash = @reflect_hash(vec<T>)
     int element_hash = @reflect_hash(T)
     return runtime.vec_cap<T>(hash, element_hash, cap) catch e {
@@ -55,7 +55,7 @@ fn vec<T>.cap_of(int cap):vec<T> {
     }
 }
 
-fn vec<T>.grow(*self) {
+pub fn vec<T>.grow(*self) {
     ptr<vec_t> rv = self as anyptr as ptr<vec_t>
     assert(rv.allocator > 0)
 
@@ -75,7 +75,7 @@ fn vec<T>.grow(*self) {
     a.dealloc(old_data)
 }
 
-fn vec<T>.push(*self, T v) {
+pub fn vec<T>.push(*self, T v) {
     ptr<vec_t> rv = self as anyptr as ptr<vec_t>
     if rv.allocator == 0 {
         ptr<T> ref = &v
@@ -95,7 +95,7 @@ fn vec<T>.push(*self, T v) {
     libc.memmove(p, &v as anyptr, @sizeof(T))
 }
 
-fn vec<T>.deinit(*self) {
+pub fn vec<T>.deinit(*self) {
     ptr<vec_t> rv = self as anyptr as ptr<vec_t>
     if rv.allocator == 0 {
         return
@@ -106,40 +106,40 @@ fn vec<T>.deinit(*self) {
     a.dealloc(rv.data)
 }
 
-fn vec<T>.append(*self, vec<T> l2) {
+pub fn vec<T>.append(*self, vec<T> l2) {
     int element_hash = @reflect_hash(T)
     return runtime.vec_append(self as anyptr, l2 as anyptr, element_hash)
 }
 
-fn vec<T>.slice(*self, int start, int end):vec<T> {
+pub fn vec<T>.slice(*self, int start, int end):vec<T> {
     return runtime.vec_slice<T>(self as anyptr, start, end) catch e {
         panic(e.msg())
         []
     }
 }
 
-fn vec<T>.concat(*self, vec<T> l2):vec<T> {
+pub fn vec<T>.concat(*self, vec<T> l2):vec<T> {
     int element_hash = @reflect_hash(T)
     return runtime.vec_concat<T>(self as anyptr, l2 as anyptr, element_hash)
 }
 
-#linkid rt_vec_copy
+pub #linkid rt_vec_copy
 fn vec<T>.copy(*self, vec<T> src):int
 
-fn vec<T>.len(*self):int {
+pub fn vec<T>.len(*self):int {
     var rv = self as anyptr as ptr<vec_t>
     return rv.length
 }
 
-fn vec<T>.cap(*self):int {
+pub fn vec<T>.cap(*self):int {
     var rv = self as anyptr as ptr<vec_t>
     return rv.capacity
 }
 
-#linkid rt_vec_ref
+pub #linkid rt_vec_ref
 fn vec<T>.ref(*self):anyptr
 
-fn vec<T>.sort(*self, fn(int, int):bool less) {
+pub fn vec<T>.sort(*self, fn(int, int):bool less) {
     // 如果向量长度小于等于1，无需排序
     if self.len() <= 1 {
         return
@@ -149,7 +149,7 @@ fn vec<T>.sort(*self, fn(int, int):bool less) {
     self.pdqsort(0, self.len(), 64, less)
 }
 
-fn vec<T>.insertion_sort(*self, int a, int b, fn(int, int):bool less) {
+pub fn vec<T>.insertion_sort(*self, int a, int b, fn(int, int):bool less) {
     for int i = a + 1; i < b; i+=1 {
         for int j = i; j > a && less(j, j-1); j-=1 {
             self.swap(j, j-1)
@@ -157,7 +157,7 @@ fn vec<T>.insertion_sort(*self, int a, int b, fn(int, int):bool less) {
     }
 }
 
-fn vec<T>.swap(self, int i, int j) {
+pub fn vec<T>.swap(self, int i, int j) {
     if i == j {
         return
     }
@@ -167,7 +167,7 @@ fn vec<T>.swap(self, int i, int j) {
     self[j] = temp
 }
 
-fn vec<T>.heap_sort(*self, int a, int b, fn(int, int):bool less) {
+pub fn vec<T>.heap_sort(*self, int a, int b, fn(int, int):bool less) {
     int first = a
     int lo = 0
     int hi = b - a
@@ -184,7 +184,7 @@ fn vec<T>.heap_sort(*self, int a, int b, fn(int, int):bool less) {
     }
 }
 
-fn vec<T>.sift_down(*self, int root, int hi, int first, fn(int, int):bool less) {
+pub fn vec<T>.sift_down(*self, int root, int hi, int first, fn(int, int):bool less) {
     for true {
         int child = 2 * root + 1
         if child >= hi {
@@ -204,7 +204,7 @@ fn vec<T>.sift_down(*self, int root, int hi, int first, fn(int, int):bool less) 
     }
 }
 
-fn vec<T>.pdqsort(*self, int a, int b, int limit, fn(int, int):bool less) {
+pub fn vec<T>.pdqsort(*self, int a, int b, int limit, fn(int, int):bool less) {
     int max_insertion = 12
     
     bool was_balanced = true    // 上次分区是否平衡
@@ -263,7 +263,7 @@ fn vec<T>.pdqsort(*self, int a, int b, int limit, fn(int, int):bool less) {
 }
 
 // 分区函数
-fn vec<T>.partition(*self, int a, int b, int pivot, fn(int, int):bool less, ptr<bool> already_partitioned):int {
+pub fn vec<T>.partition(*self, int a, int b, int pivot, fn(int, int):bool less, ptr<bool> already_partitioned):int {
     self.swap(a, pivot)
     int i = a + 1
     int j = b - 1
@@ -312,7 +312,7 @@ fn vec<T>.partition(*self, int a, int b, int pivot, fn(int, int):bool less, ptr<
     return j
 }
 
-fn vec<T>.break_patterns(*self, int a, int b) {
+pub fn vec<T>.break_patterns(*self, int a, int b) {
     int length = b - a
     
     if length >= 8 {
@@ -323,7 +323,7 @@ fn vec<T>.break_patterns(*self, int a, int b) {
     }
 }
 
-fn vec<T>.search(*self, fn(int):bool predicate):int {
+pub fn vec<T>.search(*self, fn(int):bool predicate):int {
     int low = 0
     int high = self.len()
     

--- a/std/co/co.n
+++ b/std/co/co.n
@@ -3,11 +3,11 @@ mod co
 // var SOLO = 1 << 1
 pub var SAME = 1 << 2
 
-pub #linkid rt_coroutine_sleep
-fn sleep(int ms)
+#linkid rt_coroutine_sleep
+pub fn sleep(int ms)
 
-pub #linkid rt_coroutine_yield
-fn yield()
+#linkid rt_coroutine_yield
+pub fn yield()
 
-pub #linkid rt_coroutine_arg
-fn arg():anyptr
+#linkid rt_coroutine_arg
+pub fn arg():anyptr

--- a/std/co/co.n
+++ b/std/co/co.n
@@ -1,13 +1,13 @@
 mod co
 
 // var SOLO = 1 << 1
-var SAME = 1 << 2
+pub var SAME = 1 << 2
 
-#linkid rt_coroutine_sleep
+pub #linkid rt_coroutine_sleep
 fn sleep(int ms)
 
-#linkid rt_coroutine_yield
+pub #linkid rt_coroutine_yield
 fn yield()
 
-#linkid rt_coroutine_arg
+pub #linkid rt_coroutine_arg
 fn arg():anyptr

--- a/std/co/cross.darwin.n
+++ b/std/co/cross.darwin.n
@@ -1,4 +1,4 @@
-type pthread_mutex_t = struct{
+pub type pthread_mutex_t = struct{
     i64 sig = 0x32AAABA7
     [u8;56] __opaque = [0]
 }

--- a/std/co/cross.linux.n
+++ b/std/co/cross.linux.n
@@ -1,3 +1,3 @@
-type pthread_mutex_t = struct{
+pub type pthread_mutex_t = struct{
     [u8;40] __align = []
 }

--- a/std/co/cross.windows.n
+++ b/std/co/cross.windows.n
@@ -1,3 +1,3 @@
-type pthread_mutex_t = struct{
+pub type pthread_mutex_t = struct{
     i64 value
 }

--- a/std/co/mutex.n
+++ b/std/co/mutex.n
@@ -1,13 +1,13 @@
 import co.types
 
-type mutex_t = struct{
+pub type mutex_t = struct{
     i64 state
     i64 sema
     i64 waiter_count
     var waiters = types.linkco_list_t{}
 }
 
-fn mutex_t.new():ref<mutex_t> {
+pub fn mutex_t.new():ref<mutex_t> {
     return new mutex_t()
 }
 
@@ -20,7 +20,7 @@ fn rt_mutex_try_lock(ref<mutex_t> m):bool
 #linkid rt_mutex_unlock
 fn rt_mutex_unlock(ref<mutex_t> m)
 
-fn mutex_t.lock(&self) {
+pub fn mutex_t.lock(&self) {
     rt_mutex_lock(self)
 }
 
@@ -28,6 +28,6 @@ fn mutex_t.try_lock(&self):bool {
     return rt_mutex_try_lock(self)
 }
 
-fn mutex_t.unlock(&self) {
+pub fn mutex_t.unlock(&self) {
     rt_mutex_unlock(self)
 }

--- a/std/co/types.n
+++ b/std/co/types.n
@@ -7,7 +7,7 @@ type linkco_t = struct{
     anyptr data // 各种需要的数据存储, 比如 chan 中的 msg_ptr
 }
 
-type linkco_list_t = struct{
+pub type linkco_list_t = struct{
     ptr<linkco_t> head
     ptr<linkco_t> rear
     i64 count

--- a/std/co/utils.n
+++ b/std/co/utils.n
@@ -1,14 +1,14 @@
 #linkid rt_coroutine_new
 fn coroutine_new(anyptr function, int flag, anyptr future):anyptr
 
-pub #linkid rt_coroutine_async
-fn coroutine_async(anyptr function, int flag, anyptr future):anyptr
+#linkid rt_coroutine_async
+pub fn coroutine_async(anyptr function, int flag, anyptr future):anyptr
 
 #linkid rt_coroutine_dispatch
 fn coroutine_dispatch(anyptr co)
 
-pub #linkid rt_coroutine_return
-fn coroutine_return(anyptr result)
+#linkid rt_coroutine_return
+pub fn coroutine_return(anyptr result)
 
-pub #linkid rt_coroutine_await
-fn coroutine_await(anyptr co)
+#linkid rt_coroutine_await
+pub fn coroutine_await(anyptr co)

--- a/std/co/utils.n
+++ b/std/co/utils.n
@@ -1,14 +1,14 @@
 #linkid rt_coroutine_new
 fn coroutine_new(anyptr function, int flag, anyptr future):anyptr
 
-#linkid rt_coroutine_async
+pub #linkid rt_coroutine_async
 fn coroutine_async(anyptr function, int flag, anyptr future):anyptr
 
 #linkid rt_coroutine_dispatch
 fn coroutine_dispatch(anyptr co)
 
-#linkid rt_coroutine_return
+pub #linkid rt_coroutine_return
 fn coroutine_return(anyptr result)
 
-#linkid rt_coroutine_await
+pub #linkid rt_coroutine_await
 fn coroutine_await(anyptr co)

--- a/std/crypto/bcrypt.n
+++ b/std/crypto/bcrypt.n
@@ -4,27 +4,27 @@ import time
 import libc
 
 // bcrypt constant definitions
-const MIN_COST = 4
-const MAX_COST = 31
-const DEFAULT_COST = 10
+pub const MIN_COST = 4
+pub const MAX_COST = 31
+pub const DEFAULT_COST = 10
 
-const MAJOR_VERSION = 50 // '2'
-const MINOR_VERSION = 97 // 'a'
-const MAX_SALT_SIZE = 16
-const MAX_CRYPTED_HASH_SIZE = 23
-const ENCODED_SALT_SIZE = 22
-const ENCODED_HASH_SIZE = 31
-const MIN_HASH_SIZE = 59
+pub const MAJOR_VERSION = 50 // '2'
+pub const MINOR_VERSION = 97 // 'a'
+pub const MAX_SALT_SIZE = 16
+pub const MAX_CRYPTED_HASH_SIZE = 23
+pub const ENCODED_SALT_SIZE = 22
+pub const ENCODED_HASH_SIZE = 31
+pub const MIN_HASH_SIZE = 59
 
-const DOLLAR_CHAR = 36 // $
-const ZERO_CHAR = 48 // '0'
-const NINE_CHAR = 57 // '9'
+pub const DOLLAR_CHAR = 36 // $
+pub const ZERO_CHAR = 48 // '0'
+pub const NINE_CHAR = 57 // '9'
 
 // bcrypt-specific base64 alphabet
-const ALPHABET = "./ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+pub const ALPHABET = "./ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
 
 // Magic cipher data - big-endian bytes of "OrpheanBeholderScryDoubt"
-const MAGIC_CIPHER_COUNT = 24
+pub const MAGIC_CIPHER_COUNT = 24
 [u8;MAGIC_CIPHER_COUNT] MAGIC_CIPHER_DATA = [
     0x4f, 0x72, 0x70, 0x68,
     0x65, 0x61, 0x6e, 0x42,
@@ -35,15 +35,15 @@ const MAGIC_CIPHER_COUNT = 24
 ]
 
 // Error definitions for throw
-const ERROR_PASSWORD_TOO_LONG = "password too long"
-const ERROR_INVALID_COST = "invalid cost parameter"
-const ERROR_HASH_TOO_SHORT = "hash too short"
-const ERROR_INVALID_HASH_PREFIX = "invalid hash prefix"
-const ERROR_HASH_VERSION_TOO_NEW = "hash version too new"
-const ERROR_NOT_VERIFY = "verify failed"
+pub const ERROR_PASSWORD_TOO_LONG = "password too long"
+pub const ERROR_INVALID_COST = "invalid cost parameter"
+pub const ERROR_HASH_TOO_SHORT = "hash too short"
+pub const ERROR_INVALID_HASH_PREFIX = "invalid hash prefix"
+pub const ERROR_HASH_VERSION_TOO_NEW = "hash version too new"
+pub const ERROR_NOT_VERIFY = "verify failed"
 
 // bcrypt hash structure
-type bcrypt_hash_t = struct {
+pub type bcrypt_hash_t = struct {
     [u8] hash
     [u8] salt
     int cost
@@ -52,7 +52,7 @@ type bcrypt_hash_t = struct {
 }
 
 // bcrypt-specific base64 encoding (based on C implementation)
-fn base64_encode([u8] src):[u8] {
+pub fn base64_encode([u8] src):[u8] {
     [u8] result = []
     int src_len = src.len()
 
@@ -88,7 +88,7 @@ fn base64_encode([u8] src):[u8] {
 }
 
 // bcrypt-specific base64 decoding (based on C implementation)
-fn base64_decode([u8] src):[u8]! {
+pub fn base64_decode([u8] src):[u8]! {
     // Character to value lookup function
     var char_to_value = fn(u8 c):int {
         for int i = 0; i < ALPHABET.len(); i += 1 {
@@ -145,14 +145,14 @@ fn base64_decode([u8] src):[u8]! {
 }
 
 // Check if cost parameter is valid
-fn check_cost(int cost):void! {
+pub fn check_cost(int cost):void! {
     if cost < MIN_COST || cost > MAX_COST {
         throw errorf(ERROR_INVALID_COST)
     }
 }
 
 // Generate random salt
-fn generate_salt():[u8] {
+pub fn generate_salt():[u8] {
     [u8] salt = []
 
     // Use libc random functions for better randomness
@@ -166,7 +166,7 @@ fn generate_salt():[u8] {
     return salt
 }
 
-fn expensive_blowfish_setup([u8] key, u32 cost, [u8] salt):blowfish.cipher_t! {
+pub fn expensive_blowfish_setup([u8] key, u32 cost, [u8] salt):blowfish.cipher_t! {
     var cipher = blowfish.cipher_t{
         p: vec<u32>.new(0, 18),
         s0: vec<u32>.new(0, 256),
@@ -202,7 +202,7 @@ fn expensive_blowfish_setup([u8] key, u32 cost, [u8] salt):blowfish.cipher_t! {
 }
 
 // bcrypt core function
-fn bcrypt([u8] password, int cost, [u8] salt):[u8]! {
+pub fn bcrypt([u8] password, int cost, [u8] salt):[u8]! {
     [u8] cipher_data = []
     for int i = 0; i < MAGIC_CIPHER_COUNT; i+= 1 {
         cipher_data.push(MAGIC_CIPHER_DATA[i])
@@ -238,7 +238,7 @@ fn bcrypt([u8] password, int cost, [u8] salt):[u8]! {
 }
 
 // Generate new hash from password
-fn new_from_password([u8] password, int cost):bcrypt_hash_t! {
+pub fn new_from_password([u8] password, int cost):bcrypt_hash_t! {
     if password.len() > 72 {
         throw errorf(ERROR_PASSWORD_TOO_LONG)
     }
@@ -267,7 +267,7 @@ fn new_from_password([u8] password, int cost):bcrypt_hash_t! {
 }
 
 // Parse from hash string
-fn new_from_hash([u8] hashed_secret):bcrypt_hash_t! {
+pub fn new_from_hash([u8] hashed_secret):bcrypt_hash_t! {
     if hashed_secret.len() < MIN_HASH_SIZE {
         throw errorf(ERROR_HASH_TOO_SHORT)
     }
@@ -348,7 +348,7 @@ fn new_from_hash([u8] hashed_secret):bcrypt_hash_t! {
 }
 
 // Generate complete hash string
-fn hash_to_string(bcrypt_hash_t hash_info):[u8] {
+pub fn hash_to_string(bcrypt_hash_t hash_info):[u8] {
     [u8] result = []
     
     result.push(DOLLAR_CHAR)
@@ -378,7 +378,7 @@ fn hash_to_string(bcrypt_hash_t hash_info):[u8] {
 }
 
 // Compare two byte arrays for equality (constant time)
-fn constant_time_compare([u8] a, [u8] b):bool {
+pub fn constant_time_compare([u8] a, [u8] b):bool {
     if a.len() != b.len() {
         return false
     }
@@ -394,13 +394,13 @@ fn constant_time_compare([u8] a, [u8] b):bool {
 // Public API functions
 
 // Generate bcrypt hash from password
-fn hash([u8] password, int cost):[u8]! {
+pub fn hash([u8] password, int cost):[u8]! {
     bcrypt_hash_t hash_info = new_from_password(password, cost)
     return hash_to_string(hash_info)
 }
 
 // Compare hash and password
-fn verify([u8] hashed_password, [u8] password):void! {
+pub fn verify([u8] hashed_password, [u8] password):void! {
     bcrypt_hash_t hash_info = new_from_hash(hashed_password)
     
     [u8] other_hash = bcrypt(password, hash_info.cost, hash_info.salt)
@@ -422,12 +422,12 @@ fn verify([u8] hashed_password, [u8] password):void! {
 }
 
 // Get cost of hash
-fn cost([u8] hashed_password):int! {
+pub fn cost([u8] hashed_password):int! {
     bcrypt_hash_t hash_info = new_from_hash(hashed_password)
     return hash_info.cost
 }
 
-fn main():void! {
+pub fn main():void! {
     println("bcrypt test started...")
     
     string password = "mypassword"

--- a/std/crypto/blowfish.n
+++ b/std/crypto/blowfish.n
@@ -2,15 +2,15 @@ import fmt
 import crypto.utils
 
 // Constant definitions
-const BLOCK_SIZE = 8
-const MAX_KEY_SIZE = 56
-const MIN_KEY_SIZE = 1
+pub const BLOCK_SIZE = 8
+pub const MAX_KEY_SIZE = 56
+pub const MIN_KEY_SIZE = 1
 
-const SUCCESS = 0 
-const ERROR_INVALID_KEY_SIZE = -1
+pub const SUCCESS = 0
+pub const ERROR_INVALID_KEY_SIZE = -1
 
 // Blowfish cipher structure
-type cipher_t = struct {
+pub type cipher_t = struct {
     [u32] p      // P array, 18 elements
     [u32] s0     // S-box 0, 256 elements
     [u32] s1     // S-box 1, 256 elements
@@ -213,7 +213,7 @@ type cipher_t = struct {
     0xb74e6132, 0xce77e25b, 0x578fdfe3, 0x3ac372e6,
 ]
 
-fn init_cipher(ptr<cipher_t> cipher) {
+pub fn init_cipher(ptr<cipher_t> cipher) {
     for int i = 0; i < 18; i += 1 {
         cipher.p[i] = initial_p[i]
     }
@@ -227,7 +227,7 @@ fn init_cipher(ptr<cipher_t> cipher) {
 }
 
 // Get next big-endian 32-bit word
-fn get_next_word([u8] b, int len, ptr<int> pos):u32 {
+pub fn get_next_word([u8] b, int len, ptr<int> pos):u32 {
     u32 w = 0
     int j = *pos
     
@@ -244,7 +244,7 @@ fn get_next_word([u8] b, int len, ptr<int> pos):u32 {
 }
 
 // Block encryption function
-fn encrypt_block(ptr<u32> l, ptr<u32> r, cipher_t cipher) {
+pub fn encrypt_block(ptr<u32> l, ptr<u32> r, cipher_t cipher) {
     u32 xl = *l
     u32 xr = *r
     
@@ -288,7 +288,7 @@ fn encrypt_block(ptr<u32> l, ptr<u32> r, cipher_t cipher) {
 }
 
 // Block decryption function
-fn decrypt_block(ptr<u32> l, ptr<u32> r, cipher_t cipher) {
+pub fn decrypt_block(ptr<u32> l, ptr<u32> r, cipher_t cipher) {
     u32 xl = *l
     u32 xr = *r
     
@@ -332,7 +332,7 @@ fn decrypt_block(ptr<u32> l, ptr<u32> r, cipher_t cipher) {
 }
 
 // Create new Blowfish cipher instance
-fn new_cipher([u8] key, ptr<cipher_t> cipher):int {
+pub fn new_cipher([u8] key, ptr<cipher_t> cipher):int {
     if key.len() < MIN_KEY_SIZE || key.len() > MAX_KEY_SIZE {
         return ERROR_INVALID_KEY_SIZE
     }
@@ -343,7 +343,7 @@ fn new_cipher([u8] key, ptr<cipher_t> cipher):int {
 }
 
 // Create salted Blowfish cipher instance
-fn new_salted_cipher([u8] key, [u8] salt, ptr<cipher_t> cipher):int {
+pub fn new_salted_cipher([u8] key, [u8] salt, ptr<cipher_t> cipher):int {
     if salt.len() == 0 {
         return new_cipher(key, cipher)
     }
@@ -358,7 +358,7 @@ fn new_salted_cipher([u8] key, [u8] salt, ptr<cipher_t> cipher):int {
 }
 
 // Encrypt 8-byte data block
-fn encrypt(cipher_t cipher, [u8] dst, [u8] src) {
+pub fn encrypt(cipher_t cipher, [u8] dst, [u8] src) {
     u32 l = ((src[0] as u32) << 24) | ((src[1] as u32) << 16) | 
             ((src[2] as u32) << 8) | (src[3] as u32)
     u32 r = ((src[4] as u32) << 24) | ((src[5] as u32) << 16) | 
@@ -377,7 +377,7 @@ fn encrypt(cipher_t cipher, [u8] dst, [u8] src) {
 }
 
 // Decrypt 8-byte data block
-fn decrypt(cipher_t cipher, [u8] dst, [u8] src) {
+pub fn decrypt(cipher_t cipher, [u8] dst, [u8] src) {
     u32 l = ((src[0] as u32) << 24) | ((src[1] as u32) << 16) | 
             ((src[2] as u32) << 8) | (src[3] as u32)
     u32 r = ((src[4] as u32) << 24) | ((src[5] as u32) << 16) | 
@@ -396,7 +396,7 @@ fn decrypt(cipher_t cipher, [u8] dst, [u8] src) {
 }
 
 // Key expansion function
-fn expand_key([u8] key, ptr<cipher_t> cipher) {
+pub fn expand_key([u8] key, ptr<cipher_t> cipher) {
     int j = 0
     
     // XOR key with P array
@@ -468,7 +468,7 @@ fn expand_key([u8] key, ptr<cipher_t> cipher) {
 }
 
 // Salted key expansion function
-fn expand_key_with_salt([u8] key, [u8] salt, ptr<cipher_t> cipher) {
+pub fn expand_key_with_salt([u8] key, [u8] salt, ptr<cipher_t> cipher) {
     int key_len = key.len()
     int salt_len = salt.len()
     int j = 0
@@ -545,14 +545,14 @@ fn expand_key_with_salt([u8] key, [u8] salt, ptr<cipher_t> cipher) {
 }
 
 // Helper function to print hexadecimal data
-fn print_hex([u8] output) {
+pub fn print_hex([u8] output) {
     var result = utils.to_hex(output)
 
     println(result)
 }
 
 
-fn main():void! {
+pub fn main():void! {
     // Test Blowfish implementation
     string test_key = "TESTKEY"
     [u8] plaintext = [0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF]

--- a/std/crypto/hmac.n
+++ b/std/crypto/hmac.n
@@ -1,27 +1,27 @@
 import libc
 import crypto.utils
 
-const MD5 = 0x03
-const RIPEMD160 = 0x04
-const SHA1 = 0x05
-const SHA224= 0x08
-const SHA256 = 0x09
+pub const MD5 = 0x03
+pub const RIPEMD160 = 0x04
+pub const SHA1 = 0x05
+pub const SHA224= 0x08
+pub const SHA256 = 0x09
 const SHA384 = 0x0a
-const SHA512 = 0x0b
-const SHA3_224 = 0x10
-const SHA3_256 = 0x11
-const SHA3_384 = 0x12
-const SHA3_512 = 0x13
+pub const SHA512 = 0x0b
+pub const SHA3_224 = 0x10
+pub const SHA3_256 = 0x11
+pub const SHA3_384 = 0x12
+pub const SHA3_512 = 0x13
 
 
-type hmac_t = struct{
+pub type hmac_t = struct{
     anyptr md_info
     int hasher_type
     int output_size
     utils.mbedtls_md_context_t mbed_ctx
 }
 
-fn new(int hasher_type, [u8] secret):ref<hmac_t> {
+pub fn new(int hasher_type, [u8] secret):ref<hmac_t> {
     var h = new hmac_t()
     h.hasher_type = hasher_type
     
@@ -62,12 +62,12 @@ fn new(int hasher_type, [u8] secret):ref<hmac_t> {
     return h
 }
 
-fn hmac_t.update(&self, [u8] message):ref<hmac_t> {
+pub fn hmac_t.update(&self, [u8] message):ref<hmac_t> {
     utils.mbedtls_md_hmac_update(&self.mbed_ctx, (message as string).to_cstr(), message.len())
     return self
 }
 
-fn hmac_t.finish(&self):[u8] {
+pub fn hmac_t.finish(&self):[u8] {
     var output = vec<u8>.new(0, self.output_size)
     utils.mbedtls_md_hmac_finish(&self.mbed_ctx, output.ref())
     
@@ -76,7 +76,7 @@ fn hmac_t.finish(&self):[u8] {
     return output
 }
 
-fn hmac_t.hex(&self):string {
+pub fn hmac_t.hex(&self):string {
     var output = vec<u8>.new(0, self.output_size)
     utils.mbedtls_md_hmac_finish(&self.mbed_ctx, output.ref())
     
@@ -86,6 +86,6 @@ fn hmac_t.hex(&self):string {
     return result
 }
 
-fn hex(int hasher_type, [u8] secret, [u8] message):string {
+pub fn hex(int hasher_type, [u8] secret, [u8] message):string {
     return new(hasher_type, secret).update(message).hex()
 }

--- a/std/crypto/md5.n
+++ b/std/crypto/md5.n
@@ -2,11 +2,11 @@ import libc
 import crypto.utils
 
 
-type md5_t = struct{
+pub type md5_t = struct{
     utils.mbedtls_md_context_t mbed_ctx
 }
 
-fn new():ref<md5_t> {
+pub fn new():ref<md5_t> {
     var m =  new md5_t()
     utils.mbedtls_md5_init(&m.mbed_ctx)
     //     MBEDTLS_MD_MD5=0x03,       /**< The MD5 message digest. */
@@ -20,13 +20,13 @@ fn new():ref<md5_t> {
     return m
 }
 
-fn md5_t.update(&self, [u8] input):ref<md5_t> {
+pub fn md5_t.update(&self, [u8] input):ref<md5_t> {
     utils.mbedtls_md_update(&self.mbed_ctx, (input as string).to_cstr(), input.len());
 
     return self
 }
 
-fn md5_t.finish(&self):[u8] {
+pub fn md5_t.finish(&self):[u8] {
     var output = vec<u8>.new(0, 16) 
     utils.mbedtls_md_finish(&self.mbed_ctx, output.ref())
 
@@ -35,7 +35,7 @@ fn md5_t.finish(&self):[u8] {
     return output
 }
 
-fn md5_t.hex(&self):string {
+pub fn md5_t.hex(&self):string {
     var output = vec<u8>.new(0, 16) 
     utils.mbedtls_md_finish(&self.mbed_ctx, output.ref())
     utils.mbedtls_md_free(&self.mbed_ctx);
@@ -44,6 +44,6 @@ fn md5_t.hex(&self):string {
     return result
 }
 
-fn hex(string input):string {
+pub fn hex(string input):string {
     return new().update(input as [u8]).hex()
 }

--- a/std/crypto/rsa.n
+++ b/std/crypto/rsa.n
@@ -3,35 +3,35 @@ import crypto.utils
 import time
 import fmt
 
-const SHA1 = 0x05
-const SHA224= 0x08
-const SHA256 = 0x09
+pub const SHA1 = 0x05
+pub const SHA224= 0x08
+pub const SHA256 = 0x09
 const SHA384 = 0x0a
-const SHA512 = 0x0b
-const SHA3_224 = 0x10
-const SHA3_256 = 0x11
-const SHA3_384 = 0x12
-const SHA3_512 = 0x13
+pub const SHA512 = 0x0b
+pub const SHA3_224 = 0x10
+pub const SHA3_256 = 0x11
+pub const SHA3_384 = 0x12
+pub const SHA3_512 = 0x13
 
 // RSA key pair generator context
-type rsa_key_generator_t = struct{
+pub type rsa_key_generator_t = struct{
     utils.mbedtls_rsa_context rsa_ctx
     utils.mbedtls_entropy_context entropy
     utils.mbedtls_ctr_drbg_context ctr_drbg
 }
 
 // RSA public key - only for encryption
-type rsa_public_key_t = struct{
+pub type rsa_public_key_t = struct{
     utils.mbedtls_rsa_context rsa_ctx
 }
 
 // RSA private key - only for decryption
-type rsa_private_key_t = struct{
+pub type rsa_private_key_t = struct{
     utils.mbedtls_rsa_context rsa_ctx
 }
 
 // Generate RSA key pair with specified key size in bits
-fn generate_key(u32 key_bits):(ref<rsa_public_key_t>, ref<rsa_private_key_t>)! {
+pub fn generate_key(u32 key_bits):(ref<rsa_public_key_t>, ref<rsa_private_key_t>)! {
     var generator = new rsa_key_generator_t()
     
     // Initialize entropy and random number generator
@@ -78,7 +78,7 @@ fn generate_key(u32 key_bits):(ref<rsa_public_key_t>, ref<rsa_private_key_t>)! {
 }
 
 // Create RSA public key from PEM format string
-fn public_key_from_pem([u8] pem_data):ref<rsa_public_key_t>! {
+pub fn public_key_from_pem([u8] pem_data):ref<rsa_public_key_t>! {
     var public_key = new rsa_public_key_t()
     var pk = utils.mbedtls_pk_context{}
     
@@ -107,7 +107,7 @@ fn public_key_from_pem([u8] pem_data):ref<rsa_public_key_t>! {
 }
 
 // Create RSA private key from PEM format string
-fn private_key_from_pem([u8] pem_data, [u8] password):ref<rsa_private_key_t>! {
+pub fn private_key_from_pem([u8] pem_data, [u8] password):ref<rsa_private_key_t>! {
     var private_key = new rsa_private_key_t()
     var pk = utils.mbedtls_pk_context{}
     
@@ -164,7 +164,7 @@ fn private_key_from_pem([u8] pem_data, [u8] password):ref<rsa_private_key_t>! {
 }
 
 // Encrypt data using RSA public key with OAEP padding
-fn rsa_public_key_t.encrypt_oaep(&self, i32 hash_algo, [u8] plaintext, [u8]? label):[u8]! {
+pub fn rsa_public_key_t.encrypt_oaep(&self, i32 hash_algo, [u8] plaintext, [u8]? label):[u8]! {
     // Initialize entropy and random number generator for encryption
     var entropy = utils.mbedtls_entropy_context{}
     var ctr_drbg = utils.mbedtls_ctr_drbg_context{}
@@ -210,7 +210,7 @@ fn rsa_public_key_t.encrypt_oaep(&self, i32 hash_algo, [u8] plaintext, [u8]? lab
 }
 
 // Decrypt data using RSA private key with OAEP padding
-fn rsa_private_key_t.decrypt_oaep(&self, i32 hash_algo, [u8] ciphertext, [u8]? label):[u8]! {
+pub fn rsa_private_key_t.decrypt_oaep(&self, i32 hash_algo, [u8] ciphertext, [u8]? label):[u8]! {
     // Initialize entropy and random number generator for decryption
     var entropy = utils.mbedtls_entropy_context{}
     var ctr_drbg = utils.mbedtls_ctr_drbg_context{}
@@ -257,7 +257,7 @@ fn rsa_private_key_t.decrypt_oaep(&self, i32 hash_algo, [u8] ciphertext, [u8]? l
 
 
 // Encrypt data using RSA public key with PKCS#1 v1.5 padding
-fn rsa_public_key_t.encrypt_pkcs_v15(&self, [u8] plaintext):[u8]! {
+pub fn rsa_public_key_t.encrypt_pkcs_v15(&self, [u8] plaintext):[u8]! {
     // Initialize entropy and random number generator for encryption
     var entropy = utils.mbedtls_entropy_context{}
     var ctr_drbg = utils.mbedtls_ctr_drbg_context{}
@@ -295,7 +295,7 @@ fn rsa_public_key_t.encrypt_pkcs_v15(&self, [u8] plaintext):[u8]! {
 }
 
 // Decrypt data using RSA private key with PKCS#1 v1.5 padding
-fn rsa_private_key_t.decrypt_pkcs_v15(&self, [u8] ciphertext):[u8]! {
+pub fn rsa_private_key_t.decrypt_pkcs_v15(&self, [u8] ciphertext):[u8]! {
     // Initialize entropy and random number generator for decryption
     var entropy = utils.mbedtls_entropy_context{}
     var ctr_drbg = utils.mbedtls_ctr_drbg_context{}
@@ -334,7 +334,7 @@ fn rsa_private_key_t.decrypt_pkcs_v15(&self, [u8] ciphertext):[u8]! {
 }
 
 // Export RSA public key as PEM format
-fn rsa_public_key_t.to_pem(&self):[u8]! {
+pub fn rsa_public_key_t.to_pem(&self):[u8]! {
     var pem_buff = vec<u8>.new(0, 4096)
     var pk = utils.mbedtls_pk_context{}
 
@@ -366,7 +366,7 @@ fn rsa_public_key_t.to_pem(&self):[u8]! {
 }
 
 // Export RSA private key as PEM format
-fn rsa_private_key_t.to_pem(&self):[u8]! {
+pub fn rsa_private_key_t.to_pem(&self):[u8]! {
     var pem_buff = vec<u8>.new(0, 4096)
     var pk = utils.mbedtls_pk_context{}
 
@@ -398,11 +398,11 @@ fn rsa_private_key_t.to_pem(&self):[u8]! {
 }
 
 // Clean up RSA public key resources
-fn rsa_public_key_t.free(&self):void {
+pub fn rsa_public_key_t.free(&self):void {
     utils.mbedtls_rsa_free(&self.rsa_ctx)
 }
 
 // Clean up RSA private key resources
-fn rsa_private_key_t.free(&self):void {
+pub fn rsa_private_key_t.free(&self):void {
     utils.mbedtls_rsa_free(&self.rsa_ctx)
 }

--- a/std/crypto/sha256.n
+++ b/std/crypto/sha256.n
@@ -1,11 +1,11 @@
 import libc
 import crypto.utils
 
-type sha256_t = struct{
+pub type sha256_t = struct{
     utils.mbedtls_sha256_context mbed_ctx
 }
 
-fn new():ref<sha256_t> {
+pub fn new():ref<sha256_t> {
     var s = new sha256_t()
     
     utils.mbedtls_sha256_init(&s.mbed_ctx)
@@ -15,12 +15,12 @@ fn new():ref<sha256_t> {
     return s
 }
 
-fn sha256_t.update(&self, [u8] input):ref<sha256_t> {
+pub fn sha256_t.update(&self, [u8] input):ref<sha256_t> {
     utils.mbedtls_sha256_update(&self.mbed_ctx, (input as string).to_cstr(), input.len())
     return self
 }
 
-fn sha256_t.finish(&self):[u8] {
+pub fn sha256_t.finish(&self):[u8] {
     var output = vec<u8>.new(0, 32)  // SHA256 输出 32 字节
     utils.mbedtls_sha256_finish(&self.mbed_ctx, output.ref())
     
@@ -30,7 +30,7 @@ fn sha256_t.finish(&self):[u8] {
     return output
 }
 
-fn sha256_t.hex(&self):string {
+pub fn sha256_t.hex(&self):string {
     var output = vec<u8>.new(0, 32)  // SHA256 输出 32 字节
     utils.mbedtls_sha256_finish(&self.mbed_ctx, output.ref())
     
@@ -41,6 +41,6 @@ fn sha256_t.hex(&self):string {
     return result
 }
 
-fn hex(string input):string {
+pub fn hex(string input):string {
     return new().update(input as [u8]).hex()
 }

--- a/std/crypto/utils.n
+++ b/std/crypto/utils.n
@@ -39,26 +39,26 @@ pub type mbedtls_md_context_t = struct{
     anyptr hmac_ctx
 }
 
-pub #linkid mbedtls_md5_init
-fn mbedtls_md5_init(ptr<mbedtls_md_context_t> ctx):void
+#linkid mbedtls_md5_init
+pub fn mbedtls_md5_init(ptr<mbedtls_md_context_t> ctx):void
 
-pub #linkid mbedtls_md_info_from_type
-fn mbedtls_md_info_from_type(i32 md_type):anyptr
+#linkid mbedtls_md_info_from_type
+pub fn mbedtls_md_info_from_type(i32 md_type):anyptr
 
-pub #linkid mbedtls_md_setup
-fn mbedtls_md_setup(ptr<mbedtls_md_context_t> ctx, anyptr md_info, i32 is_hmac):i32
+#linkid mbedtls_md_setup
+pub fn mbedtls_md_setup(ptr<mbedtls_md_context_t> ctx, anyptr md_info, i32 is_hmac):i32
 
-pub #linkid mbedtls_md_starts
-fn mbedtls_md_starts(ptr<mbedtls_md_context_t> ctx):i32
+#linkid mbedtls_md_starts
+pub fn mbedtls_md_starts(ptr<mbedtls_md_context_t> ctx):i32
 
-pub #linkid mbedtls_md_update
-fn mbedtls_md_update(ptr<mbedtls_md_context_t> ctx, libc.cstr input, int ilen):i32
+#linkid mbedtls_md_update
+pub fn mbedtls_md_update(ptr<mbedtls_md_context_t> ctx, libc.cstr input, int ilen):i32
 
-pub #linkid mbedtls_md_finish
-fn mbedtls_md_finish(ptr<mbedtls_md_context_t> ctx, anyptr output):i32
+#linkid mbedtls_md_finish
+pub fn mbedtls_md_finish(ptr<mbedtls_md_context_t> ctx, anyptr output):i32
 
-pub #linkid mbedtls_md_free
-fn mbedtls_md_free(ptr<mbedtls_md_context_t> ctx):void
+#linkid mbedtls_md_free
+pub fn mbedtls_md_free(ptr<mbedtls_md_context_t> ctx):void
 
 
 
@@ -69,32 +69,32 @@ pub type mbedtls_sha256_context = struct{
     i32 is224            // 0: 使用 SHA-256, 1: 使用 SHA-224
 }
 
-pub #linkid mbedtls_sha256_init
-fn mbedtls_sha256_init(ptr<mbedtls_sha256_context> ctx):void
+#linkid mbedtls_sha256_init
+pub fn mbedtls_sha256_init(ptr<mbedtls_sha256_context> ctx):void
 
-pub #linkid mbedtls_sha256_starts
-fn mbedtls_sha256_starts(ptr<mbedtls_sha256_context> ctx, i32 is224):i32
+#linkid mbedtls_sha256_starts
+pub fn mbedtls_sha256_starts(ptr<mbedtls_sha256_context> ctx, i32 is224):i32
 
-pub #linkid mbedtls_sha256_update
-fn mbedtls_sha256_update(ptr<mbedtls_sha256_context> ctx, libc.cstr input, int ilen):i32
+#linkid mbedtls_sha256_update
+pub fn mbedtls_sha256_update(ptr<mbedtls_sha256_context> ctx, libc.cstr input, int ilen):i32
 
-pub #linkid mbedtls_sha256_finish
-fn mbedtls_sha256_finish(ptr<mbedtls_sha256_context> ctx, anyptr output):i32
+#linkid mbedtls_sha256_finish
+pub fn mbedtls_sha256_finish(ptr<mbedtls_sha256_context> ctx, anyptr output):i32
 
-pub #linkid mbedtls_sha256_free
-fn mbedtls_sha256_free(ptr<mbedtls_sha256_context> ctx):void
+#linkid mbedtls_sha256_free
+pub fn mbedtls_sha256_free(ptr<mbedtls_sha256_context> ctx):void
 
-pub #linkid mbedtls_md_init
-fn mbedtls_md_init(ptr<mbedtls_md_context_t> ctx):void
+#linkid mbedtls_md_init
+pub fn mbedtls_md_init(ptr<mbedtls_md_context_t> ctx):void
 
-pub #linkid mbedtls_md_hmac_starts
-fn mbedtls_md_hmac_starts(ptr<mbedtls_md_context_t> ctx, libc.cstr key, int keylen):i32
+#linkid mbedtls_md_hmac_starts
+pub fn mbedtls_md_hmac_starts(ptr<mbedtls_md_context_t> ctx, libc.cstr key, int keylen):i32
 
-pub #linkid mbedtls_md_hmac_update
-fn mbedtls_md_hmac_update(ptr<mbedtls_md_context_t> ctx, libc.cstr input, int ilen):i32
+#linkid mbedtls_md_hmac_update
+pub fn mbedtls_md_hmac_update(ptr<mbedtls_md_context_t> ctx, libc.cstr input, int ilen):i32
 
-pub #linkid mbedtls_md_hmac_finish
-fn mbedtls_md_hmac_finish(ptr<mbedtls_md_context_t> ctx, anyptr output):i32
+#linkid mbedtls_md_hmac_finish
+pub fn mbedtls_md_hmac_finish(ptr<mbedtls_md_context_t> ctx, anyptr output):i32
 
 // RSA types and core API
 pub type mbedtls_rsa_context = struct{
@@ -126,91 +126,91 @@ pub const MBEDTLS_PK_RSA_ALT = 5
 pub const MBEDTLS_PK_RSASSA_PSS = 6
 pub const MBEDTLS_PK_OPAQUE = 7
 
-pub #linkid mbedtls_entropy_func
-fn mbedtls_entropy_func(anyptr data, anyptr output, int len):i32
+#linkid mbedtls_entropy_func
+pub fn mbedtls_entropy_func(anyptr data, anyptr output, int len):i32
 
-pub #linkid mbedtls_ctr_drbg_random
-fn mbedtls_ctr_drbg_random(anyptr p_rng, anyptr output, int output_len):i32
+#linkid mbedtls_ctr_drbg_random
+pub fn mbedtls_ctr_drbg_random(anyptr p_rng, anyptr output, int output_len):i32
 
-pub #linkid mbedtls_entropy_init
-fn mbedtls_entropy_init(ptr<mbedtls_entropy_context> ctx):void
+#linkid mbedtls_entropy_init
+pub fn mbedtls_entropy_init(ptr<mbedtls_entropy_context> ctx):void
 
-pub #linkid mbedtls_ctr_drbg_init
-fn mbedtls_ctr_drbg_init(ptr<mbedtls_ctr_drbg_context> ctx):void
+#linkid mbedtls_ctr_drbg_init
+pub fn mbedtls_ctr_drbg_init(ptr<mbedtls_ctr_drbg_context> ctx):void
 
-pub #linkid mbedtls_ctr_drbg_seed
-fn mbedtls_ctr_drbg_seed(ptr<mbedtls_ctr_drbg_context> ctx, anyptr f_entropy, anyptr p_entropy, libc.cstr custom, u64 len):i32
+#linkid mbedtls_ctr_drbg_seed
+pub fn mbedtls_ctr_drbg_seed(ptr<mbedtls_ctr_drbg_context> ctx, anyptr f_entropy, anyptr p_entropy, libc.cstr custom, u64 len):i32
 
 // Core RSA functions
-pub #linkid mbedtls_rsa_init
-fn mbedtls_rsa_init(ptr<mbedtls_rsa_context> ctx):void
+#linkid mbedtls_rsa_init
+pub fn mbedtls_rsa_init(ptr<mbedtls_rsa_context> ctx):void
 
-pub #linkid mbedtls_rsa_set_padding
-fn mbedtls_rsa_set_padding(ptr<mbedtls_rsa_context> ctx, i32 padding, i32 hash_id):i32
+#linkid mbedtls_rsa_set_padding
+pub fn mbedtls_rsa_set_padding(ptr<mbedtls_rsa_context> ctx, i32 padding, i32 hash_id):i32
 
-pub #linkid mbedtls_rsa_gen_key
-fn mbedtls_rsa_gen_key(ptr<mbedtls_rsa_context> ctx, anyptr f_rng, anyptr p_rng, u32 nbits, i32 exponent):i32
+#linkid mbedtls_rsa_gen_key
+pub fn mbedtls_rsa_gen_key(ptr<mbedtls_rsa_context> ctx, anyptr f_rng, anyptr p_rng, u32 nbits, i32 exponent):i32
 
-pub #linkid mbedtls_rsa_pkcs1_encrypt
-fn mbedtls_rsa_pkcs1_encrypt(ptr<mbedtls_rsa_context> ctx, anyptr f_rng, anyptr p_rng, int ilen, libc.cstr input, anyptr output):i32
+#linkid mbedtls_rsa_pkcs1_encrypt
+pub fn mbedtls_rsa_pkcs1_encrypt(ptr<mbedtls_rsa_context> ctx, anyptr f_rng, anyptr p_rng, int ilen, libc.cstr input, anyptr output):i32
 
-pub #linkid mbedtls_rsa_rsaes_oaep_encrypt
-fn mbedtls_rsa_rsaes_oaep_encrypt(ptr<mbedtls_rsa_context> ctx, anyptr f_rng, anyptr p_rng, libc.cstr label, int label_len, int ilen, libc.cstr input, anyptr output):i32
+#linkid mbedtls_rsa_rsaes_oaep_encrypt
+pub fn mbedtls_rsa_rsaes_oaep_encrypt(ptr<mbedtls_rsa_context> ctx, anyptr f_rng, anyptr p_rng, libc.cstr label, int label_len, int ilen, libc.cstr input, anyptr output):i32
 
-pub #linkid mbedtls_rsa_pkcs1_decrypt
-fn mbedtls_rsa_pkcs1_decrypt(ptr<mbedtls_rsa_context> ctx, anyptr f_rng, anyptr p_rng, ptr<int> olen, libc.cstr input, anyptr output, int output_max_len):i32
+#linkid mbedtls_rsa_pkcs1_decrypt
+pub fn mbedtls_rsa_pkcs1_decrypt(ptr<mbedtls_rsa_context> ctx, anyptr f_rng, anyptr p_rng, ptr<int> olen, libc.cstr input, anyptr output, int output_max_len):i32
 
-pub #linkid mbedtls_rsa_rsaes_oaep_decrypt
-fn mbedtls_rsa_rsaes_oaep_decrypt(ptr<mbedtls_rsa_context> ctx, anyptr f_rng, anyptr p_rng, libc.cstr label, int label_len, ptr<int> olen, libc.cstr input, anyptr output, int output_max_len):i32
+#linkid mbedtls_rsa_rsaes_oaep_decrypt
+pub fn mbedtls_rsa_rsaes_oaep_decrypt(ptr<mbedtls_rsa_context> ctx, anyptr f_rng, anyptr p_rng, libc.cstr label, int label_len, ptr<int> olen, libc.cstr input, anyptr output, int output_max_len):i32
 
-pub #linkid mbedtls_rsa_pkcs1_sign
-fn mbedtls_rsa_pkcs1_sign(ptr<mbedtls_rsa_context> ctx, anyptr f_rng, anyptr p_rng, i32 md_alg, u32 hashlen, libc.cstr hash, libc.cstr sig):i32
+#linkid mbedtls_rsa_pkcs1_sign
+pub fn mbedtls_rsa_pkcs1_sign(ptr<mbedtls_rsa_context> ctx, anyptr f_rng, anyptr p_rng, i32 md_alg, u32 hashlen, libc.cstr hash, libc.cstr sig):i32
 
-pub #linkid mbedtls_rsa_pkcs1_verify
-fn mbedtls_rsa_pkcs1_verify(ptr<mbedtls_rsa_context> ctx, i32 md_alg, u32 hashlen, libc.cstr hash, libc.cstr sig):i32
+#linkid mbedtls_rsa_pkcs1_verify
+pub fn mbedtls_rsa_pkcs1_verify(ptr<mbedtls_rsa_context> ctx, i32 md_alg, u32 hashlen, libc.cstr hash, libc.cstr sig):i32
 
-pub #linkid mbedtls_rsa_get_len
-fn mbedtls_rsa_get_len(ptr<mbedtls_rsa_context> ctx):int
+#linkid mbedtls_rsa_get_len
+pub fn mbedtls_rsa_get_len(ptr<mbedtls_rsa_context> ctx):int
 
-pub #linkid mbedtls_rsa_free
-fn mbedtls_rsa_free(ptr<mbedtls_rsa_context> ctx):void
+#linkid mbedtls_rsa_free
+pub fn mbedtls_rsa_free(ptr<mbedtls_rsa_context> ctx):void
 
 
-pub #linkid mbedtls_ctr_drbg_free
-fn mbedtls_ctr_drbg_free(ptr<mbedtls_ctr_drbg_context> ctx):void
+#linkid mbedtls_ctr_drbg_free
+pub fn mbedtls_ctr_drbg_free(ptr<mbedtls_ctr_drbg_context> ctx):void
 
-pub #linkid mbedtls_entropy_free
-fn mbedtls_entropy_free(ptr<mbedtls_entropy_context> ctx):void
+#linkid mbedtls_entropy_free
+pub fn mbedtls_entropy_free(ptr<mbedtls_entropy_context> ctx):void
 
-pub #linkid mbedtls_pk_init
-fn mbedtls_pk_init(ptr<mbedtls_pk_context> ctx):void
+#linkid mbedtls_pk_init
+pub fn mbedtls_pk_init(ptr<mbedtls_pk_context> ctx):void
 
-pub #linkid mbedtls_pk_info_from_type
-fn mbedtls_pk_info_from_type(i32 pk_type):anyptr
+#linkid mbedtls_pk_info_from_type
+pub fn mbedtls_pk_info_from_type(i32 pk_type):anyptr
 
-pub #linkid mbedtls_pk_setup
-fn mbedtls_pk_setup(ptr<mbedtls_pk_context> ctx, anyptr info):i32
+#linkid mbedtls_pk_setup
+pub fn mbedtls_pk_setup(ptr<mbedtls_pk_context> ctx, anyptr info):i32
 
-pub #linkid mbedtls_pk_rsa
-fn mbedtls_pk_rsa(mbedtls_pk_context ctx):ptr<mbedtls_rsa_context>
+#linkid mbedtls_pk_rsa
+pub fn mbedtls_pk_rsa(mbedtls_pk_context ctx):ptr<mbedtls_rsa_context>
 
-pub #linkid mbedtls_rsa_copy
-fn mbedtls_rsa_copy(ptr<mbedtls_rsa_context> dst, ptr<mbedtls_rsa_context> src):i32
+#linkid mbedtls_rsa_copy
+pub fn mbedtls_rsa_copy(ptr<mbedtls_rsa_context> dst, ptr<mbedtls_rsa_context> src):i32
 
-pub #linkid mbedtls_pk_write_pubkey_pem
-fn mbedtls_pk_write_pubkey_pem(ptr<mbedtls_pk_context> key, anyptr buf, int size):i32
+#linkid mbedtls_pk_write_pubkey_pem
+pub fn mbedtls_pk_write_pubkey_pem(ptr<mbedtls_pk_context> key, anyptr buf, int size):i32
 
-pub #linkid mbedtls_pk_parse_public_key
-fn mbedtls_pk_parse_public_key(ptr<mbedtls_pk_context> ctx, libc.cstr key, int keylen):i32
+#linkid mbedtls_pk_parse_public_key
+pub fn mbedtls_pk_parse_public_key(ptr<mbedtls_pk_context> ctx, libc.cstr key, int keylen):i32
 
-pub #linkid mbedtls_pk_parse_key
-fn mbedtls_pk_parse_key(ptr<mbedtls_pk_context> ctx, libc.cstr key, int keylen, libc.cstr pwd, int pwdlen, anyptr f_rng, anyptr p_rng):i32
+#linkid mbedtls_pk_parse_key
+pub fn mbedtls_pk_parse_key(ptr<mbedtls_pk_context> ctx, libc.cstr key, int keylen, libc.cstr pwd, int pwdlen, anyptr f_rng, anyptr p_rng):i32
 
-pub #linkid mbedtls_pk_write_key_pem
-fn mbedtls_pk_write_key_pem(ptr<mbedtls_pk_context> key, anyptr buf, int size):i32
+#linkid mbedtls_pk_write_key_pem
+pub fn mbedtls_pk_write_key_pem(ptr<mbedtls_pk_context> key, anyptr buf, int size):i32
 
-pub #linkid mbedtls_pk_free
-fn mbedtls_pk_free(ptr<mbedtls_pk_context> ctx)
+#linkid mbedtls_pk_free
+pub fn mbedtls_pk_free(ptr<mbedtls_pk_context> ctx)
 
 pub fn to_hex([u8] input):string {
     var hex_chars = "0123456789abcdef"
@@ -227,60 +227,60 @@ pub fn to_hex([u8] input):string {
     return result as string
 }
 
-pub #linkid mbedtls_ssl_session_reset
-fn mbedtls_ssl_session_reset(ptr<mbedtls_ssl_context> ssl):i32
+#linkid mbedtls_ssl_session_reset
+pub fn mbedtls_ssl_session_reset(ptr<mbedtls_ssl_context> ssl):i32
 
-pub #linkid mbedtls_ssl_config_init
-fn mbedtls_ssl_config_init(ptr<mbedtls_ssl_config> ssl)
+#linkid mbedtls_ssl_config_init
+pub fn mbedtls_ssl_config_init(ptr<mbedtls_ssl_config> ssl)
 
-pub #linkid mbedtls_ssl_init
-fn mbedtls_ssl_init(ptr<mbedtls_ssl_context> ssl)
+#linkid mbedtls_ssl_init
+pub fn mbedtls_ssl_init(ptr<mbedtls_ssl_context> ssl)
 
 // X.509 CRT and PK functions
-pub #linkid mbedtls_x509_crt_init
-fn mbedtls_x509_crt_init(ptr<mbedtls_x509_crt> crt):void
+#linkid mbedtls_x509_crt_init
+pub fn mbedtls_x509_crt_init(ptr<mbedtls_x509_crt> crt):void
 
 // SSL configuration functions
-pub #linkid mbedtls_ssl_conf_verify
-fn mbedtls_ssl_conf_verify(ptr<mbedtls_ssl_config> conf, anyptr f_vrfy, anyptr p_vrfy):void
+#linkid mbedtls_ssl_conf_verify
+pub fn mbedtls_ssl_conf_verify(ptr<mbedtls_ssl_config> conf, anyptr f_vrfy, anyptr p_vrfy):void
 
-pub #linkid mbedtls_ssl_conf_authmode
-fn mbedtls_ssl_conf_authmode(ptr<mbedtls_ssl_config> conf, i32 authmode):void
+#linkid mbedtls_ssl_conf_authmode
+pub fn mbedtls_ssl_conf_authmode(ptr<mbedtls_ssl_config> conf, i32 authmode):void
 
-pub #linkid mbedtls_ssl_conf_ca_chain
-fn mbedtls_ssl_conf_ca_chain(ptr<mbedtls_ssl_config> conf, ptr<mbedtls_x509_crt> ca_chain, ptr<mbedtls_x509_crl> ca_crl):void
+#linkid mbedtls_ssl_conf_ca_chain
+pub fn mbedtls_ssl_conf_ca_chain(ptr<mbedtls_ssl_config> conf, ptr<mbedtls_x509_crt> ca_chain, ptr<mbedtls_x509_crl> ca_crl):void
 
-pub #linkid mbedtls_ssl_conf_own_cert
-fn mbedtls_ssl_conf_own_cert(ptr<mbedtls_ssl_config> conf, ptr<mbedtls_x509_crt> own_cert, ptr<mbedtls_pk_context> pk_key):i32
+#linkid mbedtls_ssl_conf_own_cert
+pub fn mbedtls_ssl_conf_own_cert(ptr<mbedtls_ssl_config> conf, ptr<mbedtls_x509_crt> own_cert, ptr<mbedtls_pk_context> pk_key):i32
 
-pub #linkid mbedtls_ssl_conf_rng
-fn mbedtls_ssl_conf_rng(ptr<mbedtls_ssl_config> conf, anyptr f_rng, anyptr p_rng):void
+#linkid mbedtls_ssl_conf_rng
+pub fn mbedtls_ssl_conf_rng(ptr<mbedtls_ssl_config> conf, anyptr f_rng, anyptr p_rng):void
 
-pub #linkid mbedtls_ssl_conf_read_timeout
-fn mbedtls_ssl_conf_read_timeout(ptr<mbedtls_ssl_config> conf, u32 timeout):void
+#linkid mbedtls_ssl_conf_read_timeout
+pub fn mbedtls_ssl_conf_read_timeout(ptr<mbedtls_ssl_config> conf, u32 timeout):void
 
-pub #linkid mbedtls_ssl_config_defaults
-fn mbedtls_ssl_config_defaults(ptr<mbedtls_ssl_config> conf, i32 endpoint, i32 transport, i32 preset):i32
+#linkid mbedtls_ssl_config_defaults
+pub fn mbedtls_ssl_config_defaults(ptr<mbedtls_ssl_config> conf, i32 endpoint, i32 transport, i32 preset):i32
 
 // SSL cookie functions
-pub #linkid mbedtls_ssl_cookie_init
-fn mbedtls_ssl_cookie_init(ptr<mbedtls_ssl_cookie_ctx> ctx):void
+#linkid mbedtls_ssl_cookie_init
+pub fn mbedtls_ssl_cookie_init(ptr<mbedtls_ssl_cookie_ctx> ctx):void
 
-pub #linkid mbedtls_ssl_cookie_setup
-fn mbedtls_ssl_cookie_setup(ptr<mbedtls_ssl_cookie_ctx> ctx, anyptr f_rng, anyptr p_rng):i32
+#linkid mbedtls_ssl_cookie_setup
+pub fn mbedtls_ssl_cookie_setup(ptr<mbedtls_ssl_cookie_ctx> ctx, anyptr f_rng, anyptr p_rng):i32
 
-pub #linkid mbedtls_ssl_conf_dtls_cookies
-fn mbedtls_ssl_conf_dtls_cookies(ptr<mbedtls_ssl_config> conf, anyptr f_cookie_write, anyptr f_cookie_check, anyptr p_cookie):void
+#linkid mbedtls_ssl_conf_dtls_cookies
+pub fn mbedtls_ssl_conf_dtls_cookies(ptr<mbedtls_ssl_config> conf, anyptr f_cookie_write, anyptr f_cookie_check, anyptr p_cookie):void
 
 // DTLS-SRTP functions
-pub #linkid dtls_srtp_x509_digest
-fn dtls_srtp_x509_digest(ptr<mbedtls_x509_crt> crt, libc.cstr buf):void
+#linkid dtls_srtp_x509_digest
+pub fn dtls_srtp_x509_digest(ptr<mbedtls_x509_crt> crt, libc.cstr buf):void
 
-pub #linkid mbedtls_ssl_conf_dtls_srtp_protection_profiles
-fn mbedtls_ssl_conf_dtls_srtp_protection_profiles(ptr<mbedtls_ssl_config> conf, anyptr profiles):i32
+#linkid mbedtls_ssl_conf_dtls_srtp_protection_profiles
+pub fn mbedtls_ssl_conf_dtls_srtp_protection_profiles(ptr<mbedtls_ssl_config> conf, anyptr profiles):i32
 
-pub #linkid mbedtls_ssl_conf_srtp_mki_value_supported
-fn mbedtls_ssl_conf_srtp_mki_value_supported(ptr<mbedtls_ssl_config> conf, i32 support_mki_value):void
+#linkid mbedtls_ssl_conf_srtp_mki_value_supported
+pub fn mbedtls_ssl_conf_srtp_mki_value_supported(ptr<mbedtls_ssl_config> conf, i32 support_mki_value):void
 
-pub #linkid mbedtls_ssl_conf_cert_req_ca_list
-fn mbedtls_ssl_conf_cert_req_ca_list(ptr<mbedtls_ssl_config> conf, i8 cert_req_ca_list):void
+#linkid mbedtls_ssl_conf_cert_req_ca_list
+pub fn mbedtls_ssl_conf_cert_req_ca_list(ptr<mbedtls_ssl_config> conf, i8 cert_req_ca_list):void

--- a/std/crypto/utils.n
+++ b/std/crypto/utils.n
@@ -1,218 +1,218 @@
 import libc
 
-const MBEDTLS_SSL_IS_CLIENT = 0
+pub const MBEDTLS_SSL_IS_CLIENT = 0
 const MBEDTLS_SSL_IS_SERVER = 1
 
-const MBEDTLS_SSL_TRANSPORT_STREAM = 0   /*!< TLS      */
-const MBEDTLS_SSL_TRANSPORT_DATAGRAM = 1   /*!< DTLS     */
+pub const MBEDTLS_SSL_TRANSPORT_STREAM = 0   /*!< TLS      */
+pub const MBEDTLS_SSL_TRANSPORT_DATAGRAM = 1   /*!< DTLS     */
 
-const MBEDTLS_TLS_SRTP_AES128_CM_HMAC_SHA1_80 = 0x0001
-const MBEDTLS_TLS_SRTP_AES128_CM_HMAC_SHA1_32 = 0x0002
-const MBEDTLS_TLS_SRTP_NULL_HMAC_SHA1_80 = 0x0005
-const MBEDTLS_TLS_SRTP_NULL_HMAC_SHA1_32 = 0x0006
-const MBEDTLS_TLS_SRTP_UNSET = 0x0000
+pub const MBEDTLS_TLS_SRTP_AES128_CM_HMAC_SHA1_80 = 0x0001
+pub const MBEDTLS_TLS_SRTP_AES128_CM_HMAC_SHA1_32 = 0x0002
+pub const MBEDTLS_TLS_SRTP_NULL_HMAC_SHA1_80 = 0x0005
+pub const MBEDTLS_TLS_SRTP_NULL_HMAC_SHA1_32 = 0x0006
+pub const MBEDTLS_TLS_SRTP_UNSET = 0x0000
 
-type mbedtls_ssl_cookie_ctx = struct{
+pub type mbedtls_ssl_cookie_ctx = struct{
     mbedtls_md_context_t hmac_ctx
     u64 timeout
 }
 
-type mbedtls_ssl_context = struct{
+pub type mbedtls_ssl_context = struct{
     [u8;568] opaque_data
 }
 
-type mbedtls_ssl_config = struct{
+pub type mbedtls_ssl_config = struct{
     [u8;392] opaque_data
 }
 
-type mbedtls_x509_crt = struct{
+pub type mbedtls_x509_crt = struct{
     [u8;744] opaque_data
 }
 
-type mbedtls_x509_crl = struct{
+pub type mbedtls_x509_crl = struct{
     [u8;416] opaque_data
 }
 
-type mbedtls_md_context_t = struct{
+pub type mbedtls_md_context_t = struct{
     anyptr md_info
     anyptr md_ctx
     anyptr hmac_ctx
 }
 
-#linkid mbedtls_md5_init
+pub #linkid mbedtls_md5_init
 fn mbedtls_md5_init(ptr<mbedtls_md_context_t> ctx):void
 
-#linkid mbedtls_md_info_from_type
+pub #linkid mbedtls_md_info_from_type
 fn mbedtls_md_info_from_type(i32 md_type):anyptr
 
-#linkid mbedtls_md_setup
+pub #linkid mbedtls_md_setup
 fn mbedtls_md_setup(ptr<mbedtls_md_context_t> ctx, anyptr md_info, i32 is_hmac):i32
 
-#linkid mbedtls_md_starts
+pub #linkid mbedtls_md_starts
 fn mbedtls_md_starts(ptr<mbedtls_md_context_t> ctx):i32
 
-#linkid mbedtls_md_update
+pub #linkid mbedtls_md_update
 fn mbedtls_md_update(ptr<mbedtls_md_context_t> ctx, libc.cstr input, int ilen):i32
 
-#linkid mbedtls_md_finish
+pub #linkid mbedtls_md_finish
 fn mbedtls_md_finish(ptr<mbedtls_md_context_t> ctx, anyptr output):i32
 
-#linkid mbedtls_md_free
+pub #linkid mbedtls_md_free
 fn mbedtls_md_free(ptr<mbedtls_md_context_t> ctx):void
 
 
 
-type mbedtls_sha256_context = struct{
+pub type mbedtls_sha256_context = struct{
     [u8;64] buffer      // 正在处理的数据块
     [u32;2] total       // 已处理的字节数
     [u32;8] state       // 中间摘要状态
     i32 is224            // 0: 使用 SHA-256, 1: 使用 SHA-224
 }
 
-#linkid mbedtls_sha256_init
+pub #linkid mbedtls_sha256_init
 fn mbedtls_sha256_init(ptr<mbedtls_sha256_context> ctx):void
 
-#linkid mbedtls_sha256_starts
+pub #linkid mbedtls_sha256_starts
 fn mbedtls_sha256_starts(ptr<mbedtls_sha256_context> ctx, i32 is224):i32
 
-#linkid mbedtls_sha256_update
+pub #linkid mbedtls_sha256_update
 fn mbedtls_sha256_update(ptr<mbedtls_sha256_context> ctx, libc.cstr input, int ilen):i32
 
-#linkid mbedtls_sha256_finish
+pub #linkid mbedtls_sha256_finish
 fn mbedtls_sha256_finish(ptr<mbedtls_sha256_context> ctx, anyptr output):i32
 
-#linkid mbedtls_sha256_free
+pub #linkid mbedtls_sha256_free
 fn mbedtls_sha256_free(ptr<mbedtls_sha256_context> ctx):void
 
-#linkid mbedtls_md_init
+pub #linkid mbedtls_md_init
 fn mbedtls_md_init(ptr<mbedtls_md_context_t> ctx):void
 
-#linkid mbedtls_md_hmac_starts
+pub #linkid mbedtls_md_hmac_starts
 fn mbedtls_md_hmac_starts(ptr<mbedtls_md_context_t> ctx, libc.cstr key, int keylen):i32
 
-#linkid mbedtls_md_hmac_update
+pub #linkid mbedtls_md_hmac_update
 fn mbedtls_md_hmac_update(ptr<mbedtls_md_context_t> ctx, libc.cstr input, int ilen):i32
 
-#linkid mbedtls_md_hmac_finish
+pub #linkid mbedtls_md_hmac_finish
 fn mbedtls_md_hmac_finish(ptr<mbedtls_md_context_t> ctx, anyptr output):i32
 
 // RSA types and core API
-type mbedtls_rsa_context = struct{
+pub type mbedtls_rsa_context = struct{
     [u8;512] opaque_data    // opaque context data
 }
 
-type mbedtls_entropy_context = struct{
+pub type mbedtls_entropy_context = struct{
     [u8;1024] opaque_data    // opaque context data
 }
 
-type mbedtls_ctr_drbg_context = struct{
+pub type mbedtls_ctr_drbg_context = struct{
     [u8;512] opaque_data    // opaque context data
 }
 
-type mbedtls_pk_context = struct{
+pub type mbedtls_pk_context = struct{
     anyptr pk_info
     anyptr pk_ctx
 }
 
 // RSA constants
-const MBEDTLS_RSA_PKCS_V15 = 0
-const MBEDTLS_RSA_PKCS_V21 = 1
+pub const MBEDTLS_RSA_PKCS_V15 = 0
+pub const MBEDTLS_RSA_PKCS_V21 = 1
 
-const MBEDTLS_PK_RSA = 1
-const MBEDTLS_PK_ECKEY = 2
-const MBEDTLS_PK_ECKEY_DH = 3
-const MBEDTLS_PK_ECDSA = 4
-const MBEDTLS_PK_RSA_ALT = 5
-const MBEDTLS_PK_RSASSA_PSS = 6
-const MBEDTLS_PK_OPAQUE = 7
+pub const MBEDTLS_PK_RSA = 1
+pub const MBEDTLS_PK_ECKEY = 2
+pub const MBEDTLS_PK_ECKEY_DH = 3
+pub const MBEDTLS_PK_ECDSA = 4
+pub const MBEDTLS_PK_RSA_ALT = 5
+pub const MBEDTLS_PK_RSASSA_PSS = 6
+pub const MBEDTLS_PK_OPAQUE = 7
 
-#linkid mbedtls_entropy_func
+pub #linkid mbedtls_entropy_func
 fn mbedtls_entropy_func(anyptr data, anyptr output, int len):i32
 
-#linkid mbedtls_ctr_drbg_random
+pub #linkid mbedtls_ctr_drbg_random
 fn mbedtls_ctr_drbg_random(anyptr p_rng, anyptr output, int output_len):i32
 
-#linkid mbedtls_entropy_init
+pub #linkid mbedtls_entropy_init
 fn mbedtls_entropy_init(ptr<mbedtls_entropy_context> ctx):void
 
-#linkid mbedtls_ctr_drbg_init
+pub #linkid mbedtls_ctr_drbg_init
 fn mbedtls_ctr_drbg_init(ptr<mbedtls_ctr_drbg_context> ctx):void
 
-#linkid mbedtls_ctr_drbg_seed
+pub #linkid mbedtls_ctr_drbg_seed
 fn mbedtls_ctr_drbg_seed(ptr<mbedtls_ctr_drbg_context> ctx, anyptr f_entropy, anyptr p_entropy, libc.cstr custom, u64 len):i32
 
 // Core RSA functions
-#linkid mbedtls_rsa_init
+pub #linkid mbedtls_rsa_init
 fn mbedtls_rsa_init(ptr<mbedtls_rsa_context> ctx):void
 
-#linkid mbedtls_rsa_set_padding
+pub #linkid mbedtls_rsa_set_padding
 fn mbedtls_rsa_set_padding(ptr<mbedtls_rsa_context> ctx, i32 padding, i32 hash_id):i32
 
-#linkid mbedtls_rsa_gen_key
+pub #linkid mbedtls_rsa_gen_key
 fn mbedtls_rsa_gen_key(ptr<mbedtls_rsa_context> ctx, anyptr f_rng, anyptr p_rng, u32 nbits, i32 exponent):i32
 
-#linkid mbedtls_rsa_pkcs1_encrypt
+pub #linkid mbedtls_rsa_pkcs1_encrypt
 fn mbedtls_rsa_pkcs1_encrypt(ptr<mbedtls_rsa_context> ctx, anyptr f_rng, anyptr p_rng, int ilen, libc.cstr input, anyptr output):i32
 
-#linkid mbedtls_rsa_rsaes_oaep_encrypt
+pub #linkid mbedtls_rsa_rsaes_oaep_encrypt
 fn mbedtls_rsa_rsaes_oaep_encrypt(ptr<mbedtls_rsa_context> ctx, anyptr f_rng, anyptr p_rng, libc.cstr label, int label_len, int ilen, libc.cstr input, anyptr output):i32
 
-#linkid mbedtls_rsa_pkcs1_decrypt
+pub #linkid mbedtls_rsa_pkcs1_decrypt
 fn mbedtls_rsa_pkcs1_decrypt(ptr<mbedtls_rsa_context> ctx, anyptr f_rng, anyptr p_rng, ptr<int> olen, libc.cstr input, anyptr output, int output_max_len):i32
 
-#linkid mbedtls_rsa_rsaes_oaep_decrypt
+pub #linkid mbedtls_rsa_rsaes_oaep_decrypt
 fn mbedtls_rsa_rsaes_oaep_decrypt(ptr<mbedtls_rsa_context> ctx, anyptr f_rng, anyptr p_rng, libc.cstr label, int label_len, ptr<int> olen, libc.cstr input, anyptr output, int output_max_len):i32
 
-#linkid mbedtls_rsa_pkcs1_sign
+pub #linkid mbedtls_rsa_pkcs1_sign
 fn mbedtls_rsa_pkcs1_sign(ptr<mbedtls_rsa_context> ctx, anyptr f_rng, anyptr p_rng, i32 md_alg, u32 hashlen, libc.cstr hash, libc.cstr sig):i32
 
-#linkid mbedtls_rsa_pkcs1_verify
+pub #linkid mbedtls_rsa_pkcs1_verify
 fn mbedtls_rsa_pkcs1_verify(ptr<mbedtls_rsa_context> ctx, i32 md_alg, u32 hashlen, libc.cstr hash, libc.cstr sig):i32
 
-#linkid mbedtls_rsa_get_len
+pub #linkid mbedtls_rsa_get_len
 fn mbedtls_rsa_get_len(ptr<mbedtls_rsa_context> ctx):int
 
-#linkid mbedtls_rsa_free
+pub #linkid mbedtls_rsa_free
 fn mbedtls_rsa_free(ptr<mbedtls_rsa_context> ctx):void
 
 
-#linkid mbedtls_ctr_drbg_free
+pub #linkid mbedtls_ctr_drbg_free
 fn mbedtls_ctr_drbg_free(ptr<mbedtls_ctr_drbg_context> ctx):void
 
-#linkid mbedtls_entropy_free
+pub #linkid mbedtls_entropy_free
 fn mbedtls_entropy_free(ptr<mbedtls_entropy_context> ctx):void
 
-#linkid mbedtls_pk_init
+pub #linkid mbedtls_pk_init
 fn mbedtls_pk_init(ptr<mbedtls_pk_context> ctx):void
 
-#linkid mbedtls_pk_info_from_type
+pub #linkid mbedtls_pk_info_from_type
 fn mbedtls_pk_info_from_type(i32 pk_type):anyptr
 
-#linkid mbedtls_pk_setup
+pub #linkid mbedtls_pk_setup
 fn mbedtls_pk_setup(ptr<mbedtls_pk_context> ctx, anyptr info):i32
 
-#linkid mbedtls_pk_rsa
+pub #linkid mbedtls_pk_rsa
 fn mbedtls_pk_rsa(mbedtls_pk_context ctx):ptr<mbedtls_rsa_context>
 
-#linkid mbedtls_rsa_copy
+pub #linkid mbedtls_rsa_copy
 fn mbedtls_rsa_copy(ptr<mbedtls_rsa_context> dst, ptr<mbedtls_rsa_context> src):i32
 
-#linkid mbedtls_pk_write_pubkey_pem
+pub #linkid mbedtls_pk_write_pubkey_pem
 fn mbedtls_pk_write_pubkey_pem(ptr<mbedtls_pk_context> key, anyptr buf, int size):i32
 
-#linkid mbedtls_pk_parse_public_key
+pub #linkid mbedtls_pk_parse_public_key
 fn mbedtls_pk_parse_public_key(ptr<mbedtls_pk_context> ctx, libc.cstr key, int keylen):i32
 
-#linkid mbedtls_pk_parse_key
+pub #linkid mbedtls_pk_parse_key
 fn mbedtls_pk_parse_key(ptr<mbedtls_pk_context> ctx, libc.cstr key, int keylen, libc.cstr pwd, int pwdlen, anyptr f_rng, anyptr p_rng):i32
 
-#linkid mbedtls_pk_write_key_pem
+pub #linkid mbedtls_pk_write_key_pem
 fn mbedtls_pk_write_key_pem(ptr<mbedtls_pk_context> key, anyptr buf, int size):i32
 
-#linkid mbedtls_pk_free
+pub #linkid mbedtls_pk_free
 fn mbedtls_pk_free(ptr<mbedtls_pk_context> ctx)
 
-fn to_hex([u8] input):string {
+pub fn to_hex([u8] input):string {
     var hex_chars = "0123456789abcdef"
     [u8] result = []
     
@@ -227,60 +227,60 @@ fn to_hex([u8] input):string {
     return result as string
 }
 
-#linkid mbedtls_ssl_session_reset
+pub #linkid mbedtls_ssl_session_reset
 fn mbedtls_ssl_session_reset(ptr<mbedtls_ssl_context> ssl):i32
 
-#linkid mbedtls_ssl_config_init
+pub #linkid mbedtls_ssl_config_init
 fn mbedtls_ssl_config_init(ptr<mbedtls_ssl_config> ssl)
 
-#linkid mbedtls_ssl_init
+pub #linkid mbedtls_ssl_init
 fn mbedtls_ssl_init(ptr<mbedtls_ssl_context> ssl)
 
 // X.509 CRT and PK functions
-#linkid mbedtls_x509_crt_init
+pub #linkid mbedtls_x509_crt_init
 fn mbedtls_x509_crt_init(ptr<mbedtls_x509_crt> crt):void
 
 // SSL configuration functions
-#linkid mbedtls_ssl_conf_verify
+pub #linkid mbedtls_ssl_conf_verify
 fn mbedtls_ssl_conf_verify(ptr<mbedtls_ssl_config> conf, anyptr f_vrfy, anyptr p_vrfy):void
 
-#linkid mbedtls_ssl_conf_authmode
+pub #linkid mbedtls_ssl_conf_authmode
 fn mbedtls_ssl_conf_authmode(ptr<mbedtls_ssl_config> conf, i32 authmode):void
 
-#linkid mbedtls_ssl_conf_ca_chain
+pub #linkid mbedtls_ssl_conf_ca_chain
 fn mbedtls_ssl_conf_ca_chain(ptr<mbedtls_ssl_config> conf, ptr<mbedtls_x509_crt> ca_chain, ptr<mbedtls_x509_crl> ca_crl):void
 
-#linkid mbedtls_ssl_conf_own_cert
+pub #linkid mbedtls_ssl_conf_own_cert
 fn mbedtls_ssl_conf_own_cert(ptr<mbedtls_ssl_config> conf, ptr<mbedtls_x509_crt> own_cert, ptr<mbedtls_pk_context> pk_key):i32
 
-#linkid mbedtls_ssl_conf_rng
+pub #linkid mbedtls_ssl_conf_rng
 fn mbedtls_ssl_conf_rng(ptr<mbedtls_ssl_config> conf, anyptr f_rng, anyptr p_rng):void
 
-#linkid mbedtls_ssl_conf_read_timeout
+pub #linkid mbedtls_ssl_conf_read_timeout
 fn mbedtls_ssl_conf_read_timeout(ptr<mbedtls_ssl_config> conf, u32 timeout):void
 
-#linkid mbedtls_ssl_config_defaults
+pub #linkid mbedtls_ssl_config_defaults
 fn mbedtls_ssl_config_defaults(ptr<mbedtls_ssl_config> conf, i32 endpoint, i32 transport, i32 preset):i32
 
 // SSL cookie functions
-#linkid mbedtls_ssl_cookie_init
+pub #linkid mbedtls_ssl_cookie_init
 fn mbedtls_ssl_cookie_init(ptr<mbedtls_ssl_cookie_ctx> ctx):void
 
-#linkid mbedtls_ssl_cookie_setup
+pub #linkid mbedtls_ssl_cookie_setup
 fn mbedtls_ssl_cookie_setup(ptr<mbedtls_ssl_cookie_ctx> ctx, anyptr f_rng, anyptr p_rng):i32
 
-#linkid mbedtls_ssl_conf_dtls_cookies
+pub #linkid mbedtls_ssl_conf_dtls_cookies
 fn mbedtls_ssl_conf_dtls_cookies(ptr<mbedtls_ssl_config> conf, anyptr f_cookie_write, anyptr f_cookie_check, anyptr p_cookie):void
 
 // DTLS-SRTP functions
-#linkid dtls_srtp_x509_digest
+pub #linkid dtls_srtp_x509_digest
 fn dtls_srtp_x509_digest(ptr<mbedtls_x509_crt> crt, libc.cstr buf):void
 
-#linkid mbedtls_ssl_conf_dtls_srtp_protection_profiles
+pub #linkid mbedtls_ssl_conf_dtls_srtp_protection_profiles
 fn mbedtls_ssl_conf_dtls_srtp_protection_profiles(ptr<mbedtls_ssl_config> conf, anyptr profiles):i32
 
-#linkid mbedtls_ssl_conf_srtp_mki_value_supported
+pub #linkid mbedtls_ssl_conf_srtp_mki_value_supported
 fn mbedtls_ssl_conf_srtp_mki_value_supported(ptr<mbedtls_ssl_config> conf, i32 support_mki_value):void
 
-#linkid mbedtls_ssl_conf_cert_req_ca_list
+pub #linkid mbedtls_ssl_conf_cert_req_ca_list
 fn mbedtls_ssl_conf_cert_req_ca_list(ptr<mbedtls_ssl_config> conf, i8 cert_req_ca_list):void

--- a/std/elf/elf.n
+++ b/std/elf/elf.n
@@ -37,7 +37,7 @@ type elf64_ehdr_t = struct {
     u16 shstrndx
 }
 
-fn arch(string path):string! {
+pub fn arch(string path):string! {
     if path == '' {
         throw errorf('path is empty')
     }

--- a/std/fmt/fmt.n
+++ b/std/fmt/fmt.n
@@ -4,7 +4,7 @@ import fmt.utils as *
 import strings
 import reflect
 
-fn sprintf(string format, ...[any] args):string {
+pub fn sprintf(string format, ...[any] args):string {
     var end = format.len()
     var result = vec<u8>.new(0, 0)
 
@@ -225,12 +225,12 @@ fn sprintf(string format, ...[any] args):string {
     return result as string
 }
 
-fn printf(string format, ...[any] args) {
+pub fn printf(string format, ...[any] args) {
     var str = sprintf(format, ...args)
     print(str)
 }
 
-fn sscanf(string str, string format, ...[any] args):int {
+pub fn sscanf(string str, string format, ...[any] args):int {
     var str_len = str.len()
     var format_len = format.len()
     

--- a/std/fmt/utils.n
+++ b/std/fmt/utils.n
@@ -1,6 +1,6 @@
 import unsafe
 
-fn ascii(string c):u8 {
+pub fn ascii(string c):u8 {
     if c.len() == 0 {
         return 0
     }
@@ -9,7 +9,7 @@ fn ascii(string c):u8 {
 }
 
 // 引用传递
-fn reverse<T>([T] list) {
+pub fn reverse<T>([T] list) {
     int start = 0
     int end = list.len() - 1
     for start < end {
@@ -19,13 +19,13 @@ fn reverse<T>([T] list) {
     }
 }
 
-#where T:numeric
+pub #where T:numeric
 fn utos<T>(anyptr v):string {
     return utos_with<T>(v, '0', 0 as u8)
 }
 
 // 十六进制转换函数（小写）
-#where T:numeric
+pub #where T:numeric
 fn utos_hex_with<T>(anyptr v, string fill, u8 width):string {
     var i = unsafe.ptr_to<T>(&v as anyptr)
 
@@ -70,13 +70,13 @@ fn utos_hex_with<T>(anyptr v, string fill, u8 width):string {
     return result as string
 }
 
-#where T:numeric
+pub #where T:numeric
 fn utos_hex<T>(anyptr v):string {
     return utos_hex_with<T>(v, '0', 0 as u8)
 }
 
 // 十六进制转换函数（大写）
-#where T:numeric
+pub #where T:numeric
 fn utos_hex_upper_with<T>(anyptr v, string fill, u8 width):string {
     var i = unsafe.ptr_to<T>(&v as anyptr)
 
@@ -121,12 +121,12 @@ fn utos_hex_upper_with<T>(anyptr v, string fill, u8 width):string {
     return result as string
 }
 
-#where T:numeric
+pub #where T:numeric
 fn utos_hex_upper<T>(anyptr v):string {
     return utos_hex_upper_with<T>(v, '0', 0 as u8)
 }
 
-#where T:numeric
+pub #where T:numeric
 fn utos_with<T>(anyptr v, string fill, u8 width):string {
     var i = unsafe.ptr_to<T>(&v as anyptr)
 
@@ -167,12 +167,12 @@ fn utos_with<T>(anyptr v, string fill, u8 width):string {
     return result as string
 }
 
-#where T:numeric
+pub #where T:numeric
 fn itos<T>(anyptr v):string {
     return itos_with<T>(v, '0', 0 as u8)
 }
 
-#where T:numeric
+pub #where T:numeric
 fn itos_with<T>(anyptr v, string fill, u8 width):string {
     var i = unsafe.ptr_to<T>(&v as anyptr)
 
@@ -240,12 +240,12 @@ fn itos_with<T>(anyptr v, string fill, u8 width):string {
     return result as string
 }
 
-#where T:numeric
+pub #where T:numeric
 fn ftos<T>(anyptr v):string {
     return ftos_with<T>(v, '0', 0 as u8, 6 as u8)
 }
 
-#where T:numeric
+pub #where T:numeric
 fn ftos_with<T>(anyptr v, string fill, u8 width, u8 precision):string {
     var f = unsafe.ptr_to<T>(&v as anyptr)
 

--- a/std/fmt/utils.n
+++ b/std/fmt/utils.n
@@ -19,14 +19,14 @@ pub fn reverse<T>([T] list) {
     }
 }
 
-pub #where T:numeric
-fn utos<T>(anyptr v):string {
+#where T:numeric
+pub fn utos<T>(anyptr v):string {
     return utos_with<T>(v, '0', 0 as u8)
 }
 
 // 十六进制转换函数（小写）
-pub #where T:numeric
-fn utos_hex_with<T>(anyptr v, string fill, u8 width):string {
+#where T:numeric
+pub fn utos_hex_with<T>(anyptr v, string fill, u8 width):string {
     var i = unsafe.ptr_to<T>(&v as anyptr)
 
     T base = 16
@@ -70,14 +70,14 @@ fn utos_hex_with<T>(anyptr v, string fill, u8 width):string {
     return result as string
 }
 
-pub #where T:numeric
-fn utos_hex<T>(anyptr v):string {
+#where T:numeric
+pub fn utos_hex<T>(anyptr v):string {
     return utos_hex_with<T>(v, '0', 0 as u8)
 }
 
 // 十六进制转换函数（大写）
-pub #where T:numeric
-fn utos_hex_upper_with<T>(anyptr v, string fill, u8 width):string {
+#where T:numeric
+pub fn utos_hex_upper_with<T>(anyptr v, string fill, u8 width):string {
     var i = unsafe.ptr_to<T>(&v as anyptr)
 
     T base = 16
@@ -121,13 +121,13 @@ fn utos_hex_upper_with<T>(anyptr v, string fill, u8 width):string {
     return result as string
 }
 
-pub #where T:numeric
-fn utos_hex_upper<T>(anyptr v):string {
+#where T:numeric
+pub fn utos_hex_upper<T>(anyptr v):string {
     return utos_hex_upper_with<T>(v, '0', 0 as u8)
 }
 
-pub #where T:numeric
-fn utos_with<T>(anyptr v, string fill, u8 width):string {
+#where T:numeric
+pub fn utos_with<T>(anyptr v, string fill, u8 width):string {
     var i = unsafe.ptr_to<T>(&v as anyptr)
 
     T base = 10
@@ -167,13 +167,13 @@ fn utos_with<T>(anyptr v, string fill, u8 width):string {
     return result as string
 }
 
-pub #where T:numeric
-fn itos<T>(anyptr v):string {
+#where T:numeric
+pub fn itos<T>(anyptr v):string {
     return itos_with<T>(v, '0', 0 as u8)
 }
 
-pub #where T:numeric
-fn itos_with<T>(anyptr v, string fill, u8 width):string {
+#where T:numeric
+pub fn itos_with<T>(anyptr v, string fill, u8 width):string {
     var i = unsafe.ptr_to<T>(&v as anyptr)
 
     var base = 10
@@ -240,13 +240,13 @@ fn itos_with<T>(anyptr v, string fill, u8 width):string {
     return result as string
 }
 
-pub #where T:numeric
-fn ftos<T>(anyptr v):string {
+#where T:numeric
+pub fn ftos<T>(anyptr v):string {
     return ftos_with<T>(v, '0', 0 as u8, 6 as u8)
 }
 
-pub #where T:numeric
-fn ftos_with<T>(anyptr v, string fill, u8 width, u8 precision):string {
+#where T:numeric
+pub fn ftos_with<T>(anyptr v, string fill, u8 width, u8 precision):string {
     var f = unsafe.ptr_to<T>(&v as anyptr)
 
     var is_neg = false

--- a/std/fs/fs.n
+++ b/std/fs/fs.n
@@ -40,11 +40,11 @@ pub type file_t:io.reader, io.writer, io.seeker = struct{
 #linkid rt_uv_fs_from
 fn from(int fd, string name):ref<file_t>!
 
-pub #linkid rt_uv_fs_open
-fn open(string path, int flags, int mode):ref<file_t>!
+#linkid rt_uv_fs_open
+pub fn open(string path, int flags, int mode):ref<file_t>!
 
-pub #linkid rt_uv_fs_content
-fn file_t.content(&self):string! {
+#linkid rt_uv_fs_content
+pub fn file_t.content(&self):string! {
     var s = self.stat()
     var file_size = s.size
     var buf = vec<u8>.new(0, file_size as int)
@@ -55,27 +55,27 @@ fn file_t.content(&self):string! {
     return buf as string
 }
 
-pub #linkid rt_uv_fs_read
-fn file_t.read(&self, [u8] buf):int!
+#linkid rt_uv_fs_read
+pub fn file_t.read(&self, [u8] buf):int!
 
-pub #linkid rt_uv_fs_write
-fn file_t.write(&self, [u8] buf):int!
+#linkid rt_uv_fs_write
+pub fn file_t.write(&self, [u8] buf):int!
 
 fn file_t.seek(&self, int offset, int whence):int! {
     return syscall.seek(self.fd as int, offset, whence)
 }
 
-pub #linkid rt_uv_fs_read_at
-fn file_t.read_at(&self, [u8] buf, int offset):int!
+#linkid rt_uv_fs_read_at
+pub fn file_t.read_at(&self, [u8] buf, int offset):int!
 
-pub #linkid rt_uv_fs_write_at
-fn file_t.write_at(&self, [u8] buf, int offset):int!
+#linkid rt_uv_fs_write_at
+pub fn file_t.write_at(&self, [u8] buf, int offset):int!
 
-pub #linkid rt_uv_fs_close
-fn file_t.close(&self):void
+#linkid rt_uv_fs_close
+pub fn file_t.close(&self):void
 
-pub #linkid rt_uv_fs_stat
-fn file_t.stat(&self):stat_t!
+#linkid rt_uv_fs_stat
+pub fn file_t.stat(&self):stat_t!
 
 // io
 pub fn stdout():ref<file_t>! {

--- a/std/fs/fs.n
+++ b/std/fs/fs.n
@@ -8,7 +8,7 @@ type timespec_t = struct {
     u64 nsec
 }
 
-type stat_t = struct {
+pub type stat_t = struct {
     u64 dev      // device ID
     u64 mode     // file mode
     u64 nlink    // number of hard links
@@ -28,7 +28,7 @@ type stat_t = struct {
 }
 
 // match runtime.fs_context_t 
-type file_t:io.reader, io.writer, io.seeker = struct{
+pub type file_t:io.reader, io.writer, io.seeker = struct{
     int fd
     anyptr data
     i64 data_len
@@ -40,10 +40,10 @@ type file_t:io.reader, io.writer, io.seeker = struct{
 #linkid rt_uv_fs_from
 fn from(int fd, string name):ref<file_t>!
 
-#linkid rt_uv_fs_open
+pub #linkid rt_uv_fs_open
 fn open(string path, int flags, int mode):ref<file_t>!
 
-#linkid rt_uv_fs_content
+pub #linkid rt_uv_fs_content
 fn file_t.content(&self):string! {
     var s = self.stat()
     var file_size = s.size
@@ -55,30 +55,30 @@ fn file_t.content(&self):string! {
     return buf as string
 }
 
-#linkid rt_uv_fs_read
+pub #linkid rt_uv_fs_read
 fn file_t.read(&self, [u8] buf):int!
 
-#linkid rt_uv_fs_write
+pub #linkid rt_uv_fs_write
 fn file_t.write(&self, [u8] buf):int!
 
 fn file_t.seek(&self, int offset, int whence):int! {
     return syscall.seek(self.fd as int, offset, whence)
 }
 
-#linkid rt_uv_fs_read_at
+pub #linkid rt_uv_fs_read_at
 fn file_t.read_at(&self, [u8] buf, int offset):int!
 
-#linkid rt_uv_fs_write_at
+pub #linkid rt_uv_fs_write_at
 fn file_t.write_at(&self, [u8] buf, int offset):int!
 
-#linkid rt_uv_fs_close
+pub #linkid rt_uv_fs_close
 fn file_t.close(&self):void
 
-#linkid rt_uv_fs_stat
+pub #linkid rt_uv_fs_stat
 fn file_t.stat(&self):stat_t!
 
 // io
-fn stdout():ref<file_t>! {
+pub fn stdout():ref<file_t>! {
     return from(syscall.STDOUT, '/dev/stdout')
 }
 
@@ -86,10 +86,10 @@ fn stdin():ref<file_t>! {
     return from(syscall.STDIN, '/dev/stdin')
 }
 
-fn stderr():ref<file_t>! {
+pub fn stderr():ref<file_t>! {
     return from(syscall.STDERR, '/dev/stderr')
 }
 
-fn discard():ref<file_t>! {
+pub fn discard():ref<file_t>! {
     return open(syscall.null_device(), syscall.O_RDWR, 0)
 }

--- a/std/http/client.n
+++ b/std/http/client.n
@@ -10,19 +10,19 @@ import io.buf
 import json
 import co
 
-type multipart_item_t = struct{
+pub type multipart_item_t = struct{
     string name
     string filename 
     string value
     string content_type    
 }
 
-type multipart_t = struct{
+pub type multipart_t = struct{
     string boundary
     [multipart_item_t] items
 }
 
-fn multipart_t_new():ref<multipart_t> {
+pub fn multipart_t_new():ref<multipart_t> {
     return new multipart_t(
         boundary = generate_boundary(),
         items = [],
@@ -34,7 +34,7 @@ fn generate_boundary():string {
     return fmt.sprintf("----formdata-boundary-%d", timestamp)
 }
 
-fn multipart_t.text(&self, string name, string value):ref<multipart_t> {
+pub fn multipart_t.text(&self, string name, string value):ref<multipart_t> {
     var item = multipart_item_t{
         name: name,
         filename: "",
@@ -45,7 +45,7 @@ fn multipart_t.text(&self, string name, string value):ref<multipart_t> {
     return self
 }
 
-fn multipart_t.file(&self, string name, string filename, string data):ref<multipart_t> {
+pub fn multipart_t.file(&self, string name, string filename, string data):ref<multipart_t> {
     var content_type = "application/octet-stream" 
 
     if filename.ends_with(".jpg") || filename.ends_with(".jpeg") {
@@ -101,7 +101,7 @@ pub type request_t = struct{
     string version
 }
 
-type config_t = struct{
+pub type config_t = struct{
     string method
     {string:string} headers
     int timeout  // ms
@@ -132,37 +132,37 @@ pub fn request_t.get(&self, string url):ref<request_t> {
     return self
 }
 
-fn request_t.post(&self, string url):ref<request_t> {
+pub fn request_t.post(&self, string url):ref<request_t> {
     self.url = url
     self.method = 'POST'
     return self
 }
 
-fn request_t.put(&self, string url):ref<request_t> {
+pub fn request_t.put(&self, string url):ref<request_t> {
     self.url = url
     self.method = 'PUT'
     return self
 }
 
-fn request_t.patch(&self, string url):ref<request_t> {
+pub fn request_t.patch(&self, string url):ref<request_t> {
     self.url = url
     self.method = 'PATCH'
     return self
 }
 
-fn request_t.delete(&self, string url):ref<request_t> {
+pub fn request_t.delete(&self, string url):ref<request_t> {
     self.url = url
     self.method = 'DELETE'
     return self
 }
 
-fn request_t.options(&self, string url):ref<request_t> {
+pub fn request_t.options(&self, string url):ref<request_t> {
     self.url = url
     self.method = 'OPTIONS'
     return self
 }
 
-fn request_t.head(&self, string url):ref<request_t> {
+pub fn request_t.head(&self, string url):ref<request_t> {
     self.url = url
     self.method = 'HEAD'
     return self
@@ -173,29 +173,29 @@ pub fn request_t.timeout(&self, int timeout):ref<request_t> {
     return self
 }
 
-fn request_t.header(&self, string key, string value):ref<request_t> {
+pub fn request_t.header(&self, string key, string value):ref<request_t> {
     self.headers[key] = value
     return self
 }
 
-fn request_t.content(&self, string content):ref<request_t> {
+pub fn request_t.content(&self, string content):ref<request_t> {
     self.body = content
     return self
 }
 
-fn request_t.multipart(&self, ref<multipart_t> mp):ref<request_t> {
+pub fn request_t.multipart(&self, ref<multipart_t> mp):ref<request_t> {
     self.body = mp.serialize()
     self.headers['Content-Type'] = fmt.sprintf("multipart/form-data; boundary=%s", mp.boundary)
     return self
 }
 
-fn request_t.json(&self, any b):ref<request_t>! {
+pub fn request_t.json(&self, any b):ref<request_t>! {
     self.body = json.serialize(b)
     self.headers['Content-type'] = 'application/json'
     return self
 }
 
-fn request_t.form(&self, {string:string} data):ref<request_t> {
+pub fn request_t.form(&self, {string:string} data):ref<request_t> {
     var form_data = ""
     var first = true
     
@@ -343,12 +343,12 @@ pub fn request_t.send(&self):ref<response_t>! {
     return resp
 }
 
-fn get(string url, config_t c):ref<response_t>! {
+pub fn get(string url, config_t c):ref<response_t>! {
     c.method = 'GET'
     return fetch(url, c)
 }
 
-fn post(string url, string body, config_t c):ref<response_t>! {
+pub fn post(string url, string body, config_t c):ref<response_t>! {
     c.method = 'POST'
     c.body = body
 
@@ -367,7 +367,7 @@ fn fetch(string url, config_t c):ref<response_t>! {
 }
 
 
-fn response_t.status(&self):int {
+pub fn response_t.status(&self):int {
     return self.status
 }
 

--- a/std/http/client.n
+++ b/std/http/client.n
@@ -89,7 +89,7 @@ fn multipart_t.serialize(&self):string {
     return result
 }
 
-type request_t = struct{
+pub type request_t = struct{
     string method
     {string:string} headers
     int timeout_ms
@@ -108,7 +108,7 @@ type config_t = struct{
     string body
 }
 
-type response_t = struct{
+pub type response_t = struct{
     string version // http version
     {string:string} headers
     int status // http code
@@ -122,11 +122,11 @@ type response_t = struct{
     ref<buf.reader<types.connable>> buf_conn
 }
 
-fn new():ref<request_t> {
+pub fn new():ref<request_t> {
     return new request_t()
 }
 
-fn request_t.get(&self, string url):ref<request_t> {
+pub fn request_t.get(&self, string url):ref<request_t> {
     self.url = url
     self.method = 'GET'
     return self
@@ -168,7 +168,7 @@ fn request_t.head(&self, string url):ref<request_t> {
     return self
 }
 
-fn request_t.timeout(&self, int timeout):ref<request_t> {
+pub fn request_t.timeout(&self, int timeout):ref<request_t> {
     self.timeout_ms = timeout
     return self
 }
@@ -270,7 +270,7 @@ fn read_until_space(ref<buf.reader<types.connable>> br):string! {
     return bytes as string
 }
 
-fn request_t.send(&self):ref<response_t>! {
+pub fn request_t.send(&self):ref<response_t>! {
     self.u = url.parse(self.url)
     self.remote_ip = dns.lookup(self.u.hostname)[0]
     self.version = 'HTTP/1.1'
@@ -370,7 +370,7 @@ fn response_t.status(&self):int {
 
 // 读取响应体的一段字节到 buf, 返回实际读取的字节数,
 // 响应体读取完毕时抛出 EOF。超时错误统一为 'HTTP response read timeout'
-fn response_t.read(&self, [u8] buf):int! {
+pub fn response_t.read(&self, [u8] buf):int! {
     try {
         return self.buf_conn.read(buf)
     } catch e {
@@ -382,7 +382,7 @@ fn response_t.read(&self, [u8] buf):int! {
 }
 
 // 大小写不敏感的响应头查找, 不存在时返回空串
-fn response_t.header(&self, string key):string {
+pub fn response_t.header(&self, string key):string {
     var lower = key.to_lower()
     for k, v in self.headers {
         if k.to_lower() == lower {
@@ -393,11 +393,11 @@ fn response_t.header(&self, string key):string {
 }
 
 // 显式关闭底层连接
-fn response_t.close(&self) {
+pub fn response_t.close(&self) {
     self.buf_conn.rd.close()
 }
 
-fn response_t.text(&self):string! {
+pub fn response_t.text(&self):string! {
     if self.body_read {
         return self.body
     }

--- a/std/http/http.n
+++ b/std/http/http.n
@@ -80,8 +80,8 @@ fn callback_notfound(request_t req, ref<response_t> res):void! {
     res.send('404 not found')
 }
 
-pub #runtime_use n_http_server_t
-type server_t = struct{
+#runtime_use n_http_server_t
+pub type server_t = struct{
     fn():void! handler_fn
     string addr
     int port

--- a/std/http/http.n
+++ b/std/http/http.n
@@ -72,7 +72,7 @@ const MIME_JSON = 'application/json'
 const separation = '\r\n'
 const separation2 = '\r\n\r\n'
 
-type callback_fn = fn(request_t, ref<response_t>):void!
+pub type callback_fn = fn(request_t, ref<response_t>):void!
 
 fn callback_notfound(request_t req, ref<response_t> res):void! {
     res.status = 404
@@ -80,7 +80,7 @@ fn callback_notfound(request_t req, ref<response_t> res):void! {
     res.send('404 not found')
 }
 
-#runtime_use n_http_server_t
+pub #runtime_use n_http_server_t
 type server_t = struct{
     fn():void! handler_fn
     string addr
@@ -94,11 +94,11 @@ fn server_t.acquire_response(&self) {
     
 }
 
-fn server_t.get(&self, string path, callback_fn callback) {
+pub fn server_t.get(&self, string path, callback_fn callback) {
     self.router_register(ROUTES_GET, path, callback)
 }
 
-fn server_t.post(&self, string path, callback_fn callback) {
+pub fn server_t.post(&self, string path, callback_fn callback) {
     self.router_register(ROUTES_POST, path, callback)
 }
 
@@ -157,21 +157,21 @@ fn server_t.find_callback(&self, u8 method, string path):callback_fn {
     }
 }
 
-fn server_t.listen(&self, int port):void! {
+pub fn server_t.listen(&self, int port):void! {
     self.port = port
     uv.http_listen(self as anyptr)
 }
 
-fn server_t.close(&self) {
+pub fn server_t.close(&self) {
     uv.http_close(self as anyptr)
 }
 
-fn server():ref<server_t> {
+pub fn server():ref<server_t> {
     var s = new server_t(addr = '0.0.0.0', handler_fn = conn_handler)
     return s
 }
 
-type request_t = struct{
+pub type request_t = struct{
     u8 method
     {string:string} headers
     int length // content length
@@ -182,7 +182,7 @@ type request_t = struct{
     string body // http 请求原始 body
 }
 
-type response_t = struct{
+pub type response_t = struct{
     string version // http 版本号
     {string:string} headers
     int status // http 状态码
@@ -248,7 +248,7 @@ fn response_new():ref<response_t> {
     )
 }
 
-fn response_t.send(&self, string msg) {
+pub fn response_t.send(&self, string msg) {
     self.body = msg
     self.length = msg.len()
 }

--- a/std/http/utils.n
+++ b/std/http/utils.n
@@ -1,4 +1,4 @@
-fn status_to_str(int status):string {
+pub fn status_to_str(int status):string {
     return match status {
         200 -> '200'
         201 -> '201'
@@ -26,7 +26,7 @@ fn status_to_str(int status):string {
 }
 
 // unsigned
-fn utos(uint value):string {
+pub fn utos(uint value):string {
     var buf = vec<u8>.new(0, 20) // uint 最大数字是 20 位
     var idx = 19;
 

--- a/std/http/uv.n
+++ b/std/http/uv.n
@@ -7,7 +7,7 @@ type header_t = struct{
     int value_len
 }
 
-type conn_t = struct{
+pub type conn_t = struct{
     ref<http.server_t> server
     anyptr read_buf
     anyptr url_at
@@ -30,17 +30,17 @@ type conn_t = struct{
     // ... other field not use
 }
 
-#linkid rt_uv_http_listen
+pub #linkid rt_uv_http_listen
 fn http_listen(anyptr server):void!
 
-#linkid rt_uv_read
+pub #linkid rt_uv_read
 fn read(anyptr client):string!
 
-#linkid rt_uv_write
+pub #linkid rt_uv_write
 fn write(anyptr client, string data):void!
 
-#linkid rt_uv_conn_resp
+pub #linkid rt_uv_conn_resp
 fn conn_resp(ptr<conn_t> ctx, string data)
 
-#linkid rt_uv_http_close
+pub #linkid rt_uv_http_close
 fn http_close(anyptr server)

--- a/std/http/uv.n
+++ b/std/http/uv.n
@@ -30,17 +30,17 @@ pub type conn_t = struct{
     // ... other field not use
 }
 
-pub #linkid rt_uv_http_listen
-fn http_listen(anyptr server):void!
+#linkid rt_uv_http_listen
+pub fn http_listen(anyptr server):void!
 
-pub #linkid rt_uv_read
-fn read(anyptr client):string!
+#linkid rt_uv_read
+pub fn read(anyptr client):string!
 
-pub #linkid rt_uv_write
-fn write(anyptr client, string data):void!
+#linkid rt_uv_write
+pub fn write(anyptr client, string data):void!
 
-pub #linkid rt_uv_conn_resp
-fn conn_resp(ptr<conn_t> ctx, string data)
+#linkid rt_uv_conn_resp
+pub fn conn_resp(ptr<conn_t> ctx, string data)
 
-pub #linkid rt_uv_http_close
-fn http_close(anyptr server)
+#linkid rt_uv_http_close
+pub fn http_close(anyptr server)

--- a/std/io/buf.n
+++ b/std/io/buf.n
@@ -1,6 +1,6 @@
 import io
 
-type reader<T>:io.reader = struct{
+pub type reader<T>:io.reader = struct{
     T rd
     [u8] buf = vec<u8>.new(0, 4096)
     int r
@@ -8,12 +8,12 @@ type reader<T>:io.reader = struct{
     bool eof
 }
 
-#where T:io.reader
+pub #where T:io.reader
 fn reader<T>.size(&self):int {
     return self.buf.len()
 }
 
-#where T:io.reader
+pub #where T:io.reader
 fn reader<T>.reset(&self, T rd) {
     self.rd = rd
     if self.buf.len() == 0 {
@@ -24,7 +24,7 @@ fn reader<T>.reset(&self, T rd) {
     self.eof = false
 }
 
-#local #where T:io.reader
+pub #local #where T:io.reader
 fn reader<T>.fill(&self):void! {
     if self.r > 0 {
         // Copy unread data to the buffer start position
@@ -61,7 +61,7 @@ fn reader<T>.fill(&self):void! {
     throw errorf('no progress')
 }
 
-#where T:io.reader
+pub #where T:io.reader
 fn reader<T>.read(&self, [u8] buf):int! {
     if buf.len() == 0 {
         if self.buffered() > 0 {
@@ -101,12 +101,12 @@ fn reader<T>.read(&self, [u8] buf):int! {
     return n
 }
 
-#where T:io.reader
+pub #where T:io.reader
 fn reader<T>.buffered(&self):int {
     return self.w - self.r
 }
 
-#where T:io.reader
+pub #where T:io.reader
 fn reader<T>.read_until(&self, u8 delim):[u8] {
     [u8] result = vec<u8>.new(0, 0)
     var has_error = false
@@ -151,7 +151,7 @@ fn reader<T>.read_until(&self, u8 delim):[u8] {
     return result
 }
 
-#where T:io.reader
+pub #where T:io.reader
 fn reader<T>.read_exact(&self, [u8] buf):void! {
     int total = 0
     for total < buf.len() {
@@ -160,7 +160,7 @@ fn reader<T>.read_exact(&self, [u8] buf):void! {
     }
 }
 
-#where T:io.reader
+pub #where T:io.reader
 fn reader<T>.read_byte(&self):u8! {
     if self.r == self.w {
         self.fill()
@@ -171,7 +171,7 @@ fn reader<T>.read_byte(&self):u8! {
     return b
 }
 
-#where T:io.reader
+pub #where T:io.reader
 fn reader<T>.read_line(&self):string! {
     if self.eof {
         throw errorf('EOF')
@@ -190,19 +190,19 @@ fn reader<T>.read_line(&self):string! {
     return bytes as string
 }
 
-type writer<T>:io.writer = struct{
+pub type writer<T>:io.writer = struct{
     T wr
     [u8] buf = vec<u8>.new(0, 4096)
     int n
     bool err
 }
 
-#where T:io.writer
+pub #where T:io.writer
 fn writer<T>.size(&self):int {
     return self.buf.len()
 }
 
-#where T:io.writer
+pub #where T:io.writer
 fn writer<T>.reset(&self, T wr) {
     self.wr = wr
     if self.buf.len() == 0 {
@@ -212,17 +212,17 @@ fn writer<T>.reset(&self, T wr) {
     self.err = false
 }
 
-#where T:io.writer
+pub #where T:io.writer
 fn writer<T>.available(&self):int {
     return self.buf.len() - self.n
 }
 
-#where T:io.writer
+pub #where T:io.writer
 fn writer<T>.buffered(&self):int {
     return self.n
 }
 
-#local #where T:io.writer
+pub #local #where T:io.writer
 fn writer<T>.flush(&self):void! {
     if self.err {
         throw errorf('previous write error')
@@ -250,7 +250,7 @@ fn writer<T>.flush(&self):void! {
     self.n = 0
 }
 
-#where T:io.writer
+pub #where T:io.writer
 fn writer<T>.write(&self, [u8] buf):int! {
     if self.err {
         throw errorf('previous write error')
@@ -298,7 +298,7 @@ fn writer<T>.write(&self, [u8] buf):int! {
     return total_written
 }
 
-#where T:io.writer
+pub #where T:io.writer
 fn writer<T>.write_byte(&self, u8 b):void! {
     if self.err {
         throw errorf('previous write error')

--- a/std/io/buf.n
+++ b/std/io/buf.n
@@ -8,13 +8,13 @@ pub type reader<T>:io.reader = struct{
     bool eof
 }
 
-pub #where T:io.reader
-fn reader<T>.size(&self):int {
+#where T:io.reader
+pub fn reader<T>.size(&self):int {
     return self.buf.len()
 }
 
-pub #where T:io.reader
-fn reader<T>.reset(&self, T rd) {
+#where T:io.reader
+pub fn reader<T>.reset(&self, T rd) {
     self.rd = rd
     if self.buf.len() == 0 {
         self.buf = vec<u8>.new(0, 4096)
@@ -24,8 +24,8 @@ fn reader<T>.reset(&self, T rd) {
     self.eof = false
 }
 
-pub #local #where T:io.reader
-fn reader<T>.fill(&self):void! {
+#local #where T:io.reader
+pub fn reader<T>.fill(&self):void! {
     if self.r > 0 {
         // Copy unread data to the buffer start position
         self.buf.copy(self.buf.slice(self.r, self.w))
@@ -61,8 +61,8 @@ fn reader<T>.fill(&self):void! {
     throw errorf('no progress')
 }
 
-pub #where T:io.reader
-fn reader<T>.read(&self, [u8] buf):int! {
+#where T:io.reader
+pub fn reader<T>.read(&self, [u8] buf):int! {
     if buf.len() == 0 {
         if self.buffered() > 0 {
             return 0
@@ -101,13 +101,13 @@ fn reader<T>.read(&self, [u8] buf):int! {
     return n
 }
 
-pub #where T:io.reader
-fn reader<T>.buffered(&self):int {
+#where T:io.reader
+pub fn reader<T>.buffered(&self):int {
     return self.w - self.r
 }
 
-pub #where T:io.reader
-fn reader<T>.read_until(&self, u8 delim):[u8] {
+#where T:io.reader
+pub fn reader<T>.read_until(&self, u8 delim):[u8] {
     [u8] result = vec<u8>.new(0, 0)
     var has_error = false
 
@@ -151,8 +151,8 @@ fn reader<T>.read_until(&self, u8 delim):[u8] {
     return result
 }
 
-pub #where T:io.reader
-fn reader<T>.read_exact(&self, [u8] buf):void! {
+#where T:io.reader
+pub fn reader<T>.read_exact(&self, [u8] buf):void! {
     int total = 0
     for total < buf.len() {
         int n = self.read(buf.slice(total, buf.len()))
@@ -160,8 +160,8 @@ fn reader<T>.read_exact(&self, [u8] buf):void! {
     }
 }
 
-pub #where T:io.reader
-fn reader<T>.read_byte(&self):u8! {
+#where T:io.reader
+pub fn reader<T>.read_byte(&self):u8! {
     if self.r == self.w {
         self.fill()
     }
@@ -171,8 +171,8 @@ fn reader<T>.read_byte(&self):u8! {
     return b
 }
 
-pub #where T:io.reader
-fn reader<T>.read_line(&self):string! {
+#where T:io.reader
+pub fn reader<T>.read_line(&self):string! {
     if self.eof {
         throw errorf('EOF')
     }
@@ -197,13 +197,13 @@ pub type writer<T>:io.writer = struct{
     bool err
 }
 
-pub #where T:io.writer
-fn writer<T>.size(&self):int {
+#where T:io.writer
+pub fn writer<T>.size(&self):int {
     return self.buf.len()
 }
 
-pub #where T:io.writer
-fn writer<T>.reset(&self, T wr) {
+#where T:io.writer
+pub fn writer<T>.reset(&self, T wr) {
     self.wr = wr
     if self.buf.len() == 0 {
         self.buf = vec<u8>.new(0, 4096)
@@ -212,18 +212,18 @@ fn writer<T>.reset(&self, T wr) {
     self.err = false
 }
 
-pub #where T:io.writer
-fn writer<T>.available(&self):int {
+#where T:io.writer
+pub fn writer<T>.available(&self):int {
     return self.buf.len() - self.n
 }
 
-pub #where T:io.writer
-fn writer<T>.buffered(&self):int {
+#where T:io.writer
+pub fn writer<T>.buffered(&self):int {
     return self.n
 }
 
-pub #local #where T:io.writer
-fn writer<T>.flush(&self):void! {
+#local #where T:io.writer
+pub fn writer<T>.flush(&self):void! {
     if self.err {
         throw errorf('previous write error')
     }
@@ -250,8 +250,8 @@ fn writer<T>.flush(&self):void! {
     self.n = 0
 }
 
-pub #where T:io.writer
-fn writer<T>.write(&self, [u8] buf):int! {
+#where T:io.writer
+pub fn writer<T>.write(&self, [u8] buf):int! {
     if self.err {
         throw errorf('previous write error')
     }
@@ -298,8 +298,8 @@ fn writer<T>.write(&self, [u8] buf):int! {
     return total_written
 }
 
-pub #where T:io.writer
-fn writer<T>.write_byte(&self, u8 b):void! {
+#where T:io.writer
+pub fn writer<T>.write_byte(&self, u8 b):void! {
     if self.err {
         throw errorf('previous write error')
     }

--- a/std/io/io.n
+++ b/std/io/io.n
@@ -2,28 +2,28 @@ mod io
 
 import syscall
 
-type reader = interface{
+pub type reader = interface{
     fn read([u8] buf):int!
 }
 
-type writer = interface{
+pub type writer = interface{
     fn write([u8] buf):int!
 }
 
-type seeker = interface{
+pub type seeker = interface{
     fn seek(int offset, int whence):int!
 }
 
-type buffer:reader,writer = struct{
+pub type buffer:reader,writer = struct{
     [u8] buf
     int offset
 }
 
-fn buffer.new():ref<buffer> {
+pub fn buffer.new():ref<buffer> {
     return new buffer()
 }
 
-fn buffer.write(&self, [u8] buf):int! {
+pub fn buffer.write(&self, [u8] buf):int! {
     self.buf.append(buf)
     return buf.len()
 }
@@ -34,7 +34,7 @@ fn buffer.write_byte(&self, u8 byte):int! {
 }
 
 // The read buf will be discarded (by offset), only when offset >= buf reset discard
-fn buffer.read(&self, [u8] buf):int! {
+pub fn buffer.read(&self, [u8] buf):int! {
     if self.empty() {
         self.reset()
 
@@ -51,15 +51,15 @@ fn buffer.read(&self, [u8] buf):int! {
     return n
 }
 
-fn buffer.empty(&self):bool {
+pub fn buffer.empty(&self):bool {
     return self.buf.len() <= self.offset
 }
 
-fn buffer.len(&self):int {
+pub fn buffer.len(&self):int {
     return self.buf.len() - self.offset
 }
 
-fn buffer.cap(&self):int {
+pub fn buffer.cap(&self):int {
     return self.buf.cap()
 }
 
@@ -81,7 +81,7 @@ fn buffer.reset(&self):void! {
     self.buf = self.buf.slice(0, 0)
 }
 
-fn buffer.read_all(&self):[u8]! {
+pub fn buffer.read_all(&self):[u8]! {
     if self.empty() {
         return []
     }

--- a/std/json/json.n
+++ b/std/json/json.n
@@ -8,7 +8,7 @@ import runtime
 var null_hash = @reflect_hash(null) 
 
 // Convert object to json string
-fn serialize<T>(T object):string! {
+pub fn serialize<T>(T object):string! {
     var t = reflect.typeof(object)
     return serialize_value(&object as anyptr, t) as string
 }
@@ -227,7 +227,7 @@ type deserialize_t = struct{
 }
 
 // Convert json string to object
-fn deserialize<T>(string s):T! {
+pub fn deserialize<T>(string s):T! {
     var val = @default(T)
     var t = reflect.typeof(val)
 

--- a/std/libc/cross.darwin.n
+++ b/std/libc/cross.darwin.n
@@ -1,17 +1,17 @@
-pub #linkid timegm
-fn timegm(anyptr value):i64
+#linkid timegm
+pub fn timegm(anyptr value):i64
 
-pub #linkid atol
-fn atol(anyptr value):i64
+#linkid atol
+pub fn atol(anyptr value):i64
 
-pub #linkid strtol
-fn strtol(anyptr value, anyptr endptr, i32 base):i64
+#linkid strtol
+pub fn strtol(anyptr value, anyptr endptr, i32 base):i64
 
-pub #linkid strtoul
-fn strtoul(anyptr value, anyptr endptr, i32 base):u64
+#linkid strtoul
+pub fn strtoul(anyptr value, anyptr endptr, i32 base):u64
 
-pub #linkid localtime
-fn localtime(anyptr timestamp):anyptr
+#linkid localtime
+pub fn localtime(anyptr timestamp):anyptr
 
-pub #linkid gmtime
-fn gmtime(anyptr timestamp):anyptr
+#linkid gmtime
+pub fn gmtime(anyptr timestamp):anyptr

--- a/std/libc/cross.darwin.n
+++ b/std/libc/cross.darwin.n
@@ -1,17 +1,17 @@
-#linkid timegm
+pub #linkid timegm
 fn timegm(anyptr value):i64
 
-#linkid atol
+pub #linkid atol
 fn atol(anyptr value):i64
 
-#linkid strtol
+pub #linkid strtol
 fn strtol(anyptr value, anyptr endptr, i32 base):i64
 
-#linkid strtoul
+pub #linkid strtoul
 fn strtoul(anyptr value, anyptr endptr, i32 base):u64
 
-#linkid localtime
+pub #linkid localtime
 fn localtime(anyptr timestamp):anyptr
 
-#linkid gmtime
+pub #linkid gmtime
 fn gmtime(anyptr timestamp):anyptr

--- a/std/libc/cross.linux.n
+++ b/std/libc/cross.linux.n
@@ -1,17 +1,17 @@
-pub #linkid timegm
-fn timegm(anyptr value):i64
+#linkid timegm
+pub fn timegm(anyptr value):i64
 
-pub #linkid atol
-fn atol(anyptr value):i64
+#linkid atol
+pub fn atol(anyptr value):i64
 
-pub #linkid strtol
-fn strtol(anyptr value, anyptr endptr, i32 base):i64
+#linkid strtol
+pub fn strtol(anyptr value, anyptr endptr, i32 base):i64
 
-pub #linkid strtoul
-fn strtoul(anyptr value, anyptr endptr, i32 base):u64
+#linkid strtoul
+pub fn strtoul(anyptr value, anyptr endptr, i32 base):u64
 
-pub #linkid localtime
-fn localtime(anyptr timestamp):anyptr
+#linkid localtime
+pub fn localtime(anyptr timestamp):anyptr
 
-pub #linkid gmtime
-fn gmtime(anyptr timestamp):anyptr
+#linkid gmtime
+pub fn gmtime(anyptr timestamp):anyptr

--- a/std/libc/cross.linux.n
+++ b/std/libc/cross.linux.n
@@ -1,17 +1,17 @@
-#linkid timegm
+pub #linkid timegm
 fn timegm(anyptr value):i64
 
-#linkid atol
+pub #linkid atol
 fn atol(anyptr value):i64
 
-#linkid strtol
+pub #linkid strtol
 fn strtol(anyptr value, anyptr endptr, i32 base):i64
 
-#linkid strtoul
+pub #linkid strtoul
 fn strtoul(anyptr value, anyptr endptr, i32 base):u64
 
-#linkid localtime
+pub #linkid localtime
 fn localtime(anyptr timestamp):anyptr
 
-#linkid gmtime
+pub #linkid gmtime
 fn gmtime(anyptr timestamp):anyptr

--- a/std/libc/cross.windows.n
+++ b/std/libc/cross.windows.n
@@ -1,17 +1,17 @@
-#linkid _mkgmtime64
+pub #linkid _mkgmtime64
 fn timegm(anyptr value):i64
 
-#linkid _atoi64
+pub #linkid _atoi64
 fn atol(anyptr value):i64
 
-#linkid _strtoi64
+pub #linkid _strtoi64
 fn strtol(anyptr value, anyptr endptr, i32 base):i64
 
-#linkid _strtoui64
+pub #linkid _strtoui64
 fn strtoul(anyptr value, anyptr endptr, i32 base):u64
 
-#linkid rt_windows_localtime
+pub #linkid rt_windows_localtime
 fn localtime(anyptr timestamp):anyptr
 
-#linkid rt_windows_gmtime
+pub #linkid rt_windows_gmtime
 fn gmtime(anyptr timestamp):anyptr

--- a/std/libc/cross.windows.n
+++ b/std/libc/cross.windows.n
@@ -1,17 +1,17 @@
-pub #linkid _mkgmtime64
-fn timegm(anyptr value):i64
+#linkid _mkgmtime64
+pub fn timegm(anyptr value):i64
 
-pub #linkid _atoi64
-fn atol(anyptr value):i64
+#linkid _atoi64
+pub fn atol(anyptr value):i64
 
-pub #linkid _strtoi64
-fn strtol(anyptr value, anyptr endptr, i32 base):i64
+#linkid _strtoi64
+pub fn strtol(anyptr value, anyptr endptr, i32 base):i64
 
-pub #linkid _strtoui64
-fn strtoul(anyptr value, anyptr endptr, i32 base):u64
+#linkid _strtoui64
+pub fn strtoul(anyptr value, anyptr endptr, i32 base):u64
 
-pub #linkid rt_windows_localtime
-fn localtime(anyptr timestamp):anyptr
+#linkid rt_windows_localtime
+pub fn localtime(anyptr timestamp):anyptr
 
-pub #linkid rt_windows_gmtime
-fn gmtime(anyptr timestamp):anyptr
+#linkid rt_windows_gmtime
+pub fn gmtime(anyptr timestamp):anyptr

--- a/std/libc/dirent.darwin_amd64.n
+++ b/std/libc/dirent.darwin_amd64.n
@@ -1,6 +1,6 @@
 type dir_t = anyptr
 
-type dirent_t = struct {
+pub type dirent_t = struct {
     u64 ino
     u64 off
     u16 reclen
@@ -9,11 +9,11 @@ type dirent_t = struct {
     [u8;1024] name
 }
 
-#linkid 'opendir$INODE64'
+pub #linkid 'opendir$INODE64'
 fn opendir(anyptr str):dir_t
 
-#linkid 'readdir$INODE64'
+pub #linkid 'readdir$INODE64'
 fn readdir(dir_t d):ptr<dirent_t>
 
-#linkid closedir
+pub #linkid closedir
 fn closedir(dir_t d):int

--- a/std/libc/dirent.darwin_amd64.n
+++ b/std/libc/dirent.darwin_amd64.n
@@ -9,11 +9,11 @@ pub type dirent_t = struct {
     [u8;1024] name
 }
 
-pub #linkid 'opendir$INODE64'
-fn opendir(anyptr str):dir_t
+#linkid 'opendir$INODE64'
+pub fn opendir(anyptr str):dir_t
 
-pub #linkid 'readdir$INODE64'
-fn readdir(dir_t d):ptr<dirent_t>
+#linkid 'readdir$INODE64'
+pub fn readdir(dir_t d):ptr<dirent_t>
 
-pub #linkid closedir
-fn closedir(dir_t d):int
+#linkid closedir
+pub fn closedir(dir_t d):int

--- a/std/libc/dirent.darwin_arm64.n
+++ b/std/libc/dirent.darwin_arm64.n
@@ -1,6 +1,6 @@
 type dir_t = anyptr
 
-type dirent_t = struct {
+pub type dirent_t = struct {
     u64 ino
     u64 off
     u16 reclen
@@ -9,11 +9,11 @@ type dirent_t = struct {
     [u8;1024] name
 }
 
-#linkid 'opendir'
+pub #linkid 'opendir'
 fn opendir(anyptr str):dir_t
 
-#linkid 'readdir'
+pub #linkid 'readdir'
 fn readdir(dir_t d):ptr<dirent_t>
 
-#linkid closedir
+pub #linkid closedir
 fn closedir(dir_t d):int

--- a/std/libc/dirent.darwin_arm64.n
+++ b/std/libc/dirent.darwin_arm64.n
@@ -9,11 +9,11 @@ pub type dirent_t = struct {
     [u8;1024] name
 }
 
-pub #linkid 'opendir'
-fn opendir(anyptr str):dir_t
+#linkid 'opendir'
+pub fn opendir(anyptr str):dir_t
 
-pub #linkid 'readdir'
-fn readdir(dir_t d):ptr<dirent_t>
+#linkid 'readdir'
+pub fn readdir(dir_t d):ptr<dirent_t>
 
-pub #linkid closedir
-fn closedir(dir_t d):int
+#linkid closedir
+pub fn closedir(dir_t d):int

--- a/std/libc/dirent.linux.n
+++ b/std/libc/dirent.linux.n
@@ -8,11 +8,11 @@ pub type dirent_t = struct {
     [u8;256] name
 }
 
-pub #linkid opendir
-fn opendir(anyptr str):dir_t
+#linkid opendir
+pub fn opendir(anyptr str):dir_t
 
-pub #linkid readdir
-fn readdir(dir_t d):ptr<dirent_t>
+#linkid readdir
+pub fn readdir(dir_t d):ptr<dirent_t>
 
-pub #linkid closedir
-fn closedir(dir_t d):int
+#linkid closedir
+pub fn closedir(dir_t d):int

--- a/std/libc/dirent.linux.n
+++ b/std/libc/dirent.linux.n
@@ -1,6 +1,6 @@
 type dir_t = anyptr
 
-type dirent_t = struct {
+pub type dirent_t = struct {
     u64 ino
     i64 off
     u16 reclen
@@ -8,11 +8,11 @@ type dirent_t = struct {
     [u8;256] name
 }
 
-#linkid opendir
+pub #linkid opendir
 fn opendir(anyptr str):dir_t
 
-#linkid readdir
+pub #linkid readdir
 fn readdir(dir_t d):ptr<dirent_t>
 
-#linkid closedir
+pub #linkid closedir
 fn closedir(dir_t d):int

--- a/std/libc/libc.n
+++ b/std/libc/libc.n
@@ -4,8 +4,8 @@ import libc.cross
 
 pub type cstr = anyptr
 
-pub #linkid rt_string_ref
-fn string.to_cstr(*self):cstr
+#linkid rt_string_ref
+pub fn string.to_cstr(*self):cstr
 
 pub fn to_cfn(anyptr closure):anyptr {
     type fn_t = struct{
@@ -20,25 +20,25 @@ pub fn to_cfn(anyptr closure):anyptr {
 pub const AF_INET = 2
 pub const AF_INET6 = 10
 
-pub #linkid rt_string_new
-fn cstr.to_string(self):string
+#linkid rt_string_new
+pub fn cstr.to_string(self):string
 
 // stdlib.h
-pub #linkid atoi
-fn atoi(cstr str):i32
+#linkid atoi
+pub fn atoi(cstr str):i32
 
 pub fn atol(cstr str):i64 {
     return cross.atol(str as anyptr)
 }
 
-pub #linkid atof
-fn atof(cstr str):f64
+#linkid atof
+pub fn atof(cstr str):f64
 
-pub #linkid strtof
-fn strtof(cstr str, anyptr endptr):f32
+#linkid strtof
+pub fn strtof(cstr str, anyptr endptr):f32
 
-pub #linkid strtod
-fn strtod(cstr str, anyptr endptr):f64
+#linkid strtod
+pub fn strtod(cstr str, anyptr endptr):f64
 
 pub fn strtol(cstr str, anyptr endptr, i32 base):i64 {
     return cross.strtol(str as anyptr, endptr, base)
@@ -48,53 +48,53 @@ pub fn strtoul(cstr str, anyptr endptr, i32 base):u64 {
     return cross.strtoul(str as anyptr, endptr, base)
 }
 
-pub #linkid rand
-fn rand():i32
+#linkid rand
+pub fn rand():i32
 
-pub #linkid srand
-fn srand(u32 seed):void
+#linkid srand
+pub fn srand(u32 seed):void
 
-pub #linkid malloc
-fn malloc(u64 size):anyptr
+#linkid malloc
+pub fn malloc(u64 size):anyptr
 
-pub #linkid calloc
-fn calloc(u64 nmemb, u64 size):anyptr
+#linkid calloc
+pub fn calloc(u64 nmemb, u64 size):anyptr
 
-pub #linkid realloc
-fn realloc(anyptr p, u64 size):anyptr
+#linkid realloc
+pub fn realloc(anyptr p, u64 size):anyptr
 
-pub #linkid free
-fn free(anyptr p):void
+#linkid free
+pub fn free(anyptr p):void
 
-pub #linkid aligned_alloc
-fn aligned_alloc(u64 alignment, u64 size):anyptr
+#linkid aligned_alloc
+pub fn aligned_alloc(u64 alignment, u64 size):anyptr
 
-pub #linkid abort
-fn abort()
+#linkid abort
+pub fn abort()
 
-pub #linkid atexit
-fn atexit(anyptr func):i32
+#linkid atexit
+pub fn atexit(anyptr func):i32
 
-pub #linkid exit
-fn exit(i32 status)
+#linkid exit
+pub fn exit(i32 status)
 
-pub #linkid _Exit
-fn _exit(i32 status)
+#linkid _Exit
+pub fn _exit(i32 status)
 
-pub #linkid at_quick_exit
-fn at_quick_exit(anyptr func):i32
+#linkid at_quick_exit
+pub fn at_quick_exit(anyptr func):i32
 
-pub #linkid quick_exit
-fn quick_exit(i32 status)
+#linkid quick_exit
+pub fn quick_exit(i32 status)
 
-pub #linkid getenv
-fn getenv(cstr name):cstr
+#linkid getenv
+pub fn getenv(cstr name):cstr
 
-pub #linkid system
-fn system(cstr command):i32
+#linkid system
+pub fn system(cstr command):i32
 
-pub #linkid abs
-fn abs(i32 x):i32
+#linkid abs
+pub fn abs(i32 x):i32
 
 pub fn labs(i64 x):i64 {
     if x < 0 {
@@ -113,8 +113,8 @@ pub type ldiv_t = struct {
     i64 rem
 }
 
-pub #linkid div
-fn div(i32 numer, i32 denom):div_t
+#linkid div
+pub fn div(i32 numer, i32 denom):div_t
 
 pub fn ldiv(i64 numer, i64 denom):ldiv_t {
     return ldiv_t {
@@ -123,143 +123,143 @@ pub fn ldiv(i64 numer, i64 denom):ldiv_t {
     }
 }
 
-pub #linkid mblen
-fn mblen(cstr s, u64 n):i32
+#linkid mblen
+pub fn mblen(cstr s, u64 n):i32
 
-pub #linkid mbtowc
-fn mbtowc(anyptr pwc, cstr s, u64 n):i32
+#linkid mbtowc
+pub fn mbtowc(anyptr pwc, cstr s, u64 n):i32
 
-pub #linkid wctomb
-fn wctomb(cstr s, i32 wc):i32
+#linkid wctomb
+pub fn wctomb(cstr s, i32 wc):i32
 
-pub #linkid mbstowcs
-fn mbstowcs(anyptr pwcs, cstr s, u64 n):u64
+#linkid mbstowcs
+pub fn mbstowcs(anyptr pwcs, cstr s, u64 n):u64
 
-pub #linkid wcstombs
-fn wcstombs(cstr s, anyptr pwcs, u64 n):u64
+#linkid wcstombs
+pub fn wcstombs(cstr s, anyptr pwcs, u64 n):u64
 
-pub #linkid posix_memalign
-fn posix_memalign(anyptr memptr, u64 alignment, u64 size):i32
+#linkid posix_memalign
+pub fn posix_memalign(anyptr memptr, u64 alignment, u64 size):i32
 
-pub #linkid setenv
-fn setenv(cstr name, cstr value, i32 overwrite):i32
+#linkid setenv
+pub fn setenv(cstr name, cstr value, i32 overwrite):i32
 
-pub #linkid unsetenv
-fn unsetenv(cstr name):i32
+#linkid unsetenv
+pub fn unsetenv(cstr name):i32
 
-pub #linkid putenv
-fn putenv(cstr str):i32
+#linkid putenv
+pub fn putenv(cstr str):i32
 
-pub #linkid mkstemp
-fn mkstemp(cstr template):i32
+#linkid mkstemp
+pub fn mkstemp(cstr template):i32
 
-pub #linkid mkostemp
-fn mkostemp(cstr template, i32 flags):i32
+#linkid mkostemp
+pub fn mkostemp(cstr template, i32 flags):i32
 
-pub #linkid mkdtemp
-fn mkdtemp(cstr template):cstr
+#linkid mkdtemp
+pub fn mkdtemp(cstr template):cstr
 
-pub #linkid mktemp
-fn mktemp(cstr template):cstr
+#linkid mktemp
+pub fn mktemp(cstr template):cstr
 
-pub #linkid mkstemps
-fn mkstemps(cstr template, i32 suffixlen):i32
+#linkid mkstemps
+pub fn mkstemps(cstr template, i32 suffixlen):i32
 
-pub #linkid mkostemps
-fn mkostemps(cstr template, i32 suffixlen, i32 flags):i32
+#linkid mkostemps
+pub fn mkostemps(cstr template, i32 suffixlen, i32 flags):i32
 
-pub #linkid getsubopt
-fn getsubopt(anyptr optionp, anyptr tokens, anyptr valuep):i32
+#linkid getsubopt
+pub fn getsubopt(anyptr optionp, anyptr tokens, anyptr valuep):i32
 
-pub #linkid rand_r
-fn rand_r(ptr<u32> seed):i32
+#linkid rand_r
+pub fn rand_r(ptr<u32> seed):i32
 
-pub #linkid realpath
-fn realpath(cstr path, cstr resolved_path):cstr
+#linkid realpath
+pub fn realpath(cstr path, cstr resolved_path):cstr
 
-pub #linkid random
-fn random():i64
+#linkid random
+pub fn random():i64
 
-pub #linkid srandom
-fn srandom(u32 seed):void
+#linkid srandom
+pub fn srandom(u32 seed):void
 
-pub #linkid initstate
-fn initstate(u32 seed, cstr state, u64 size):cstr
+#linkid initstate
+pub fn initstate(u32 seed, cstr state, u64 size):cstr
 
-pub #linkid setstate
-fn setstate(cstr state):cstr
+#linkid setstate
+pub fn setstate(cstr state):cstr
 
-pub #linkid posix_openpt
-fn posix_openpt(i32 flags):i32
+#linkid posix_openpt
+pub fn posix_openpt(i32 flags):i32
 
-pub #linkid grantpt
-fn grantpt(i32 fd):i32
+#linkid grantpt
+pub fn grantpt(i32 fd):i32
 
-pub #linkid unlockpt
-fn unlockpt(i32 fd):i32
+#linkid unlockpt
+pub fn unlockpt(i32 fd):i32
 
-pub #linkid ptsname_r
-fn ptsname_r(i32 fd, cstr buf, u64 buflen):i32
+#linkid ptsname_r
+pub fn ptsname_r(i32 fd, cstr buf, u64 buflen):i32
 
-pub #linkid l64a
-fn l64a(i64 value):cstr
+#linkid l64a
+pub fn l64a(i64 value):cstr
 
-pub #linkid a64l
-fn a64l(cstr s):i64
+#linkid a64l
+pub fn a64l(cstr s):i64
 
-pub #linkid setkey
-fn setkey(cstr key):void
+#linkid setkey
+pub fn setkey(cstr key):void
 
-pub #linkid drand48
-fn drand48():f64
+#linkid drand48
+pub fn drand48():f64
 
-pub #linkid erand48
-fn erand48(anyptr xsubi):f64
+#linkid erand48
+pub fn erand48(anyptr xsubi):f64
 
-pub #linkid lrand48
-fn lrand48():i64
+#linkid lrand48
+pub fn lrand48():i64
 
-pub #linkid nrand48
-fn nrand48(anyptr xsubi):i64
+#linkid nrand48
+pub fn nrand48(anyptr xsubi):i64
 
-pub #linkid mrand48
-fn mrand48():i64
+#linkid mrand48
+pub fn mrand48():i64
 
-pub #linkid jrand48
-fn jrand48(anyptr xsubi):i64
+#linkid jrand48
+pub fn jrand48(anyptr xsubi):i64
 
-pub #linkid srand48
-fn srand48(i64 seedval):void
+#linkid srand48
+pub fn srand48(i64 seedval):void
 
-pub #linkid seed48
-fn seed48(anyptr seed16v):ptr<u16>
+#linkid seed48
+pub fn seed48(anyptr seed16v):ptr<u16>
 
-pub #linkid lcong48
-fn lcong48(anyptr param):void
+#linkid lcong48
+pub fn lcong48(anyptr param):void
 
-pub #linkid valloc
-fn valloc(u64 size):anyptr
+#linkid valloc
+pub fn valloc(u64 size):anyptr
 
-pub #linkid memalign
-fn memalign(u64 alignment, u64 size):anyptr
+#linkid memalign
+pub fn memalign(u64 alignment, u64 size):anyptr
 
-pub #linkid reallocarray
-fn reallocarray(anyptr p, u64 nmemb, u64 size):anyptr
+#linkid reallocarray
+pub fn reallocarray(anyptr p, u64 nmemb, u64 size):anyptr
 
-pub #linkid getloadavg
-fn getloadavg(ptr<f64> loadavg, i32 nelem):i32
+#linkid getloadavg
+pub fn getloadavg(ptr<f64> loadavg, i32 nelem):i32
 
-pub #linkid ecvt
-fn ecvt(f64 number, i32 ndigits, ptr<i32> decpt, ptr<i32> sign):cstr
+#linkid ecvt
+pub fn ecvt(f64 number, i32 ndigits, ptr<i32> decpt, ptr<i32> sign):cstr
 
-pub #linkid fcvt
-fn fcvt(f64 number, i32 ndigits, ptr<i32> decpt, ptr<i32> sign):cstr
+#linkid fcvt
+pub fn fcvt(f64 number, i32 ndigits, ptr<i32> decpt, ptr<i32> sign):cstr
 
-pub #linkid gcvt
-fn gcvt(f64 number, i32 ndigit, cstr buf):cstr
+#linkid gcvt
+pub fn gcvt(f64 number, i32 ndigit, cstr buf):cstr
 
-pub #linkid secure_getenv
-fn secure_getenv(cstr name):cstr
+#linkid secure_getenv
+pub fn secure_getenv(cstr name):cstr
 
 
 // stdio.h
@@ -288,215 +288,215 @@ pub type fpos_t = struct {
     f64 __align
 }
 
-pub #linkid fopen
-fn fopen(cstr filename, cstr mode):fileptr
+#linkid fopen
+pub fn fopen(cstr filename, cstr mode):fileptr
 
-pub #linkid freopen
-fn freopen(cstr filename, cstr mode, fileptr stream):fileptr
+#linkid freopen
+pub fn freopen(cstr filename, cstr mode, fileptr stream):fileptr
 
-pub #linkid fclose
-fn fclose(fileptr stream):i32
+#linkid fclose
+pub fn fclose(fileptr stream):i32
 
-pub #linkid remove
-fn remove(cstr filename):i32
+#linkid remove
+pub fn remove(cstr filename):i32
 
-pub #linkid rename
-fn rename(cstr old_name, cstr new_name):i32
+#linkid rename
+pub fn rename(cstr old_name, cstr new_name):i32
 
-pub #linkid feof
-fn feof(fileptr stream):i32
+#linkid feof
+pub fn feof(fileptr stream):i32
 
-pub #linkid ferror
-fn ferror(fileptr stream):i32
+#linkid ferror
+pub fn ferror(fileptr stream):i32
 
-pub #linkid fflush
-fn fflush(fileptr stream):i32
+#linkid fflush
+pub fn fflush(fileptr stream):i32
 
-pub #linkid clearerr
-fn clearerr(fileptr stream):void
+#linkid clearerr
+pub fn clearerr(fileptr stream):void
 
-pub #linkid fseek
-fn fseek(fileptr stream, i64 offset, i32 whence):i32
+#linkid fseek
+pub fn fseek(fileptr stream, i64 offset, i32 whence):i32
 
-pub #linkid ftell
-fn ftell(fileptr stream):i64
+#linkid ftell
+pub fn ftell(fileptr stream):i64
 
-pub #linkid rewind
-fn rewind(fileptr stream):void
+#linkid rewind
+pub fn rewind(fileptr stream):void
 
-pub #linkid fgetpos
-fn fgetpos(fileptr stream, ptr<fpos_t> pos):i32
+#linkid fgetpos
+pub fn fgetpos(fileptr stream, ptr<fpos_t> pos):i32
 
-pub #linkid fsetpos
-fn fsetpos(fileptr stream, ptr<fpos_t> pos):i32
+#linkid fsetpos
+pub fn fsetpos(fileptr stream, ptr<fpos_t> pos):i32
 
-pub #linkid fread
-fn fread(anyptr p, u64 size, u64 nmemb, fileptr stream):u64
+#linkid fread
+pub fn fread(anyptr p, u64 size, u64 nmemb, fileptr stream):u64
 
-pub #linkid fwrite
-fn fwrite(anyptr p, u64 size, u64 nmemb, fileptr stream):u64
+#linkid fwrite
+pub fn fwrite(anyptr p, u64 size, u64 nmemb, fileptr stream):u64
 
-pub #linkid fgetc
-fn fgetc(fileptr stream):i32
+#linkid fgetc
+pub fn fgetc(fileptr stream):i32
 
-pub #linkid getc
-fn getc(fileptr stream):i32
+#linkid getc
+pub fn getc(fileptr stream):i32
 
-pub #linkid getchar
-fn getchar():i32
+#linkid getchar
+pub fn getchar():i32
 
-pub #linkid ungetc
-fn ungetc(i32 c, fileptr stream):i32
+#linkid ungetc
+pub fn ungetc(i32 c, fileptr stream):i32
 
-pub #linkid fputc
-fn fputc(i32 c, fileptr stream):i32
+#linkid fputc
+pub fn fputc(i32 c, fileptr stream):i32
 
-pub #linkid putc
-fn putc(i32 c, fileptr stream):i32
+#linkid putc
+pub fn putc(i32 c, fileptr stream):i32
 
-pub #linkid putchar
-fn putchar(i32 c):i32
+#linkid putchar
+pub fn putchar(i32 c):i32
 
-pub #linkid fgets
-fn fgets(cstr s, i32 size, fileptr stream):cstr
+#linkid fgets
+pub fn fgets(cstr s, i32 size, fileptr stream):cstr
 
-pub #linkid fputs
-fn fputs(cstr s, fileptr stream):i32
+#linkid fputs
+pub fn fputs(cstr s, fileptr stream):i32
 
-pub #linkid puts
-fn puts(cstr s):i32
+#linkid puts
+pub fn puts(cstr s):i32
 
 // Error handling
-pub #linkid perror
-fn perror(cstr s):void
+#linkid perror
+pub fn perror(cstr s):void
 
 // Buffer control
-pub #linkid setvbuf
-fn setvbuf(fileptr stream, cstr buffer, i32 mode, u64 size):i32
+#linkid setvbuf
+pub fn setvbuf(fileptr stream, cstr buffer, i32 mode, u64 size):i32
 
-pub #linkid setbuf
-fn setbuf(fileptr stream, cstr buffer):void
+#linkid setbuf
+pub fn setbuf(fileptr stream, cstr buffer):void
 
 // Temporary files
-pub #linkid tmpnam
-fn tmpnam(cstr s):cstr
+#linkid tmpnam
+pub fn tmpnam(cstr s):cstr
 
-pub #linkid tmpfile
-fn tmpfile():fileptr
+#linkid tmpfile
+pub fn tmpfile():fileptr
 
 
 // POSIX extensions
-pub #linkid fmemopen
-fn fmemopen(anyptr buffer, u64 size, cstr mode):fileptr
+#linkid fmemopen
+pub fn fmemopen(anyptr buffer, u64 size, cstr mode):fileptr
 
-pub #linkid open_memstream
-fn open_memstream(ptr<cstr> bufp, ptr<u64> sizep):fileptr
+#linkid open_memstream
+pub fn open_memstream(ptr<cstr> bufp, ptr<u64> sizep):fileptr
 
-pub #linkid fdopen
-fn fdopen(i32 fd, cstr mode):fileptr
+#linkid fdopen
+pub fn fdopen(i32 fd, cstr mode):fileptr
 
-pub #linkid popen
-fn popen(cstr command, cstr t):fileptr
+#linkid popen
+pub fn popen(cstr command, cstr t):fileptr
 
-pub #linkid pclose
-fn pclose(fileptr stream):i32
+#linkid pclose
+pub fn pclose(fileptr stream):i32
 
-pub #linkid fileno
-fn fileno(fileptr stream):i32
+#linkid fileno
+pub fn fileno(fileptr stream):i32
 
-pub #linkid fseeko
-fn fseeko(fileptr stream, i64 offset, i32 whence):i32
+#linkid fseeko
+pub fn fseeko(fileptr stream, i64 offset, i32 whence):i32
 
-pub #linkid ftello
-fn ftello(fileptr stream):i64
+#linkid ftello
+pub fn ftello(fileptr stream):i64
 
 // File locking
-pub #linkid flockfile
-fn flockfile(fileptr stream):void
+#linkid flockfile
+pub fn flockfile(fileptr stream):void
 
-pub #linkid ftrylockfile
-fn ftrylockfile(fileptr stream):i32
+#linkid ftrylockfile
+pub fn ftrylockfile(fileptr stream):i32
 
-pub #linkid funlockfile
-fn funlockfile(fileptr stream):void
+#linkid funlockfile
+pub fn funlockfile(fileptr stream):void
 
 // Unlocked I/O
-pub #linkid getc_unlocked
-fn getc_unlocked(fileptr stream):i32
+#linkid getc_unlocked
+pub fn getc_unlocked(fileptr stream):i32
 
-pub #linkid getchar_unlocked
-fn getchar_unlocked():i32
+#linkid getchar_unlocked
+pub fn getchar_unlocked():i32
 
-pub #linkid putc_unlocked
-fn putc_unlocked(i32 c, fileptr stream):i32
+#linkid putc_unlocked
+pub fn putc_unlocked(i32 c, fileptr stream):i32
 
-pub #linkid putchar_unlocked
-fn putchar_unlocked(i32 c):i32
+#linkid putchar_unlocked
+pub fn putchar_unlocked(i32 c):i32
 
-pub #linkid fgetc_unlocked
-fn fgetc_unlocked(fileptr stream):i32
+#linkid fgetc_unlocked
+pub fn fgetc_unlocked(fileptr stream):i32
 
-pub #linkid fputc_unlocked
-fn fputc_unlocked(i32 c, fileptr stream):i32
+#linkid fputc_unlocked
+pub fn fputc_unlocked(i32 c, fileptr stream):i32
 
-pub #linkid fflush_unlocked
-fn fflush_unlocked(fileptr stream):i32
+#linkid fflush_unlocked
+pub fn fflush_unlocked(fileptr stream):i32
 
-pub #linkid fread_unlocked
-fn fread_unlocked(anyptr p, u64 size, u64 nmemb, fileptr stream):u64
+#linkid fread_unlocked
+pub fn fread_unlocked(anyptr p, u64 size, u64 nmemb, fileptr stream):u64
 
-pub #linkid fwrite_unlocked
-fn fwrite_unlocked(anyptr p, u64 size, u64 nmemb, fileptr stream):u64
+#linkid fwrite_unlocked
+pub fn fwrite_unlocked(anyptr p, u64 size, u64 nmemb, fileptr stream):u64
 
-pub #linkid clearerr_unlocked
-fn clearerr_unlocked(fileptr stream):void
+#linkid clearerr_unlocked
+pub fn clearerr_unlocked(fileptr stream):void
 
-pub #linkid feof_unlocked
-fn feof_unlocked(fileptr stream):i32
+#linkid feof_unlocked
+pub fn feof_unlocked(fileptr stream):i32
 
-pub #linkid ferror_unlocked
-fn ferror_unlocked(fileptr stream):i32
+#linkid ferror_unlocked
+pub fn ferror_unlocked(fileptr stream):i32
 
-pub #linkid fileno_unlocked
-fn fileno_unlocked(fileptr stream):i32
+#linkid fileno_unlocked
+pub fn fileno_unlocked(fileptr stream):i32
 
-pub #linkid fgets_unlocked
-fn fgets_unlocked(cstr s, i32 size, fileptr stream):cstr
+#linkid fgets_unlocked
+pub fn fgets_unlocked(cstr s, i32 size, fileptr stream):cstr
 
-pub #linkid fputs_unlocked
-fn fputs_unlocked(cstr s, fileptr stream):i32
+#linkid fputs_unlocked
+pub fn fputs_unlocked(cstr s, fileptr stream):i32
 
 // Line-oriented I/O
-pub #linkid getdelim
-fn getdelim(ptr<cstr> lineptr, ptr<u64> n, i32 delim, fileptr stream):i64
+#linkid getdelim
+pub fn getdelim(ptr<cstr> lineptr, ptr<u64> n, i32 delim, fileptr stream):i64
 
-pub #linkid getline
-fn getline(ptr<cstr> lineptr, ptr<u64> n, fileptr stream):i64
+#linkid getline
+pub fn getline(ptr<cstr> lineptr, ptr<u64> n, fileptr stream):i64
 
 // Additional functions
-pub #linkid renameat
-fn renameat(i32 olddirfd, cstr oldpath, i32 newdirfd, cstr newpath):i32
+#linkid renameat
+pub fn renameat(i32 olddirfd, cstr oldpath, i32 newdirfd, cstr newpath):i32
 
-pub #linkid tempnam
-fn tempnam(cstr dir, cstr pfx):cstr
+#linkid tempnam
+pub fn tempnam(cstr dir, cstr pfx):cstr
 
-pub #linkid cuserid
-fn cuserid(cstr s):cstr
+#linkid cuserid
+pub fn cuserid(cstr s):cstr
 
-pub #linkid setlinebuf
-fn setlinebuf(fileptr stream):void
+#linkid setlinebuf
+pub fn setlinebuf(fileptr stream):void
 
-pub #linkid setbuffer
-fn setbuffer(fileptr stream, cstr buffer, u64 size):void
+#linkid setbuffer
+pub fn setbuffer(fileptr stream, cstr buffer, u64 size):void
 
-pub #linkid getw
-fn getw(fileptr stream):i32
+#linkid getw
+pub fn getw(fileptr stream):i32
 
-pub #linkid putw
-fn putw(i32 w, fileptr stream):i32
+#linkid putw
+pub fn putw(i32 w, fileptr stream):i32
 
-pub #linkid fgetln
-fn fgetln(fileptr stream, ptr<u64> len):cstr
+#linkid fgetln
+pub fn fgetln(fileptr stream, ptr<u64> len):cstr
 
 // Cookie I/O function types
 pub type cookie_read_function_t = fn(anyptr, cstr, u64):i64
@@ -511,160 +511,160 @@ pub type cookie_io_functions_t = struct {
     cookie_close_function_t close
 }
 
-pub #linkid fopencookie
-fn fopencookie(anyptr cookie, cstr mode, cookie_io_functions_t io_funcs):fileptr
+#linkid fopencookie
+pub fn fopencookie(anyptr cookie, cstr mode, cookie_io_functions_t io_funcs):fileptr
 
 
 
 // string.h
 // Memory functions
-pub #linkid memcpy
-fn memcpy(anyptr dst, anyptr src, u64 n):anyptr
+#linkid memcpy
+pub fn memcpy(anyptr dst, anyptr src, u64 n):anyptr
 
-pub #linkid memmove
-fn memmove(anyptr dst, anyptr src, u64 n):anyptr
+#linkid memmove
+pub fn memmove(anyptr dst, anyptr src, u64 n):anyptr
 
-pub #linkid memset
-fn memset(anyptr s, i32 c, u64 n):anyptr
+#linkid memset
+pub fn memset(anyptr s, i32 c, u64 n):anyptr
 
-pub #linkid memcmp
-fn memcmp(anyptr s1, anyptr s2, u64 n):i32
+#linkid memcmp
+pub fn memcmp(anyptr s1, anyptr s2, u64 n):i32
 
-pub #linkid memchr
-fn memchr(anyptr s, i32 c, u64 n):anyptr
+#linkid memchr
+pub fn memchr(anyptr s, i32 c, u64 n):anyptr
 
 // String copy functions
-pub #linkid strcpy
-fn strcpy(cstr dst, cstr src):cstr
+#linkid strcpy
+pub fn strcpy(cstr dst, cstr src):cstr
 
-pub #linkid strncpy
-fn strncpy(cstr dst, cstr src, u64 n):cstr
+#linkid strncpy
+pub fn strncpy(cstr dst, cstr src, u64 n):cstr
 
 // String concatenation functions
-pub #linkid strcat
-fn strcat(cstr dst, cstr src):cstr
+#linkid strcat
+pub fn strcat(cstr dst, cstr src):cstr
 
-pub #linkid strncat
-fn strncat(cstr dst, cstr src, u64 n):cstr
+#linkid strncat
+pub fn strncat(cstr dst, cstr src, u64 n):cstr
 
 // String comparison functions
-pub #linkid strcmp
-fn strcmp(cstr s1, cstr s2):i32
+#linkid strcmp
+pub fn strcmp(cstr s1, cstr s2):i32
 
-pub #linkid strncmp
-fn strncmp(cstr s1, cstr s2, u64 n):i32
+#linkid strncmp
+pub fn strncmp(cstr s1, cstr s2, u64 n):i32
 
-pub #linkid strcoll
-fn strcoll(cstr s1, cstr s2):i32
+#linkid strcoll
+pub fn strcoll(cstr s1, cstr s2):i32
 
-pub #linkid strxfrm
-fn strxfrm(cstr dst, cstr src, u64 n):u64
+#linkid strxfrm
+pub fn strxfrm(cstr dst, cstr src, u64 n):u64
 
 // String search functions
-pub #linkid strchr
-fn strchr(cstr s, i32 c):cstr
+#linkid strchr
+pub fn strchr(cstr s, i32 c):cstr
 
-pub #linkid strrchr
-fn strrchr(cstr s, i32 c):cstr
+#linkid strrchr
+pub fn strrchr(cstr s, i32 c):cstr
 
-pub #linkid strcspn
-fn strcspn(cstr s1, cstr s2):u64
+#linkid strcspn
+pub fn strcspn(cstr s1, cstr s2):u64
 
-pub #linkid strspn
-fn strspn(cstr s1, cstr s2):u64
+#linkid strspn
+pub fn strspn(cstr s1, cstr s2):u64
 
-pub #linkid strpbrk
-fn strpbrk(cstr s1, cstr s2):cstr
+#linkid strpbrk
+pub fn strpbrk(cstr s1, cstr s2):cstr
 
-pub #linkid strstr
-fn strstr(cstr haystack, cstr needle):cstr
+#linkid strstr
+pub fn strstr(cstr haystack, cstr needle):cstr
 
-pub #linkid strtok
-fn strtok(cstr str, cstr delim):cstr
+#linkid strtok
+pub fn strtok(cstr str, cstr delim):cstr
 
 // String length function
-pub #linkid strlen
-fn strlen(cstr s):u64
+#linkid strlen
+pub fn strlen(cstr s):u64
 
-pub #linkid rt_strerror
-fn error_string():string
+#linkid rt_strerror
+pub fn error_string():string
 
 // Error functions
-pub #linkid strerror
-fn strerror(i32 errnum):cstr
+#linkid strerror
+pub fn strerror(i32 errnum):cstr
 
 // POSIX extensions
-pub #linkid strtok_r
-fn strtok_r(cstr str, cstr delim, ptr<cstr> saveptr):cstr
+#linkid strtok_r
+pub fn strtok_r(cstr str, cstr delim, ptr<cstr> saveptr):cstr
 
-pub #linkid strerror_r
-fn strerror_r(i32 errnum, cstr buf, u64 buflen):i32
+#linkid strerror_r
+pub fn strerror_r(i32 errnum, cstr buf, u64 buflen):i32
 
-pub #linkid stpcpy
-fn stpcpy(cstr dst, cstr src):cstr
+#linkid stpcpy
+pub fn stpcpy(cstr dst, cstr src):cstr
 
-pub #linkid stpncpy
-fn stpncpy(cstr dst, cstr src, u64 n):cstr
+#linkid stpncpy
+pub fn stpncpy(cstr dst, cstr src, u64 n):cstr
 
-pub #linkid strnlen
-fn strnlen(cstr s, u64 maxlen):u64
+#linkid strnlen
+pub fn strnlen(cstr s, u64 maxlen):u64
 
-pub #linkid strdup
-fn strdup(cstr s):cstr
+#linkid strdup
+pub fn strdup(cstr s):cstr
 
-pub #linkid strndup
-fn strndup(cstr s, u64 n):cstr
+#linkid strndup
+pub fn strndup(cstr s, u64 n):cstr
 
-pub #linkid strsignal
-fn strsignal(i32 sig):cstr
+#linkid strsignal
+pub fn strsignal(i32 sig):cstr
 
 // Locale-aware functions (requires locale_t type)
 pub type locale_t = anyptr
 
-pub #linkid strerror_l
-fn strerror_l(i32 errnum, locale_t locale):cstr
+#linkid strerror_l
+pub fn strerror_l(i32 errnum, locale_t locale):cstr
 
-pub #linkid strcoll_l
-fn strcoll_l(cstr s1, cstr s2, locale_t locale):i32
+#linkid strcoll_l
+pub fn strcoll_l(cstr s1, cstr s2, locale_t locale):i32
 
-pub #linkid strxfrm_l
-fn strxfrm_l(cstr dst, cstr src, u64 n, locale_t locale):u64
+#linkid strxfrm_l
+pub fn strxfrm_l(cstr dst, cstr src, u64 n, locale_t locale):u64
 
-pub #linkid memmem
-fn memmem(anyptr haystack, u64 haystacklen, anyptr needle, u64 needlelen):anyptr
+#linkid memmem
+pub fn memmem(anyptr haystack, u64 haystacklen, anyptr needle, u64 needlelen):anyptr
 
 // X/Open extensions
-pub #linkid memccpy
-fn memccpy(anyptr dst, anyptr src, i32 c, u64 n):anyptr
+#linkid memccpy
+pub fn memccpy(anyptr dst, anyptr src, i32 c, u64 n):anyptr
 
 // GNU/BSD extensions
-pub #linkid strsep
-fn strsep(ptr<cstr> strp, cstr delim):cstr
+#linkid strsep
+pub fn strsep(ptr<cstr> strp, cstr delim):cstr
 
-pub #linkid strlcat
-fn strlcat(cstr dst, cstr src, u64 size):u64
+#linkid strlcat
+pub fn strlcat(cstr dst, cstr src, u64 size):u64
 
-pub #linkid strlcpy
-fn strlcpy(cstr dst, cstr src, u64 size):u64
+#linkid strlcpy
+pub fn strlcpy(cstr dst, cstr src, u64 size):u64
 
-pub #linkid explicit_bzero
-fn explicit_bzero(anyptr s, u64 n):void
+#linkid explicit_bzero
+pub fn explicit_bzero(anyptr s, u64 n):void
 
 // GNU extensions
-pub #linkid strverscmp
-fn strverscmp(cstr s1, cstr s2):i32
+#linkid strverscmp
+pub fn strverscmp(cstr s1, cstr s2):i32
 
-pub #linkid strchrnul
-fn strchrnul(cstr s, i32 c):cstr
+#linkid strchrnul
+pub fn strchrnul(cstr s, i32 c):cstr
 
-pub #linkid strcasestr
-fn strcasestr(cstr haystack, cstr needle):cstr
+#linkid strcasestr
+pub fn strcasestr(cstr haystack, cstr needle):cstr
 
-pub #linkid memrchr
-fn memrchr(anyptr s, i32 c, u64 n):anyptr
+#linkid memrchr
+pub fn memrchr(anyptr s, i32 c, u64 n):anyptr
 
-pub #linkid mempcpy
-fn mempcpy(anyptr dst, anyptr src, u64 n):anyptr
+#linkid mempcpy
+pub fn mempcpy(anyptr dst, anyptr src, u64 n):anyptr
 
 
 // math.h
@@ -682,439 +682,439 @@ pub const M_2_SQRTPI = 1.12837916709551257390
 pub const M_SQRT2 = 1.41421356237309504880
 pub const M_SQRT1_2 = 0.70710678118654752440
 
-pub #linkid acos
-fn acos(f64 x):f64
+#linkid acos
+pub fn acos(f64 x):f64
 
-pub #linkid acosf
-fn acosf(f32 x):f32
+#linkid acosf
+pub fn acosf(f32 x):f32
 
-pub #linkid acosh
-fn acosh(f64 x):f64
+#linkid acosh
+pub fn acosh(f64 x):f64
 
-pub #linkid acoshf
-fn acoshf(f32 x):f32
+#linkid acoshf
+pub fn acoshf(f32 x):f32
 
-pub #linkid asin
-fn asin(f64 x):f64
+#linkid asin
+pub fn asin(f64 x):f64
 
-pub #linkid asinf
-fn asinf(f32 x):f32
+#linkid asinf
+pub fn asinf(f32 x):f32
 
-pub #linkid asinh
-fn asinh(f64 x):f64
+#linkid asinh
+pub fn asinh(f64 x):f64
 
-pub #linkid asinhf
-fn asinhf(f32 x):f32
+#linkid asinhf
+pub fn asinhf(f32 x):f32
 
-pub #linkid atan
-fn atan(f64 x):f64
+#linkid atan
+pub fn atan(f64 x):f64
 
-pub #linkid atanf
-fn atanf(f32 x):f32
+#linkid atanf
+pub fn atanf(f32 x):f32
 
-pub #linkid atan2
-fn atan2(f64 y, f64 x):f64
+#linkid atan2
+pub fn atan2(f64 y, f64 x):f64
 
-pub #linkid atan2f
-fn atan2f(f32 y, f32 x):f32
+#linkid atan2f
+pub fn atan2f(f32 y, f32 x):f32
 
-pub #linkid cos
-fn cos(f64 x):f64
+#linkid cos
+pub fn cos(f64 x):f64
 
-pub #linkid cosf
-fn cosf(f32 x):f32
+#linkid cosf
+pub fn cosf(f32 x):f32
 
-pub #linkid sin
-fn sin(f64 x):f64
+#linkid sin
+pub fn sin(f64 x):f64
 
-pub #linkid sinf
-fn sinf(f32 x):f32
+#linkid sinf
+pub fn sinf(f32 x):f32
 
-pub #linkid tan
-fn tan(f64 x):f64
+#linkid tan
+pub fn tan(f64 x):f64
 
-pub #linkid tanf
-fn tanf(f32 x):f32
+#linkid tanf
+pub fn tanf(f32 x):f32
 
-pub #linkid atanh
-fn atanh(f64 x):f64
+#linkid atanh
+pub fn atanh(f64 x):f64
 
-pub #linkid atanhf
-fn atanhf(f32 x):f32
+#linkid atanhf
+pub fn atanhf(f32 x):f32
 
-pub #linkid cosh
-fn cosh(f64 x):f64
+#linkid cosh
+pub fn cosh(f64 x):f64
 
-pub #linkid coshf
-fn coshf(f32 x):f32
+#linkid coshf
+pub fn coshf(f32 x):f32
 
-pub #linkid sinh
-fn sinh(f64 x):f64
+#linkid sinh
+pub fn sinh(f64 x):f64
 
-pub #linkid sinhf
-fn sinhf(f32 x):f32
+#linkid sinhf
+pub fn sinhf(f32 x):f32
 
-pub #linkid sqrt
-fn sqrt(f64 x):f64
+#linkid sqrt
+pub fn sqrt(f64 x):f64
 
-pub #linkid sqrtf
-fn sqrtf(f32 x):f32
+#linkid sqrtf
+pub fn sqrtf(f32 x):f32
 
-pub #linkid tanh
-fn tanh(f64 x):f64
+#linkid tanh
+pub fn tanh(f64 x):f64
 
-pub #linkid tanhf
-fn tanhf(f32 x):f32
+#linkid tanhf
+pub fn tanhf(f32 x):f32
 
-pub #linkid exp
-fn exp(f64 x):f64
+#linkid exp
+pub fn exp(f64 x):f64
 
-pub #linkid expf
-fn expf(f32 x):f32
+#linkid expf
+pub fn expf(f32 x):f32
 
-pub #linkid exp2
-fn exp2(f64 x):f64
+#linkid exp2
+pub fn exp2(f64 x):f64
 
-pub #linkid exp2f
-fn exp2f(f32 x):f32
+#linkid exp2f
+pub fn exp2f(f32 x):f32
 
-pub #linkid expm1
-fn expm1(f64 x):f64
+#linkid expm1
+pub fn expm1(f64 x):f64
 
-pub #linkid expm1f
-fn expm1f(f32 x):f32
+#linkid expm1f
+pub fn expm1f(f32 x):f32
 
-pub #linkid fabs
-fn fabs(f64 x):f64
+#linkid fabs
+pub fn fabs(f64 x):f64
 
-pub #linkid fabsf
-fn fabsf(f32 x):f32
+#linkid fabsf
+pub fn fabsf(f32 x):f32
 
-pub #linkid log
-fn log(f64 x):f64
+#linkid log
+pub fn log(f64 x):f64
 
-pub #linkid logf
-fn logf(f32 x):f32
+#linkid logf
+pub fn logf(f32 x):f32
 
-pub #linkid log10
-fn log10(f64 x):f64
+#linkid log10
+pub fn log10(f64 x):f64
 
-pub #linkid log10f
-fn log10f(f32 x):f32
+#linkid log10f
+pub fn log10f(f32 x):f32
 
-pub #linkid log1p
-fn log1p(f64 x):f64
+#linkid log1p
+pub fn log1p(f64 x):f64
 
-pub #linkid log1pf
-fn log1pf(f32 x):f32
+#linkid log1pf
+pub fn log1pf(f32 x):f32
 
-pub #linkid log2
-fn log2(f64 x):f64
+#linkid log2
+pub fn log2(f64 x):f64
 
-pub #linkid log2f
-fn log2f(f32 x):f32
+#linkid log2f
+pub fn log2f(f32 x):f32
 
-pub #linkid logb
-fn logb(f64 x):f64
+#linkid logb
+pub fn logb(f64 x):f64
 
-pub #linkid logbf
-fn logbf(f32 x):f32
+#linkid logbf
+pub fn logbf(f32 x):f32
 
 // 幂函数
-pub #linkid pow
-fn pow(f64 x, f64 y):f64
+#linkid pow
+pub fn pow(f64 x, f64 y):f64
 
-pub #linkid powf
-fn powf(f32 x, f32 y):f32
+#linkid powf
+pub fn powf(f32 x, f32 y):f32
 
-pub #linkid cbrt
-fn cbrt(f64 x):f64
+#linkid cbrt
+pub fn cbrt(f64 x):f64
 
-pub #linkid cbrtf
-fn cbrtf(f32 x):f32
+#linkid cbrtf
+pub fn cbrtf(f32 x):f32
 
-pub #linkid hypot
-fn hypot(f64 x, f64 y):f64
+#linkid hypot
+pub fn hypot(f64 x, f64 y):f64
 
-pub #linkid hypotf
-fn hypotf(f32 x, f32 y):f32
+#linkid hypotf
+pub fn hypotf(f32 x, f32 y):f32
 
-pub #linkid ceil
-fn ceil(f64 x):f64
+#linkid ceil
+pub fn ceil(f64 x):f64
 
-pub #linkid ceilf
-fn ceilf(f32 x):f32
+#linkid ceilf
+pub fn ceilf(f32 x):f32
 
-pub #linkid floor
-fn floor(f64 x):f64
+#linkid floor
+pub fn floor(f64 x):f64
 
-pub #linkid floorf
-fn floorf(f32 x):f32
+#linkid floorf
+pub fn floorf(f32 x):f32
 
-pub #linkid trunc
-fn trunc(f64 x):f64
+#linkid trunc
+pub fn trunc(f64 x):f64
 
-pub #linkid truncf
-fn truncf(f32 x):f32
+#linkid truncf
+pub fn truncf(f32 x):f32
 
-pub #linkid rint
-fn rint(f64 x):f64
+#linkid rint
+pub fn rint(f64 x):f64
 
-pub #linkid rintf
-fn rintf(f32 x):f32
+#linkid rintf
+pub fn rintf(f32 x):f32
 
-pub #linkid nearbyint
-fn nearbyint(f64 x):f64
+#linkid nearbyint
+pub fn nearbyint(f64 x):f64
 
-pub #linkid nearbyintf
-fn nearbyintf(f32 x):f32
+#linkid nearbyintf
+pub fn nearbyintf(f32 x):f32
 
-pub #linkid lrint
-fn lrint(f64 x):i64
+#linkid lrint
+pub fn lrint(f64 x):i64
 
-pub #linkid lrintf
-fn lrintf(f32 x):i64
+#linkid lrintf
+pub fn lrintf(f32 x):i64
 
-pub #linkid llrint
-fn llrint(f64 x):i64
+#linkid llrint
+pub fn llrint(f64 x):i64
 
-pub #linkid llrintf
-fn llrintf(f32 x):i64
+#linkid llrintf
+pub fn llrintf(f32 x):i64
 
-pub #linkid lround
-fn lround(f64 x):i64
+#linkid lround
+pub fn lround(f64 x):i64
 
-pub #linkid lroundf
-fn lroundf(f32 x):i64
+#linkid lroundf
+pub fn lroundf(f32 x):i64
 
-pub #linkid llround
-fn llround(f64 x):i64
+#linkid llround
+pub fn llround(f64 x):i64
 
-pub #linkid llroundf
-fn llroundf(f32 x):i64
+#linkid llroundf
+pub fn llroundf(f32 x):i64
 
-pub #linkid copysign
-fn copysign(f64 x, f64 y):f64
+#linkid copysign
+pub fn copysign(f64 x, f64 y):f64
 
-pub #linkid copysignf
-fn copysignf(f32 x, f32 y):f32
+#linkid copysignf
+pub fn copysignf(f32 x, f32 y):f32
 
-pub #linkid frexp
-fn frexp(f64 x, ptr<i32> exp):f64
+#linkid frexp
+pub fn frexp(f64 x, ptr<i32> exp):f64
 
-pub #linkid frexpf
-fn frexpf(f32 x, ptr<i32> exp):f32
+#linkid frexpf
+pub fn frexpf(f32 x, ptr<i32> exp):f32
 
-pub #linkid ldexp
-fn ldexp(f64 x, i32 exp):f64
+#linkid ldexp
+pub fn ldexp(f64 x, i32 exp):f64
 
-pub #linkid ldexpf
-fn ldexpf(f32 x, i32 exp):f32
+#linkid ldexpf
+pub fn ldexpf(f32 x, i32 exp):f32
 
-pub #linkid modf
-fn modf(f64 x, ptr<f64> iptr):f64
+#linkid modf
+pub fn modf(f64 x, ptr<f64> iptr):f64
 
-pub #linkid modff
-fn modff(f32 x, ptr<f32> iptr):f32
+#linkid modff
+pub fn modff(f32 x, ptr<f32> iptr):f32
 
-pub #linkid scalbn
-fn scalbn(f64 x, i32 n):f64
+#linkid scalbn
+pub fn scalbn(f64 x, i32 n):f64
 
-pub #linkid scalbnf
-fn scalbnf(f32 x, i32 n):f32
+#linkid scalbnf
+pub fn scalbnf(f32 x, i32 n):f32
 
-pub #linkid scalbln
-fn scalbln(f64 x, i64 n):f64
+#linkid scalbln
+pub fn scalbln(f64 x, i64 n):f64
 
-pub #linkid scalblnf
-fn scalblnf(f32 x, i64 n):f32
+#linkid scalblnf
+pub fn scalblnf(f32 x, i64 n):f32
 
-pub #linkid round
-fn round(f64 x):f64
+#linkid round
+pub fn round(f64 x):f64
 
-pub #linkid roundf
-fn roundf(f32 x):f32
+#linkid roundf
+pub fn roundf(f32 x):f32
 
-pub #linkid ilogb
-fn ilogb(f64 x):i32
+#linkid ilogb
+pub fn ilogb(f64 x):i32
 
-pub #linkid ilogbf
-fn ilogbf(f32 x):i32
+#linkid ilogbf
+pub fn ilogbf(f32 x):i32
 
 // 浮点余数和商函数
-pub #linkid fmod
-fn fmod(f64 x, f64 y):f64
+#linkid fmod
+pub fn fmod(f64 x, f64 y):f64
 
-pub #linkid fmodf
-fn fmodf(f32 x, f32 y):f32
+#linkid fmodf
+pub fn fmodf(f32 x, f32 y):f32
 
-pub #linkid remainder
-fn remainder(f64 x, f64 y):f64
+#linkid remainder
+pub fn remainder(f64 x, f64 y):f64
 
-pub #linkid remainderf
-fn remainderf(f32 x, f32 y):f32
+#linkid remainderf
+pub fn remainderf(f32 x, f32 y):f32
 
-pub #linkid remquo
-fn remquo(f64 x, f64 y, ptr<i32> quo):f64
+#linkid remquo
+pub fn remquo(f64 x, f64 y, ptr<i32> quo):f64
 
-pub #linkid remquof
-fn remquof(f32 x, f32 y, ptr<i32> quo):f32
+#linkid remquof
+pub fn remquof(f32 x, f32 y, ptr<i32> quo):f32
 
-pub #linkid fmax
-fn fmax(f64 x, f64 y):f64
+#linkid fmax
+pub fn fmax(f64 x, f64 y):f64
 
-pub #linkid fmaxf
-fn fmaxf(f32 x, f32 y):f32
+#linkid fmaxf
+pub fn fmaxf(f32 x, f32 y):f32
 
-pub #linkid fmin
-fn fmin(f64 x, f64 y):f64
+#linkid fmin
+pub fn fmin(f64 x, f64 y):f64
 
-pub #linkid fminf
-fn fminf(f32 x, f32 y):f32
+#linkid fminf
+pub fn fminf(f32 x, f32 y):f32
 
-pub #linkid fdim
-fn fdim(f64 x, f64 y):f64
+#linkid fdim
+pub fn fdim(f64 x, f64 y):f64
 
-pub #linkid fdimf
-fn fdimf(f32 x, f32 y):f32
+#linkid fdimf
+pub fn fdimf(f32 x, f32 y):f32
 
 // 融合乘加函数
-pub #linkid fma
-fn fma(f64 x, f64 y, f64 z):f64
+#linkid fma
+pub fn fma(f64 x, f64 y, f64 z):f64
 
-pub #linkid fmaf
-fn fmaf(f32 x, f32 y, f32 z):f32
+#linkid fmaf
+pub fn fmaf(f32 x, f32 y, f32 z):f32
 
 // 特殊函数
-pub #linkid erf
-fn erf(f64 x):f64
+#linkid erf
+pub fn erf(f64 x):f64
 
-pub #linkid erff
-fn erff(f32 x):f32
+#linkid erff
+pub fn erff(f32 x):f32
 
-pub #linkid erfc
-fn erfc(f64 x):f64
+#linkid erfc
+pub fn erfc(f64 x):f64
 
-pub #linkid erfcf
-fn erfcf(f32 x):f32
+#linkid erfcf
+pub fn erfcf(f32 x):f32
 
-pub #linkid lgamma
-fn lgamma(f64 x):f64
+#linkid lgamma
+pub fn lgamma(f64 x):f64
 
-pub #linkid lgammaf
-fn lgammaf(f32 x):f32
+#linkid lgammaf
+pub fn lgammaf(f32 x):f32
 
-pub #linkid tgamma
-fn tgamma(f64 x):f64
+#linkid tgamma
+pub fn tgamma(f64 x):f64
 
-pub #linkid tgammaf
-fn tgammaf(f32 x):f32
+#linkid tgammaf
+pub fn tgammaf(f32 x):f32
 
 // NaN 函数
-pub #linkid nan
-fn nan(cstr tagp):f64
+#linkid nan
+pub fn nan(cstr tagp):f64
 
-pub #linkid nanf
-fn nanf(cstr tagp):f32
+#linkid nanf
+pub fn nanf(cstr tagp):f32
 
 // 下一个可表示值函数
-pub #linkid nextafter
-fn nextafter(f64 x, f64 y):f64
+#linkid nextafter
+pub fn nextafter(f64 x, f64 y):f64
 
-pub #linkid nextafterf
-fn nextafterf(f32 x, f32 y):f32
+#linkid nextafterf
+pub fn nextafterf(f32 x, f32 y):f32
 
-pub #linkid nexttoward
-fn nexttoward(f64 x, f64 y):f64
+#linkid nexttoward
+pub fn nexttoward(f64 x, f64 y):f64
 
-pub #linkid nexttowardf
-fn nexttowardf(f32 x, f64 y):f32
+#linkid nexttowardf
+pub fn nexttowardf(f32 x, f64 y):f32
 
 // Bessel 函数 (POSIX 扩展)
-pub #linkid j0
-fn j0(f64 x):f64
+#linkid j0
+pub fn j0(f64 x):f64
 
-pub #linkid j0f
-fn j0f(f32 x):f32
+#linkid j0f
+pub fn j0f(f32 x):f32
 
-pub #linkid j1
-fn j1(f64 x):f64
+#linkid j1
+pub fn j1(f64 x):f64
 
-pub #linkid j1f
-fn j1f(f32 x):f32
+#linkid j1f
+pub fn j1f(f32 x):f32
 
-pub #linkid jn
-fn jn(i32 n, f64 x):f64
+#linkid jn
+pub fn jn(i32 n, f64 x):f64
 
-pub #linkid jnf
-fn jnf(i32 n, f32 x):f32
+#linkid jnf
+pub fn jnf(i32 n, f32 x):f32
 
-pub #linkid y0
-fn y0(f64 x):f64
+#linkid y0
+pub fn y0(f64 x):f64
 
-pub #linkid y0f
-fn y0f(f32 x):f32
+#linkid y0f
+pub fn y0f(f32 x):f32
 
-pub #linkid y1
-fn y1(f64 x):f64
+#linkid y1
+pub fn y1(f64 x):f64
 
-pub #linkid y1f
-fn y1f(f32 x):f32
+#linkid y1f
+pub fn y1f(f32 x):f32
 
-pub #linkid yn
-fn yn(i32 n, f64 x):f64
+#linkid yn
+pub fn yn(i32 n, f64 x):f64
 
-pub #linkid ynf
-fn ynf(i32 n, f32 x):f32
+#linkid ynf
+pub fn ynf(i32 n, f32 x):f32
 
 // GNU/BSD 扩展
-pub #linkid drem
-fn drem(f64 x, f64 y):f64
+#linkid drem
+pub fn drem(f64 x, f64 y):f64
 
-pub #linkid dremf
-fn dremf(f32 x, f32 y):f32
+#linkid dremf
+pub fn dremf(f32 x, f32 y):f32
 
-pub #linkid finite
-fn finite(f64 x):i32
+#linkid finite
+pub fn finite(f64 x):i32
 
-pub #linkid finitef
-fn finitef(f32 x):i32
+#linkid finitef
+pub fn finitef(f32 x):i32
 
-pub #linkid scalb
-fn scalb(f64 x, f64 n):f64
+#linkid scalb
+pub fn scalb(f64 x, f64 n):f64
 
-pub #linkid scalbf
-fn scalbf(f32 x, f32 n):f32
+#linkid scalbf
+pub fn scalbf(f32 x, f32 n):f32
 
-pub #linkid significand
-fn significand(f64 x):f64
+#linkid significand
+pub fn significand(f64 x):f64
 
-pub #linkid significandf
-fn significandf(f32 x):f32
+#linkid significandf
+pub fn significandf(f32 x):f32
 
-pub #linkid lgamma_r
-fn lgamma_r(f64 x, ptr<i32> signgamp):f64
+#linkid lgamma_r
+pub fn lgamma_r(f64 x, ptr<i32> signgamp):f64
 
-pub #linkid lgammaf_r
-fn lgammaf_r(f32 x, ptr<i32> signgamp):f32
+#linkid lgammaf_r
+pub fn lgammaf_r(f32 x, ptr<i32> signgamp):f32
 
-pub #linkid sincos
-fn sincos(f64 x, ptr<f64> sin, ptr<f64> cos):void
+#linkid sincos
+pub fn sincos(f64 x, ptr<f64> sin, ptr<f64> cos):void
 
-pub #linkid sincosf
-fn sincosf(f32 x, ptr<f32> sin, ptr<f32> cos):void
+#linkid sincosf
+pub fn sincosf(f32 x, ptr<f32> sin, ptr<f32> cos):void
 
-pub #linkid exp10
-fn exp10(f64 x):f64
+#linkid exp10
+pub fn exp10(f64 x):f64
 
-pub #linkid exp10f
-fn exp10f(f32 x):f32
+#linkid exp10f
+pub fn exp10f(f32 x):f32
 
-pub #linkid pow10
-fn pow10(f64 x):f64
+#linkid pow10
+pub fn pow10(f64 x):f64
 
-pub #linkid pow10f
-fn pow10f(f32 x):f32
+#linkid pow10f
+pub fn pow10f(f32 x):f32
 
 
 // time.h
@@ -1172,24 +1172,24 @@ pub type tm = struct {
 }
 
 // Basic time functions
-pub #linkid time
-fn time(ptr<time_t> t):time_t
+#linkid time
+pub fn time(ptr<time_t> t):time_t
 
-pub #linkid clock
-fn clock():clock_t
+#linkid clock
+pub fn clock():clock_t
 
-pub #linkid difftime
-fn difftime(time_t time1, time_t time0):f64
+#linkid difftime
+pub fn difftime(time_t time1, time_t time0):f64
 
-pub #linkid mktime
-fn mktime(ptr<tm> time_info):time_t
+#linkid mktime
+pub fn mktime(ptr<tm> time_info):time_t
 
 // Time formatting
-pub #linkid strftime
-fn strftime(cstr s, u64 size, cstr format, ptr<tm> time_info):u64
+#linkid strftime
+pub fn strftime(cstr s, u64 size, cstr format, ptr<tm> time_info):u64
 
-pub #linkid strftime_l
-fn strftime_l(cstr s, u64 size, cstr format, ptr<tm> time_info, locale_t locale):u64
+#linkid strftime_l
+pub fn strftime_l(cstr s, u64 size, cstr format, ptr<tm> time_info, locale_t locale):u64
 
 // Time conversion functions
 pub fn localtime(ptr<time_t> timestamp):ptr<tm> {
@@ -1200,208 +1200,208 @@ pub fn gmtime(ptr<time_t> timestamp):ptr<tm> {
     return cross.gmtime(timestamp as anyptr) as ptr<tm>
 }
 
-pub #linkid asctime
-fn asctime(ptr<tm> tm):cstr
+#linkid asctime
+pub fn asctime(ptr<tm> tm):cstr
 
-pub #linkid ctime
-fn ctime(ptr<time_t> timestamp):cstr
+#linkid ctime
+pub fn ctime(ptr<time_t> timestamp):cstr
 
 // Thread-safe versions
-pub #linkid localtime_r
-fn localtime_r(ptr<time_t> timestamp, ptr<tm> result):ptr<tm>
+#linkid localtime_r
+pub fn localtime_r(ptr<time_t> timestamp, ptr<tm> result):ptr<tm>
 
-pub #linkid gmtime_r
-fn gmtime_r(ptr<time_t> timestamp, ptr<tm> result):ptr<tm>
+#linkid gmtime_r
+pub fn gmtime_r(ptr<time_t> timestamp, ptr<tm> result):ptr<tm>
 
-pub #linkid asctime_r
-fn asctime_r(ptr<tm> tm, cstr buf):cstr
+#linkid asctime_r
+pub fn asctime_r(ptr<tm> tm, cstr buf):cstr
 
-pub #linkid ctime_r
-fn ctime_r(ptr<time_t> timestamp, cstr buf):cstr
+#linkid ctime_r
+pub fn ctime_r(ptr<time_t> timestamp, cstr buf):cstr
 
 // Time parsing
-pub #linkid strptime
-fn strptime(cstr s, cstr format, ptr<tm> tm):cstr
+#linkid strptime
+pub fn strptime(cstr s, cstr format, ptr<tm> tm):cstr
 
 // High-resolution time functions
-pub #linkid timespec_get
-fn timespec_get(ptr<timespec> ts, i32 base):i32
+#linkid timespec_get
+pub fn timespec_get(ptr<timespec> ts, i32 base):i32
 
-pub #linkid nanosleep
-fn nanosleep(ptr<timespec> req, ptr<timespec> rem):i32
+#linkid nanosleep
+pub fn nanosleep(ptr<timespec> req, ptr<timespec> rem):i32
 
 // Clock functions
-pub #linkid clock_getres
-fn clock_getres(clockid_t clk_id, ptr<timespec> res):i32
+#linkid clock_getres
+pub fn clock_getres(clockid_t clk_id, ptr<timespec> res):i32
 
-pub #linkid clock_gettime
-fn clock_gettime(clockid_t clk_id, ptr<timespec> tp):i32
+#linkid clock_gettime
+pub fn clock_gettime(clockid_t clk_id, ptr<timespec> tp):i32
 
-pub #linkid clock_settime
-fn clock_settime(clockid_t clk_id, ptr<timespec> tp):i32
+#linkid clock_settime
+pub fn clock_settime(clockid_t clk_id, ptr<timespec> tp):i32
 
-pub #linkid clock_nanosleep
-fn clock_nanosleep(clockid_t clk_id, i32 flags, ptr<timespec> req, ptr<timespec> rem):i32
+#linkid clock_nanosleep
+pub fn clock_nanosleep(clockid_t clk_id, i32 flags, ptr<timespec> req, ptr<timespec> rem):i32
 
-pub #linkid clock_getcpuclockid
-fn clock_getcpuclockid(i32 pid, ptr<clockid_t> clk_id):i32
+#linkid clock_getcpuclockid
+pub fn clock_getcpuclockid(i32 pid, ptr<clockid_t> clk_id):i32
 
 // Timer functions
-pub #linkid timer_create
-fn timer_create(clockid_t clk_id, anyptr sevp, ptr<timer_t> timerid):i32
+#linkid timer_create
+pub fn timer_create(clockid_t clk_id, anyptr sevp, ptr<timer_t> timerid):i32
 
-pub #linkid timer_delete
-fn timer_delete(timer_t timerid):i32
+#linkid timer_delete
+pub fn timer_delete(timer_t timerid):i32
 
-pub #linkid timer_settime
-fn timer_settime(timer_t timerid, i32 flags, ptr<itimerspec> new_value, ptr<itimerspec> old_value):i32
+#linkid timer_settime
+pub fn timer_settime(timer_t timerid, i32 flags, ptr<itimerspec> new_value, ptr<itimerspec> old_value):i32
 
-pub #linkid timer_gettime
-fn timer_gettime(timer_t timerid, ptr<itimerspec> curr_value):i32
+#linkid timer_gettime
+pub fn timer_gettime(timer_t timerid, ptr<itimerspec> curr_value):i32
 
-pub #linkid timer_getoverrun
-fn timer_getoverrun(timer_t timerid):i32
+#linkid timer_getoverrun
+pub fn timer_getoverrun(timer_t timerid):i32
 
 // Timezone functions
-pub #linkid tzset
-fn tzset():void
+#linkid tzset
+pub fn tzset():void
 
 // GNU/BSD extensions
-pub #linkid stime
-fn stime(ptr<time_t> t):i32
+#linkid stime
+pub fn stime(ptr<time_t> t):i32
 
 pub fn timegm(ptr<tm> value):time_t {
     return cross.timegm(value as anyptr) as time_t
 }
 
-pub #linkid getdate
-fn getdate(cstr str):ptr<tm>
+#linkid getdate
+pub fn getdate(cstr str):ptr<tm>
 
 // unistd.h - File operations
-pub #linkid pipe
-fn pipe(anyptr pipefd):i32
+#linkid pipe
+pub fn pipe(anyptr pipefd):i32
 
-pub #linkid pipe2
-fn pipe2(anyptr pipefd, i32 flags):i32
+#linkid pipe2
+pub fn pipe2(anyptr pipefd, i32 flags):i32
 
-pub #linkid close
-fn close(i32 fd):i32
+#linkid close
+pub fn close(i32 fd):i32
 
-pub #linkid posix_close
-fn posix_close(i32 fd, i32 flags):i32
+#linkid posix_close
+pub fn posix_close(i32 fd, i32 flags):i32
 
-pub #linkid dup
-fn dup(i32 oldfd):i32
+#linkid dup
+pub fn dup(i32 oldfd):i32
 
-pub #linkid dup2
-fn dup2(i32 oldfd, i32 newfd):i32
+#linkid dup2
+pub fn dup2(i32 oldfd, i32 newfd):i32
 
-pub #linkid dup3
-fn dup3(i32 oldfd, i32 newfd, i32 flags):i32
+#linkid dup3
+pub fn dup3(i32 oldfd, i32 newfd, i32 flags):i32
 
-pub #linkid lseek
-fn lseek(i32 fd, i64 offset, i32 whence):i64
+#linkid lseek
+pub fn lseek(i32 fd, i64 offset, i32 whence):i64
 
-pub #linkid fsync
-fn fsync(i32 fd):i32
+#linkid fsync
+pub fn fsync(i32 fd):i32
 
-pub #linkid fdatasync
-fn fdatasync(i32 fd):i32
+#linkid fdatasync
+pub fn fdatasync(i32 fd):i32
 
-pub #linkid read
-fn read(i32 fd, anyptr buf, u64 count):i64
+#linkid read
+pub fn read(i32 fd, anyptr buf, u64 count):i64
 
-pub #linkid write
-fn write(i32 fd, anyptr buf, u64 count):i64
+#linkid write
+pub fn write(i32 fd, anyptr buf, u64 count):i64
 
-pub #linkid pread
-fn pread(i32 fd, anyptr buf, u64 count, i64 offset):i64
+#linkid pread
+pub fn pread(i32 fd, anyptr buf, u64 count, i64 offset):i64
 
-pub #linkid pwrite
-fn pwrite(i32 fd, anyptr buf, u64 count, i64 offset):i64
+#linkid pwrite
+pub fn pwrite(i32 fd, anyptr buf, u64 count, i64 offset):i64
 
 // unistd.h - File ownership and permissions
-pub #linkid chown
-fn chown(cstr path, u32 owner, u32 group):i32
+#linkid chown
+pub fn chown(cstr path, u32 owner, u32 group):i32
 
-pub #linkid fchown
-fn fchown(i32 fd, u32 owner, u32 group):i32
+#linkid fchown
+pub fn fchown(i32 fd, u32 owner, u32 group):i32
 
-pub #linkid lchown
-fn lchown(cstr path, u32 owner, u32 group):i32
+#linkid lchown
+pub fn lchown(cstr path, u32 owner, u32 group):i32
 
-pub #linkid fchownat
-fn fchownat(i32 dirfd, cstr path, u32 owner, u32 group, i32 flags):i32
+#linkid fchownat
+pub fn fchownat(i32 dirfd, cstr path, u32 owner, u32 group, i32 flags):i32
 
 // unistd.h - File linking
-pub #linkid link
-fn link(cstr oldpath, cstr newpath):i32
+#linkid link
+pub fn link(cstr oldpath, cstr newpath):i32
 
-pub #linkid linkat
-fn linkat(i32 olddirfd, cstr oldpath, i32 newdirfd, cstr newpath, i32 flags):i32
+#linkid linkat
+pub fn linkat(i32 olddirfd, cstr oldpath, i32 newdirfd, cstr newpath, i32 flags):i32
 
-pub #linkid symlink
-fn symlink(cstr target, cstr linkpath):i32
+#linkid symlink
+pub fn symlink(cstr target, cstr linkpath):i32
 
-pub #linkid symlinkat
-fn symlinkat(cstr target, i32 newdirfd, cstr linkpath):i32
+#linkid symlinkat
+pub fn symlinkat(cstr target, i32 newdirfd, cstr linkpath):i32
 
-pub #linkid readlink
-fn readlink(cstr path, cstr buf, u64 bufsiz):i64
+#linkid readlink
+pub fn readlink(cstr path, cstr buf, u64 bufsiz):i64
 
-pub #linkid readlinkat
-fn readlinkat(i32 dirfd, cstr path, cstr buf, u64 bufsiz):i64
+#linkid readlinkat
+pub fn readlinkat(i32 dirfd, cstr path, cstr buf, u64 bufsiz):i64
 
-pub #linkid unlink
-fn unlink(cstr path):i32
+#linkid unlink
+pub fn unlink(cstr path):i32
 
-pub #linkid unlinkat
-fn unlinkat(i32 dirfd, cstr path, i32 flags):i32
+#linkid unlinkat
+pub fn unlinkat(i32 dirfd, cstr path, i32 flags):i32
 
-pub #linkid rmdir
-fn rmdir(cstr path):i32
+#linkid rmdir
+pub fn rmdir(cstr path):i32
 
-pub #linkid truncate
-fn truncate(cstr path, i64 length):i32
+#linkid truncate
+pub fn truncate(cstr path, i64 length):i32
 
-pub #linkid ftruncate
-fn ftruncate(i32 fd, i64 length):i32
+#linkid ftruncate
+pub fn ftruncate(i32 fd, i64 length):i32
 
 // unistd.h - File access
-pub #linkid access
-fn access(cstr path, i32 mode):i32
+#linkid access
+pub fn access(cstr path, i32 mode):i32
 
-pub #linkid faccessat
-fn faccessat(i32 dirfd, cstr path, i32 mode, i32 flags):i32
+#linkid faccessat
+pub fn faccessat(i32 dirfd, cstr path, i32 mode, i32 flags):i32
 
 // unistd.h - Directory operations
-pub #linkid chdir
-fn chdir(cstr path):i32
+#linkid chdir
+pub fn chdir(cstr path):i32
 
-pub #linkid fchdir
-fn fchdir(i32 fd):i32
+#linkid fchdir
+pub fn fchdir(i32 fd):i32
 
 // unistd.h - Process control
-pub #linkid alarm
-fn alarm(u32 seconds):u32
+#linkid alarm
+pub fn alarm(u32 seconds):u32
 
-pub #linkid sleep
-fn sleep(int second)
+#linkid sleep
+pub fn sleep(int second)
 
-pub #linkid usleep
-fn usleep(u32 usec):i32
+#linkid usleep
+pub fn usleep(u32 usec):i32
 
-pub #linkid pause
-fn pause():i32
+#linkid pause
+pub fn pause():i32
 
-pub #linkid _Fork
-fn _fork():i32
+#linkid _Fork
+pub fn _fork():i32
 
-pub #linkid execve
-fn execve(cstr filename, ptr<cstr> argv, ptr<cstr> envp):i32
+#linkid execve
+pub fn execve(cstr filename, ptr<cstr> argv, ptr<cstr> envp):i32
 
-pub #linkid execv
-fn execv(cstr path, ptr<cstr> argv):i32
+#linkid execv
+pub fn execv(cstr path, ptr<cstr> argv):i32
 
 // not support
 // #linkid execle
@@ -1420,228 +1420,228 @@ fn execv(cstr path, ptr<cstr> argv):i32
 // fn fexecve(i32 fd, ptr<cstr> argv, ptr<cstr> envp):i32
 
 // unistd.h - Process identification
-pub #linkid getpid
-fn getpid():i32
+#linkid getpid
+pub fn getpid():i32
 
-pub #linkid getppid
-fn getppid():i32
+#linkid getppid
+pub fn getppid():i32
 
-pub #linkid getpgrp
-fn getpgrp():i32
+#linkid getpgrp
+pub fn getpgrp():i32
 
-pub #linkid getpgid
-fn getpgid(i32 pid):i32
+#linkid getpgid
+pub fn getpgid(i32 pid):i32
 
-pub #linkid setpgid
-fn setpgid(i32 pid, i32 pgid):i32
+#linkid setpgid
+pub fn setpgid(i32 pid, i32 pgid):i32
 
-pub #linkid setsid
-fn setsid():i32
+#linkid setsid
+pub fn setsid():i32
 
-pub #linkid getsid
-fn getsid(i32 pid):i32
+#linkid getsid
+pub fn getsid(i32 pid):i32
 
-pub #linkid ttyname
-fn ttyname(i32 fd):cstr
+#linkid ttyname
+pub fn ttyname(i32 fd):cstr
 
-pub #linkid ttyname_r
-fn ttyname_r(i32 fd, cstr buf, u64 buflen):i32
+#linkid ttyname_r
+pub fn ttyname_r(i32 fd, cstr buf, u64 buflen):i32
 
-pub #linkid isatty
-fn isatty(i32 fd):i32
+#linkid isatty
+pub fn isatty(i32 fd):i32
 
-pub #linkid tcgetpgrp
-fn tcgetpgrp(i32 fd):i32
+#linkid tcgetpgrp
+pub fn tcgetpgrp(i32 fd):i32
 
-pub #linkid tcsetpgrp
-fn tcsetpgrp(i32 fd, i32 pgrp):i32
+#linkid tcsetpgrp
+pub fn tcsetpgrp(i32 fd, i32 pgrp):i32
 
 // unistd.h - User and group identification
-pub #linkid getuid
-fn getuid():u32
+#linkid getuid
+pub fn getuid():u32
 
-pub #linkid geteuid
-fn geteuid():u32
+#linkid geteuid
+pub fn geteuid():u32
 
-pub #linkid getgid
-fn getgid():u32
+#linkid getgid
+pub fn getgid():u32
 
-pub #linkid getegid
-fn getegid():u32
+#linkid getegid
+pub fn getegid():u32
 
-pub #linkid getgroups
-fn getgroups(i32 size, ptr<u32> list):i32
+#linkid getgroups
+pub fn getgroups(i32 size, ptr<u32> list):i32
 
-pub #linkid setuid
-fn setuid(u32 uid):i32
+#linkid setuid
+pub fn setuid(u32 uid):i32
 
-pub #linkid seteuid
-fn seteuid(u32 euid):i32
+#linkid seteuid
+pub fn seteuid(u32 euid):i32
 
-pub #linkid setgid
-fn setgid(u32 gid):i32
+#linkid setgid
+pub fn setgid(u32 gid):i32
 
-pub #linkid setegid
-fn setegid(u32 egid):i32
+#linkid setegid
+pub fn setegid(u32 egid):i32
 
 // unistd.h - Login and hostname
-pub #linkid getlogin
-fn getlogin():cstr
+#linkid getlogin
+pub fn getlogin():cstr
 
-pub #linkid getlogin_r
-fn getlogin_r(cstr buf, u64 bufsize):i32
+#linkid getlogin_r
+pub fn getlogin_r(cstr buf, u64 bufsize):i32
 
-pub #linkid gethostname
-fn gethostname(cstr name, u64 len):i32
+#linkid gethostname
+pub fn gethostname(cstr name, u64 len):i32
 
-pub #linkid ctermid
-fn ctermid(cstr s):cstr
+#linkid ctermid
+pub fn ctermid(cstr s):cstr
 
 // unistd.h - Command line options
-pub #linkid getopt
-fn getopt(i32 argc, ptr<cstr> argv, cstr optstring):i32
+#linkid getopt
+pub fn getopt(i32 argc, ptr<cstr> argv, cstr optstring):i32
 
 // unistd.h - Configuration
-pub #linkid pathconf
-fn pathconf(cstr path, i32 name):i64
+#linkid pathconf
+pub fn pathconf(cstr path, i32 name):i64
 
-pub #linkid fpathconf
-fn fpathconf(i32 fd, i32 name):i64
+#linkid fpathconf
+pub fn fpathconf(i32 fd, i32 name):i64
 
-pub #linkid sysconf
-fn sysconf(i32 name):i64
+#linkid sysconf
+pub fn sysconf(i32 name):i64
 
-pub #linkid confstr
-fn confstr(i32 name, cstr buf, u64 len):u64
+#linkid confstr
+pub fn confstr(i32 name, cstr buf, u64 len):u64
 
 // unistd.h - POSIX extensions
-pub #linkid setreuid
-fn setreuid(u32 ruid, u32 euid):i32
+#linkid setreuid
+pub fn setreuid(u32 ruid, u32 euid):i32
 
-pub #linkid setregid
-fn setregid(u32 rgid, u32 egid):i32
+#linkid setregid
+pub fn setregid(u32 rgid, u32 egid):i32
 
-pub #linkid lockf
-fn lockf(i32 fd, i32 cmd, i64 len):i32
+#linkid lockf
+pub fn lockf(i32 fd, i32 cmd, i64 len):i32
 
-pub #linkid gethostid
-fn gethostid():i64
+#linkid gethostid
+pub fn gethostid():i64
 
-pub #linkid nice
-fn nice(i32 inc):i32
+#linkid nice
+pub fn nice(i32 inc):i32
 
-pub #linkid sync
-fn sync():void
+#linkid sync
+pub fn sync():void
 
-pub #linkid setpgrp
-fn setpgrp():i32
+#linkid setpgrp
+pub fn setpgrp():i32
 
-pub #linkid crypt
-fn crypt(cstr key, cstr salt):cstr
+#linkid crypt
+pub fn crypt(cstr key, cstr salt):cstr
 
-pub #linkid encrypt
-fn encrypt(cstr block, i32 edflag):void
+#linkid encrypt
+pub fn encrypt(cstr block, i32 edflag):void
 
-pub #linkid swab
-fn swab(anyptr from, anyptr to, i64 n):void
+#linkid swab
+pub fn swab(anyptr from, anyptr to, i64 n):void
 
-pub #linkid ualarm
-fn ualarm(u32 value, u32 interval):u32
+#linkid ualarm
+pub fn ualarm(u32 value, u32 interval):u32
 
 // unistd.h - BSD/GNU extensions
-pub #linkid brk
-fn brk(anyptr addr):i32
+#linkid brk
+pub fn brk(anyptr addr):i32
 
-pub #linkid sbrk
-fn sbrk(i64 increment):anyptr
+#linkid sbrk
+pub fn sbrk(i64 increment):anyptr
 
-pub #linkid vfork
-fn vfork():i32
+#linkid vfork
+pub fn vfork():i32
 
-pub #linkid vhangup
-fn vhangup():i32
+#linkid vhangup
+pub fn vhangup():i32
 
-pub #linkid chroot
-fn chroot(cstr path):i32
+#linkid chroot
+pub fn chroot(cstr path):i32
 
-pub #linkid getpagesize
-fn getpagesize():i32
+#linkid getpagesize
+pub fn getpagesize():i32
 
-pub #linkid getdtablesize
-fn getdtablesize():i32
+#linkid getdtablesize
+pub fn getdtablesize():i32
 
-pub #linkid sethostname
-fn sethostname(cstr name, u64 len):i32
+#linkid sethostname
+pub fn sethostname(cstr name, u64 len):i32
 
-pub #linkid getdomainname
-fn getdomainname(cstr name, u64 len):i32
+#linkid getdomainname
+pub fn getdomainname(cstr name, u64 len):i32
 
-pub #linkid setdomainname
-fn setdomainname(cstr name, u64 len):i32
+#linkid setdomainname
+pub fn setdomainname(cstr name, u64 len):i32
 
-pub #linkid setgroups
-fn setgroups(u64 size, ptr<u32> list):i32
+#linkid setgroups
+pub fn setgroups(u64 size, ptr<u32> list):i32
 
-pub #linkid getpass
-fn getpass(cstr prompt):cstr
+#linkid getpass
+pub fn getpass(cstr prompt):cstr
 
-pub #linkid daemon
-fn daemon(i32 nochdir, i32 noclose):i32
+#linkid daemon
+pub fn daemon(i32 nochdir, i32 noclose):i32
 
-pub #linkid setusershell
-fn setusershell():void
+#linkid setusershell
+pub fn setusershell():void
 
-pub #linkid endusershell
-fn endusershell():void
+#linkid endusershell
+pub fn endusershell():void
 
-pub #linkid getusershell
-fn getusershell():cstr
+#linkid getusershell
+pub fn getusershell():cstr
 
-pub #linkid acct
-fn acct(cstr filename):i32
+#linkid acct
+pub fn acct(cstr filename):i32
 
 // #linkid syscall
 // fn syscall(i64 number, ...):i64
 
-pub #linkid execvpe
-fn execvpe(cstr file, ptr<cstr> argv, ptr<cstr> envp):i32
+#linkid execvpe
+pub fn execvpe(cstr file, ptr<cstr> argv, ptr<cstr> envp):i32
 
-pub #linkid issetugid
-fn issetugid():i32
+#linkid issetugid
+pub fn issetugid():i32
 
-pub #linkid getentropy
-fn getentropy(anyptr buffer, u64 length):i32
+#linkid getentropy
+pub fn getentropy(anyptr buffer, u64 length):i32
 
 // unistd.h - GNU extensions
-pub #os linux #linkid setresuid
-fn setresuid(u32 ruid, u32 euid, u32 suid):i32
+#os linux #linkid setresuid
+pub fn setresuid(u32 ruid, u32 euid, u32 suid):i32
 
-pub #os linux #linkid setresgid
-fn setresgid(u32 rgid, u32 egid, u32 sgid):i32
+#os linux #linkid setresgid
+pub fn setresgid(u32 rgid, u32 egid, u32 sgid):i32
 
-pub #linkid getresuid
-fn getresuid(ptr<u32> ruid, ptr<u32> euid, ptr<u32> suid):i32
+#linkid getresuid
+pub fn getresuid(ptr<u32> ruid, ptr<u32> euid, ptr<u32> suid):i32
 
-pub #os linux #linkid getresgid
-fn getresgid(ptr<u32> rgid, ptr<u32> egid, ptr<u32> sgid):i32
+#os linux #linkid getresgid
+pub fn getresgid(ptr<u32> rgid, ptr<u32> egid, ptr<u32> sgid):i32
 
-pub #linkid get_current_dir_name
-fn get_current_dir_name():cstr
+#linkid get_current_dir_name
+pub fn get_current_dir_name():cstr
 
-pub #linkid syncfs
-fn syncfs(i32 fd):i32
+#linkid syncfs
+pub fn syncfs(i32 fd):i32
 
-pub #linkid euidaccess
-fn euidaccess(cstr pathname, i32 mode):i32
+#linkid euidaccess
+pub fn euidaccess(cstr pathname, i32 mode):i32
 
-pub #linkid eaccess
-fn eaccess(cstr pathname, i32 mode):i32
+#linkid eaccess
+pub fn eaccess(cstr pathname, i32 mode):i32
 
-pub #linkid copy_file_range
-fn copy_file_range(i32 fd_in, ptr<i64> off_in, i32 fd_out, ptr<i64> off_out, u64 len, u32 flags):i64
+#linkid copy_file_range
+pub fn copy_file_range(i32 fd_in, ptr<i64> off_in, i32 fd_out, ptr<i64> off_out, u64 len, u32 flags):i64
 
-pub #linkid gettid
-fn gettid():i32
+#linkid gettid
+pub fn gettid():i32
 
 // fcntl.h
 // Type definitions
@@ -1825,76 +1825,76 @@ pub const SPLICE_F_MORE = 4
 pub const SPLICE_F_GIFT = 8
 
 // Basic file operations
-pub #linkid creat
-fn creat(cstr pathname, mode_t mode):i32
+#linkid creat
+pub fn creat(cstr pathname, mode_t mode):i32
 
-pub #linkid fcntl
-fn fcntl(i32 fd, i32 cmd, anyptr flag):i32
+#linkid fcntl
+pub fn fcntl(i32 fd, i32 cmd, anyptr flag):i32
 
-pub #linkid open
-fn open(cstr pathname, i32 flags, u32 mode):i32
+#linkid open
+pub fn open(cstr pathname, i32 flags, u32 mode):i32
 
-pub #linkid openat
-fn openat(i32 dirfd, cstr pathname, i32 flags, u32 mode):i32
+#linkid openat
+pub fn openat(i32 dirfd, cstr pathname, i32 flags, u32 mode):i32
 
 // POSIX advisory functions
-pub #linkid posix_fadvise
-fn posix_fadvise(i32 fd, off_t offset, off_t len, i32 advice):i32
+#linkid posix_fadvise
+pub fn posix_fadvise(i32 fd, off_t offset, off_t len, i32 advice):i32
 
-pub #linkid posix_fallocate
-fn posix_fallocate(i32 fd, off_t offset, off_t len):i32
+#linkid posix_fallocate
+pub fn posix_fallocate(i32 fd, off_t offset, off_t len):i32
 
 // GNU/Linux extensions
-pub #linkid fallocate
-fn fallocate(i32 fd, i32 mode, off_t offset, off_t len):i32
+#linkid fallocate
+pub fn fallocate(i32 fd, i32 mode, off_t offset, off_t len):i32
 
-pub #linkid name_to_handle_at
-fn name_to_handle_at(i32 dirfd, cstr pathname, anyptr handle, ptr<i32> mount_id, i32 flags):i32
+#linkid name_to_handle_at
+pub fn name_to_handle_at(i32 dirfd, cstr pathname, anyptr handle, ptr<i32> mount_id, i32 flags):i32
 
-pub #linkid open_by_handle_at
-fn open_by_handle_at(i32 mount_fd, anyptr handle, i32 flags):i32
+#linkid open_by_handle_at
+pub fn open_by_handle_at(i32 mount_fd, anyptr handle, i32 flags):i32
 
-pub #linkid readahead
-fn readahead(i32 fd, off_t offset, u64 count):i64
+#linkid readahead
+pub fn readahead(i32 fd, off_t offset, u64 count):i64
 
-pub #linkid sync_file_range
-fn sync_file_range(i32 fd, off_t offset, off_t nbytes, u32 flags):i32
+#linkid sync_file_range
+pub fn sync_file_range(i32 fd, off_t offset, off_t nbytes, u32 flags):i32
 
 // Splice operations
-pub #linkid vmsplice
-fn vmsplice(i32 fd, anyptr iov, u64 nr_segs, u32 flags):i64
+#linkid vmsplice
+pub fn vmsplice(i32 fd, anyptr iov, u64 nr_segs, u32 flags):i64
 
-pub #linkid splice
-fn splice(i32 fd_in, ptr<off_t> off_in, i32 fd_out, ptr<off_t> off_out, u64 len, u32 flags):i64
+#linkid splice
+pub fn splice(i32 fd_in, ptr<off_t> off_in, i32 fd_out, ptr<off_t> off_out, u64 len, u32 flags):i64
 
-pub #linkid tee
-fn tee(i32 fd_in, i32 fd_out, u64 len, u32 flags):i64
+#linkid tee
+pub fn tee(i32 fd_in, i32 fd_out, u64 len, u32 flags):i64
 
 
 
 // signal.h
-pub #linkid std_args
-fn std_args():[string]
+#linkid std_args
+pub fn std_args():[string]
 
 // 主机顺序转网络顺序
-pub #linkid htons
-fn htons(u16 host):u16
+#linkid htons
+pub fn htons(u16 host):u16
 
-pub #linkid htonl
-fn htonl(u32 host):u32
+#linkid htonl
+pub fn htonl(u32 host):u32
 
 // 网络顺序转主机顺序
-pub #linkid ntohs
-fn ntohs(u16 x):u16
+#linkid ntohs
+pub fn ntohs(u16 x):u16
 
-pub #linkid ntohl
-fn ntohl(u32 x):u32
+#linkid ntohl
+pub fn ntohl(u32 x):u32
 
-pub #linkid inet_pton
-fn inet_pton(i32 family, anyptr src_str, anyptr dst_buf):i32
+#linkid inet_pton
+pub fn inet_pton(i32 family, anyptr src_str, anyptr dst_buf):i32
 
-pub #linkid inet_ntop
-fn inet_ntop(i32 family, anyptr src_buf, anyptr dst_str, i32 len):i32
+#linkid inet_ntop
+pub fn inet_ntop(i32 family, anyptr src_buf, anyptr dst_str, i32 len):i32
 
 /*
  * Protections are chosen from these bits, or-ed together
@@ -1917,8 +1917,8 @@ int MAP_PRIVATE = 0x2
 int MAP_RENAME = 0x20
 
 // 通过空值 options 实现阻塞和非阻塞模式
-pub #linkid waitpid
-fn waitpid(int pid, ptr<int> status, int options):int
+#linkid waitpid
+pub fn waitpid(int pid, ptr<int> status, int options):int
 
 // --- signal 相关 <sys/signalfd.h> 和 <signal.h>
 pub type sigset_t = struct {
@@ -1950,48 +1950,48 @@ pub type signalfd_siginfo_t = struct {
     [u8;48] __pad
 }
 
-pub #linkid sigemptyset
-fn sigemptyset(ref<sigset_t> sigset):i32
+#linkid sigemptyset
+pub fn sigemptyset(ref<sigset_t> sigset):i32
 
-pub #linkid sigaddset
-fn sigaddset(ref<sigset_t> sigset, i32 signo):i32
+#linkid sigaddset
+pub fn sigaddset(ref<sigset_t> sigset, i32 signo):i32
 
-pub #linkid sigfillset
-fn sigfillset(ref<sigset_t> sigset):i32
+#linkid sigfillset
+pub fn sigfillset(ref<sigset_t> sigset):i32
 
-pub #linkid sigprocmask
-fn sigprocmask(i32 how, ref<sigset_t> sigset, ptr<sigset_t> oldset):i32
+#linkid sigprocmask
+pub fn sigprocmask(i32 how, ref<sigset_t> sigset, ptr<sigset_t> oldset):i32
 
-pub #linkid signalfd
-fn signalfd(int fd, ref<sigset_t> mask, i32 flags):i32
+#linkid signalfd
+pub fn signalfd(int fd, ref<sigset_t> mask, i32 flags):i32
 
-pub #linkid prctl
-fn prctl(int option, u64 arg2, u64 arg3, u64 arg4, u64 arg5):int
+#linkid prctl
+pub fn prctl(int option, u64 arg2, u64 arg3, u64 arg4, u64 arg5):int
 
-pub #linkid uv_hrtime
-fn uv_hrtime():u64
+#linkid uv_hrtime
+pub fn uv_hrtime():u64
 
 // 读取当前全局的 errno 编码
-pub #linkid rt_errno
-fn errno():int
+#linkid rt_errno
+pub fn errno():int
 
-pub #linkid rt_get_envs
-fn get_envs():[string]
+#linkid rt_get_envs
+pub fn get_envs():[string]
 
-pub #linkid fork
-fn fork():int
+#linkid fork
+pub fn fork():int
 
-pub #linkid getcwd
-fn getcwd(cstr path, uint size):cstr
+#linkid getcwd
+pub fn getcwd(cstr path, uint size):cstr
 
-pub #linkid mmap
-fn mmap(anyptr addr, int len, int prot, int flags, int fd, int off):anyptr
+#linkid mmap
+pub fn mmap(anyptr addr, int len, int prot, int flags, int fd, int off):anyptr
 
-pub #linkid munmap
-fn munmap(anyptr addr, int len)
+#linkid munmap
+pub fn munmap(anyptr addr, int len)
 
-pub #linkid isprint
-fn isprint(u8 c):bool
+#linkid isprint
+pub fn isprint(u8 c):bool
 
-pub #linkid isspace
-fn isspace(u8 c):bool
+#linkid isspace
+pub fn isspace(u8 c):bool

--- a/std/libc/libc.n
+++ b/std/libc/libc.n
@@ -2,12 +2,12 @@ mod libc
 
 import libc.cross
 
-type cstr = anyptr
+pub type cstr = anyptr
 
-#linkid rt_string_ref
+pub #linkid rt_string_ref
 fn string.to_cstr(*self):cstr
 
-fn to_cfn(anyptr closure):anyptr {
+pub fn to_cfn(anyptr closure):anyptr {
     type fn_t = struct{
         anyptr envs
         anyptr addr
@@ -17,1147 +17,1147 @@ fn to_cfn(anyptr closure):anyptr {
     return c.addr
 }
 
-const AF_INET = 2
-const AF_INET6 = 10
+pub const AF_INET = 2
+pub const AF_INET6 = 10
 
-#linkid rt_string_new
+pub #linkid rt_string_new
 fn cstr.to_string(self):string
 
 // stdlib.h
-#linkid atoi
+pub #linkid atoi
 fn atoi(cstr str):i32
 
-fn atol(cstr str):i64 {
+pub fn atol(cstr str):i64 {
     return cross.atol(str as anyptr)
 }
 
-#linkid atof
+pub #linkid atof
 fn atof(cstr str):f64
 
-#linkid strtof
+pub #linkid strtof
 fn strtof(cstr str, anyptr endptr):f32
 
-#linkid strtod
+pub #linkid strtod
 fn strtod(cstr str, anyptr endptr):f64
 
-fn strtol(cstr str, anyptr endptr, i32 base):i64 {
+pub fn strtol(cstr str, anyptr endptr, i32 base):i64 {
     return cross.strtol(str as anyptr, endptr, base)
 }
 
-fn strtoul(cstr str, anyptr endptr, i32 base):u64 {
+pub fn strtoul(cstr str, anyptr endptr, i32 base):u64 {
     return cross.strtoul(str as anyptr, endptr, base)
 }
 
-#linkid rand
+pub #linkid rand
 fn rand():i32
 
-#linkid srand
+pub #linkid srand
 fn srand(u32 seed):void
 
-#linkid malloc
+pub #linkid malloc
 fn malloc(u64 size):anyptr
 
-#linkid calloc
+pub #linkid calloc
 fn calloc(u64 nmemb, u64 size):anyptr
 
-#linkid realloc
+pub #linkid realloc
 fn realloc(anyptr p, u64 size):anyptr
 
-#linkid free
+pub #linkid free
 fn free(anyptr p):void
 
-#linkid aligned_alloc
+pub #linkid aligned_alloc
 fn aligned_alloc(u64 alignment, u64 size):anyptr
 
-#linkid abort
+pub #linkid abort
 fn abort()
 
-#linkid atexit
+pub #linkid atexit
 fn atexit(anyptr func):i32
 
-#linkid exit
+pub #linkid exit
 fn exit(i32 status)
 
-#linkid _Exit
+pub #linkid _Exit
 fn _exit(i32 status)
 
-#linkid at_quick_exit
+pub #linkid at_quick_exit
 fn at_quick_exit(anyptr func):i32
 
-#linkid quick_exit
+pub #linkid quick_exit
 fn quick_exit(i32 status)
 
-#linkid getenv
+pub #linkid getenv
 fn getenv(cstr name):cstr
 
-#linkid system
+pub #linkid system
 fn system(cstr command):i32
 
-#linkid abs
+pub #linkid abs
 fn abs(i32 x):i32
 
-fn labs(i64 x):i64 {
+pub fn labs(i64 x):i64 {
     if x < 0 {
         return -x
     }
     return x
 }
 
-type div_t = struct {
+pub type div_t = struct {
     i32 quot
     i32 rem
 }
 
-type ldiv_t = struct {
+pub type ldiv_t = struct {
     i64 quot
     i64 rem
 }
 
-#linkid div
+pub #linkid div
 fn div(i32 numer, i32 denom):div_t
 
-fn ldiv(i64 numer, i64 denom):ldiv_t {
+pub fn ldiv(i64 numer, i64 denom):ldiv_t {
     return ldiv_t {
         quot: numer / denom,
         rem: numer % denom,
     }
 }
 
-#linkid mblen
+pub #linkid mblen
 fn mblen(cstr s, u64 n):i32
 
-#linkid mbtowc
+pub #linkid mbtowc
 fn mbtowc(anyptr pwc, cstr s, u64 n):i32
 
-#linkid wctomb
+pub #linkid wctomb
 fn wctomb(cstr s, i32 wc):i32
 
-#linkid mbstowcs
+pub #linkid mbstowcs
 fn mbstowcs(anyptr pwcs, cstr s, u64 n):u64
 
-#linkid wcstombs
+pub #linkid wcstombs
 fn wcstombs(cstr s, anyptr pwcs, u64 n):u64
 
-#linkid posix_memalign
+pub #linkid posix_memalign
 fn posix_memalign(anyptr memptr, u64 alignment, u64 size):i32
 
-#linkid setenv
+pub #linkid setenv
 fn setenv(cstr name, cstr value, i32 overwrite):i32
 
-#linkid unsetenv
+pub #linkid unsetenv
 fn unsetenv(cstr name):i32
 
-#linkid putenv
+pub #linkid putenv
 fn putenv(cstr str):i32
 
-#linkid mkstemp
+pub #linkid mkstemp
 fn mkstemp(cstr template):i32
 
-#linkid mkostemp
+pub #linkid mkostemp
 fn mkostemp(cstr template, i32 flags):i32
 
-#linkid mkdtemp
+pub #linkid mkdtemp
 fn mkdtemp(cstr template):cstr
 
-#linkid mktemp
+pub #linkid mktemp
 fn mktemp(cstr template):cstr
 
-#linkid mkstemps
+pub #linkid mkstemps
 fn mkstemps(cstr template, i32 suffixlen):i32
 
-#linkid mkostemps
+pub #linkid mkostemps
 fn mkostemps(cstr template, i32 suffixlen, i32 flags):i32
 
-#linkid getsubopt
+pub #linkid getsubopt
 fn getsubopt(anyptr optionp, anyptr tokens, anyptr valuep):i32
 
-#linkid rand_r
+pub #linkid rand_r
 fn rand_r(ptr<u32> seed):i32
 
-#linkid realpath
+pub #linkid realpath
 fn realpath(cstr path, cstr resolved_path):cstr
 
-#linkid random
+pub #linkid random
 fn random():i64
 
-#linkid srandom
+pub #linkid srandom
 fn srandom(u32 seed):void
 
-#linkid initstate
+pub #linkid initstate
 fn initstate(u32 seed, cstr state, u64 size):cstr
 
-#linkid setstate
+pub #linkid setstate
 fn setstate(cstr state):cstr
 
-#linkid posix_openpt
+pub #linkid posix_openpt
 fn posix_openpt(i32 flags):i32
 
-#linkid grantpt
+pub #linkid grantpt
 fn grantpt(i32 fd):i32
 
-#linkid unlockpt
+pub #linkid unlockpt
 fn unlockpt(i32 fd):i32
 
-#linkid ptsname_r
+pub #linkid ptsname_r
 fn ptsname_r(i32 fd, cstr buf, u64 buflen):i32
 
-#linkid l64a
+pub #linkid l64a
 fn l64a(i64 value):cstr
 
-#linkid a64l
+pub #linkid a64l
 fn a64l(cstr s):i64
 
-#linkid setkey
+pub #linkid setkey
 fn setkey(cstr key):void
 
-#linkid drand48
+pub #linkid drand48
 fn drand48():f64
 
-#linkid erand48
+pub #linkid erand48
 fn erand48(anyptr xsubi):f64
 
-#linkid lrand48
+pub #linkid lrand48
 fn lrand48():i64
 
-#linkid nrand48
+pub #linkid nrand48
 fn nrand48(anyptr xsubi):i64
 
-#linkid mrand48
+pub #linkid mrand48
 fn mrand48():i64
 
-#linkid jrand48
+pub #linkid jrand48
 fn jrand48(anyptr xsubi):i64
 
-#linkid srand48
+pub #linkid srand48
 fn srand48(i64 seedval):void
 
-#linkid seed48
+pub #linkid seed48
 fn seed48(anyptr seed16v):ptr<u16>
 
-#linkid lcong48
+pub #linkid lcong48
 fn lcong48(anyptr param):void
 
-#linkid valloc
+pub #linkid valloc
 fn valloc(u64 size):anyptr
 
-#linkid memalign
+pub #linkid memalign
 fn memalign(u64 alignment, u64 size):anyptr
 
-#linkid reallocarray
+pub #linkid reallocarray
 fn reallocarray(anyptr p, u64 nmemb, u64 size):anyptr
 
-#linkid getloadavg
+pub #linkid getloadavg
 fn getloadavg(ptr<f64> loadavg, i32 nelem):i32
 
-#linkid ecvt
+pub #linkid ecvt
 fn ecvt(f64 number, i32 ndigits, ptr<i32> decpt, ptr<i32> sign):cstr
 
-#linkid fcvt
+pub #linkid fcvt
 fn fcvt(f64 number, i32 ndigits, ptr<i32> decpt, ptr<i32> sign):cstr
 
-#linkid gcvt
+pub #linkid gcvt
 fn gcvt(f64 number, i32 ndigit, cstr buf):cstr
 
-#linkid secure_getenv
+pub #linkid secure_getenv
 fn secure_getenv(cstr name):cstr
 
 
 // stdio.h
-type fileptr = anyptr
+pub type fileptr = anyptr
 
 // stdio.h constants
-const EOF = -1
-const SEEK_SET = 0
+pub const EOF = -1
+pub const SEEK_SET = 0
 const SEEK_CUR = 1
-const SEEK_END = 2
-const _IOFBF = 0
-const _IOLBF = 1
-const _IONBF = 2
-const BUFSIZ = 1024
-const FILENAME_MAX = 4096
-const FOPEN_MAX = 1000
-const TMP_MAX = 10000
-const L_tmpnam = 20
-const L_ctermid = 20
-const L_cuserid = 20
+pub const SEEK_END = 2
+pub const _IOFBF = 0
+pub const _IOLBF = 1
+pub const _IONBF = 2
+pub const BUFSIZ = 1024
+pub const FILENAME_MAX = 4096
+pub const FOPEN_MAX = 1000
+pub const TMP_MAX = 10000
+pub const L_tmpnam = 20
+pub const L_ctermid = 20
+pub const L_cuserid = 20
 
 // fpos_t type
-type fpos_t = struct {
+pub type fpos_t = struct {
     [u8;16] __opaque
     i64 __lldata
     f64 __align
 }
 
-#linkid fopen
+pub #linkid fopen
 fn fopen(cstr filename, cstr mode):fileptr
 
-#linkid freopen
+pub #linkid freopen
 fn freopen(cstr filename, cstr mode, fileptr stream):fileptr
 
-#linkid fclose
+pub #linkid fclose
 fn fclose(fileptr stream):i32
 
-#linkid remove
+pub #linkid remove
 fn remove(cstr filename):i32
 
-#linkid rename
+pub #linkid rename
 fn rename(cstr old_name, cstr new_name):i32
 
-#linkid feof
+pub #linkid feof
 fn feof(fileptr stream):i32
 
-#linkid ferror
+pub #linkid ferror
 fn ferror(fileptr stream):i32
 
-#linkid fflush
+pub #linkid fflush
 fn fflush(fileptr stream):i32
 
-#linkid clearerr
+pub #linkid clearerr
 fn clearerr(fileptr stream):void
 
-#linkid fseek
+pub #linkid fseek
 fn fseek(fileptr stream, i64 offset, i32 whence):i32
 
-#linkid ftell
+pub #linkid ftell
 fn ftell(fileptr stream):i64
 
-#linkid rewind
+pub #linkid rewind
 fn rewind(fileptr stream):void
 
-#linkid fgetpos
+pub #linkid fgetpos
 fn fgetpos(fileptr stream, ptr<fpos_t> pos):i32
 
-#linkid fsetpos
+pub #linkid fsetpos
 fn fsetpos(fileptr stream, ptr<fpos_t> pos):i32
 
-#linkid fread
+pub #linkid fread
 fn fread(anyptr p, u64 size, u64 nmemb, fileptr stream):u64
 
-#linkid fwrite
+pub #linkid fwrite
 fn fwrite(anyptr p, u64 size, u64 nmemb, fileptr stream):u64
 
-#linkid fgetc
+pub #linkid fgetc
 fn fgetc(fileptr stream):i32
 
-#linkid getc
+pub #linkid getc
 fn getc(fileptr stream):i32
 
-#linkid getchar
+pub #linkid getchar
 fn getchar():i32
 
-#linkid ungetc
+pub #linkid ungetc
 fn ungetc(i32 c, fileptr stream):i32
 
-#linkid fputc
+pub #linkid fputc
 fn fputc(i32 c, fileptr stream):i32
 
-#linkid putc
+pub #linkid putc
 fn putc(i32 c, fileptr stream):i32
 
-#linkid putchar
+pub #linkid putchar
 fn putchar(i32 c):i32
 
-#linkid fgets
+pub #linkid fgets
 fn fgets(cstr s, i32 size, fileptr stream):cstr
 
-#linkid fputs
+pub #linkid fputs
 fn fputs(cstr s, fileptr stream):i32
 
-#linkid puts
+pub #linkid puts
 fn puts(cstr s):i32
 
 // Error handling
-#linkid perror
+pub #linkid perror
 fn perror(cstr s):void
 
 // Buffer control
-#linkid setvbuf
+pub #linkid setvbuf
 fn setvbuf(fileptr stream, cstr buffer, i32 mode, u64 size):i32
 
-#linkid setbuf
+pub #linkid setbuf
 fn setbuf(fileptr stream, cstr buffer):void
 
 // Temporary files
-#linkid tmpnam
+pub #linkid tmpnam
 fn tmpnam(cstr s):cstr
 
-#linkid tmpfile
+pub #linkid tmpfile
 fn tmpfile():fileptr
 
 
 // POSIX extensions
-#linkid fmemopen
+pub #linkid fmemopen
 fn fmemopen(anyptr buffer, u64 size, cstr mode):fileptr
 
-#linkid open_memstream
+pub #linkid open_memstream
 fn open_memstream(ptr<cstr> bufp, ptr<u64> sizep):fileptr
 
-#linkid fdopen
+pub #linkid fdopen
 fn fdopen(i32 fd, cstr mode):fileptr
 
-#linkid popen
+pub #linkid popen
 fn popen(cstr command, cstr t):fileptr
 
-#linkid pclose
+pub #linkid pclose
 fn pclose(fileptr stream):i32
 
-#linkid fileno
+pub #linkid fileno
 fn fileno(fileptr stream):i32
 
-#linkid fseeko
+pub #linkid fseeko
 fn fseeko(fileptr stream, i64 offset, i32 whence):i32
 
-#linkid ftello
+pub #linkid ftello
 fn ftello(fileptr stream):i64
 
 // File locking
-#linkid flockfile
+pub #linkid flockfile
 fn flockfile(fileptr stream):void
 
-#linkid ftrylockfile
+pub #linkid ftrylockfile
 fn ftrylockfile(fileptr stream):i32
 
-#linkid funlockfile
+pub #linkid funlockfile
 fn funlockfile(fileptr stream):void
 
 // Unlocked I/O
-#linkid getc_unlocked
+pub #linkid getc_unlocked
 fn getc_unlocked(fileptr stream):i32
 
-#linkid getchar_unlocked
+pub #linkid getchar_unlocked
 fn getchar_unlocked():i32
 
-#linkid putc_unlocked
+pub #linkid putc_unlocked
 fn putc_unlocked(i32 c, fileptr stream):i32
 
-#linkid putchar_unlocked
+pub #linkid putchar_unlocked
 fn putchar_unlocked(i32 c):i32
 
-#linkid fgetc_unlocked
+pub #linkid fgetc_unlocked
 fn fgetc_unlocked(fileptr stream):i32
 
-#linkid fputc_unlocked
+pub #linkid fputc_unlocked
 fn fputc_unlocked(i32 c, fileptr stream):i32
 
-#linkid fflush_unlocked
+pub #linkid fflush_unlocked
 fn fflush_unlocked(fileptr stream):i32
 
-#linkid fread_unlocked
+pub #linkid fread_unlocked
 fn fread_unlocked(anyptr p, u64 size, u64 nmemb, fileptr stream):u64
 
-#linkid fwrite_unlocked
+pub #linkid fwrite_unlocked
 fn fwrite_unlocked(anyptr p, u64 size, u64 nmemb, fileptr stream):u64
 
-#linkid clearerr_unlocked
+pub #linkid clearerr_unlocked
 fn clearerr_unlocked(fileptr stream):void
 
-#linkid feof_unlocked
+pub #linkid feof_unlocked
 fn feof_unlocked(fileptr stream):i32
 
-#linkid ferror_unlocked
+pub #linkid ferror_unlocked
 fn ferror_unlocked(fileptr stream):i32
 
-#linkid fileno_unlocked
+pub #linkid fileno_unlocked
 fn fileno_unlocked(fileptr stream):i32
 
-#linkid fgets_unlocked
+pub #linkid fgets_unlocked
 fn fgets_unlocked(cstr s, i32 size, fileptr stream):cstr
 
-#linkid fputs_unlocked
+pub #linkid fputs_unlocked
 fn fputs_unlocked(cstr s, fileptr stream):i32
 
 // Line-oriented I/O
-#linkid getdelim
+pub #linkid getdelim
 fn getdelim(ptr<cstr> lineptr, ptr<u64> n, i32 delim, fileptr stream):i64
 
-#linkid getline
+pub #linkid getline
 fn getline(ptr<cstr> lineptr, ptr<u64> n, fileptr stream):i64
 
 // Additional functions
-#linkid renameat
+pub #linkid renameat
 fn renameat(i32 olddirfd, cstr oldpath, i32 newdirfd, cstr newpath):i32
 
-#linkid tempnam
+pub #linkid tempnam
 fn tempnam(cstr dir, cstr pfx):cstr
 
-#linkid cuserid
+pub #linkid cuserid
 fn cuserid(cstr s):cstr
 
-#linkid setlinebuf
+pub #linkid setlinebuf
 fn setlinebuf(fileptr stream):void
 
-#linkid setbuffer
+pub #linkid setbuffer
 fn setbuffer(fileptr stream, cstr buffer, u64 size):void
 
-#linkid getw
+pub #linkid getw
 fn getw(fileptr stream):i32
 
-#linkid putw
+pub #linkid putw
 fn putw(i32 w, fileptr stream):i32
 
-#linkid fgetln
+pub #linkid fgetln
 fn fgetln(fileptr stream, ptr<u64> len):cstr
 
 // Cookie I/O function types
-type cookie_read_function_t = fn(anyptr, cstr, u64):i64
-type cookie_write_function_t = fn(anyptr, cstr, u64):i64
-type cookie_seek_function_t = fn(anyptr, ptr<i64>, i32):i32
-type cookie_close_function_t = fn(anyptr):i32
+pub type cookie_read_function_t = fn(anyptr, cstr, u64):i64
+pub type cookie_write_function_t = fn(anyptr, cstr, u64):i64
+pub type cookie_seek_function_t = fn(anyptr, ptr<i64>, i32):i32
+pub type cookie_close_function_t = fn(anyptr):i32
 
-type cookie_io_functions_t = struct {
+pub type cookie_io_functions_t = struct {
     cookie_read_function_t read
     cookie_write_function_t write
     cookie_seek_function_t seek
     cookie_close_function_t close
 }
 
-#linkid fopencookie
+pub #linkid fopencookie
 fn fopencookie(anyptr cookie, cstr mode, cookie_io_functions_t io_funcs):fileptr
 
 
 
 // string.h
 // Memory functions
-#linkid memcpy
+pub #linkid memcpy
 fn memcpy(anyptr dst, anyptr src, u64 n):anyptr
 
-#linkid memmove  
+pub #linkid memmove
 fn memmove(anyptr dst, anyptr src, u64 n):anyptr
 
-#linkid memset
+pub #linkid memset
 fn memset(anyptr s, i32 c, u64 n):anyptr
 
-#linkid memcmp
+pub #linkid memcmp
 fn memcmp(anyptr s1, anyptr s2, u64 n):i32
 
-#linkid memchr
+pub #linkid memchr
 fn memchr(anyptr s, i32 c, u64 n):anyptr
 
 // String copy functions
-#linkid strcpy
+pub #linkid strcpy
 fn strcpy(cstr dst, cstr src):cstr
 
-#linkid strncpy
+pub #linkid strncpy
 fn strncpy(cstr dst, cstr src, u64 n):cstr
 
 // String concatenation functions
-#linkid strcat
+pub #linkid strcat
 fn strcat(cstr dst, cstr src):cstr
 
-#linkid strncat
+pub #linkid strncat
 fn strncat(cstr dst, cstr src, u64 n):cstr
 
 // String comparison functions
-#linkid strcmp
+pub #linkid strcmp
 fn strcmp(cstr s1, cstr s2):i32
 
-#linkid strncmp
+pub #linkid strncmp
 fn strncmp(cstr s1, cstr s2, u64 n):i32
 
-#linkid strcoll
+pub #linkid strcoll
 fn strcoll(cstr s1, cstr s2):i32
 
-#linkid strxfrm
+pub #linkid strxfrm
 fn strxfrm(cstr dst, cstr src, u64 n):u64
 
 // String search functions
-#linkid strchr
+pub #linkid strchr
 fn strchr(cstr s, i32 c):cstr
 
-#linkid strrchr
+pub #linkid strrchr
 fn strrchr(cstr s, i32 c):cstr
 
-#linkid strcspn
+pub #linkid strcspn
 fn strcspn(cstr s1, cstr s2):u64
 
-#linkid strspn
+pub #linkid strspn
 fn strspn(cstr s1, cstr s2):u64
 
-#linkid strpbrk
+pub #linkid strpbrk
 fn strpbrk(cstr s1, cstr s2):cstr
 
-#linkid strstr
+pub #linkid strstr
 fn strstr(cstr haystack, cstr needle):cstr
 
-#linkid strtok
+pub #linkid strtok
 fn strtok(cstr str, cstr delim):cstr
 
 // String length function
-#linkid strlen
+pub #linkid strlen
 fn strlen(cstr s):u64
 
-#linkid rt_strerror
+pub #linkid rt_strerror
 fn error_string():string
 
 // Error functions
-#linkid strerror
+pub #linkid strerror
 fn strerror(i32 errnum):cstr
 
 // POSIX extensions
-#linkid strtok_r
+pub #linkid strtok_r
 fn strtok_r(cstr str, cstr delim, ptr<cstr> saveptr):cstr
 
-#linkid strerror_r
+pub #linkid strerror_r
 fn strerror_r(i32 errnum, cstr buf, u64 buflen):i32
 
-#linkid stpcpy
+pub #linkid stpcpy
 fn stpcpy(cstr dst, cstr src):cstr
 
-#linkid stpncpy
+pub #linkid stpncpy
 fn stpncpy(cstr dst, cstr src, u64 n):cstr
 
-#linkid strnlen
+pub #linkid strnlen
 fn strnlen(cstr s, u64 maxlen):u64
 
-#linkid strdup
+pub #linkid strdup
 fn strdup(cstr s):cstr
 
-#linkid strndup
+pub #linkid strndup
 fn strndup(cstr s, u64 n):cstr
 
-#linkid strsignal
+pub #linkid strsignal
 fn strsignal(i32 sig):cstr
 
 // Locale-aware functions (requires locale_t type)
-type locale_t = anyptr
+pub type locale_t = anyptr
 
-#linkid strerror_l
+pub #linkid strerror_l
 fn strerror_l(i32 errnum, locale_t locale):cstr
 
-#linkid strcoll_l
+pub #linkid strcoll_l
 fn strcoll_l(cstr s1, cstr s2, locale_t locale):i32
 
-#linkid strxfrm_l
+pub #linkid strxfrm_l
 fn strxfrm_l(cstr dst, cstr src, u64 n, locale_t locale):u64
 
-#linkid memmem
+pub #linkid memmem
 fn memmem(anyptr haystack, u64 haystacklen, anyptr needle, u64 needlelen):anyptr
 
 // X/Open extensions
-#linkid memccpy
+pub #linkid memccpy
 fn memccpy(anyptr dst, anyptr src, i32 c, u64 n):anyptr
 
 // GNU/BSD extensions
-#linkid strsep
+pub #linkid strsep
 fn strsep(ptr<cstr> strp, cstr delim):cstr
 
-#linkid strlcat
+pub #linkid strlcat
 fn strlcat(cstr dst, cstr src, u64 size):u64
 
-#linkid strlcpy
+pub #linkid strlcpy
 fn strlcpy(cstr dst, cstr src, u64 size):u64
 
-#linkid explicit_bzero
+pub #linkid explicit_bzero
 fn explicit_bzero(anyptr s, u64 n):void
 
 // GNU extensions
-#linkid strverscmp
+pub #linkid strverscmp
 fn strverscmp(cstr s1, cstr s2):i32
 
-#linkid strchrnul
+pub #linkid strchrnul
 fn strchrnul(cstr s, i32 c):cstr
 
-#linkid strcasestr
+pub #linkid strcasestr
 fn strcasestr(cstr haystack, cstr needle):cstr
 
-#linkid memrchr
+pub #linkid memrchr
 fn memrchr(anyptr s, i32 c, u64 n):anyptr
 
-#linkid mempcpy
+pub #linkid mempcpy
 fn mempcpy(anyptr dst, anyptr src, u64 n):anyptr
 
 
 // math.h
-const M_E = 2.7182818284590452354
-const M_LOG2E = 1.4426950408889634074
-const M_LOG10E = 0.43429448190325182765
-const M_LN2 = 0.69314718055994530942
-const M_LN10 = 2.30258509299404568402
-const M_PI = 3.14159265358979323846
-const M_PI_2 = 1.57079632679489661923
-const M_PI_4 = 0.78539816339744830962
-const M_1_PI = 0.31830988618379067154
-const M_2_PI = 0.63661977236758134308
-const M_2_SQRTPI = 1.12837916709551257390
-const M_SQRT2 = 1.41421356237309504880
-const M_SQRT1_2 = 0.70710678118654752440
+pub const M_E = 2.7182818284590452354
+pub const M_LOG2E = 1.4426950408889634074
+pub const M_LOG10E = 0.43429448190325182765
+pub const M_LN2 = 0.69314718055994530942
+pub const M_LN10 = 2.30258509299404568402
+pub const M_PI = 3.14159265358979323846
+pub const M_PI_2 = 1.57079632679489661923
+pub const M_PI_4 = 0.78539816339744830962
+pub const M_1_PI = 0.31830988618379067154
+pub const M_2_PI = 0.63661977236758134308
+pub const M_2_SQRTPI = 1.12837916709551257390
+pub const M_SQRT2 = 1.41421356237309504880
+pub const M_SQRT1_2 = 0.70710678118654752440
 
-#linkid acos
+pub #linkid acos
 fn acos(f64 x):f64
 
-#linkid acosf
+pub #linkid acosf
 fn acosf(f32 x):f32
 
-#linkid acosh
+pub #linkid acosh
 fn acosh(f64 x):f64
 
-#linkid acoshf
+pub #linkid acoshf
 fn acoshf(f32 x):f32
 
-#linkid asin
+pub #linkid asin
 fn asin(f64 x):f64
 
-#linkid asinf
+pub #linkid asinf
 fn asinf(f32 x):f32
 
-#linkid asinh
+pub #linkid asinh
 fn asinh(f64 x):f64
 
-#linkid asinhf
+pub #linkid asinhf
 fn asinhf(f32 x):f32
 
-#linkid atan
+pub #linkid atan
 fn atan(f64 x):f64
 
-#linkid atanf
+pub #linkid atanf
 fn atanf(f32 x):f32
 
-#linkid atan2
+pub #linkid atan2
 fn atan2(f64 y, f64 x):f64
 
-#linkid atan2f
+pub #linkid atan2f
 fn atan2f(f32 y, f32 x):f32
 
-#linkid cos
+pub #linkid cos
 fn cos(f64 x):f64
 
-#linkid cosf
+pub #linkid cosf
 fn cosf(f32 x):f32
 
-#linkid sin
+pub #linkid sin
 fn sin(f64 x):f64
 
-#linkid sinf
+pub #linkid sinf
 fn sinf(f32 x):f32
 
-#linkid tan
+pub #linkid tan
 fn tan(f64 x):f64
 
-#linkid tanf
+pub #linkid tanf
 fn tanf(f32 x):f32
 
-#linkid atanh
+pub #linkid atanh
 fn atanh(f64 x):f64
 
-#linkid atanhf
+pub #linkid atanhf
 fn atanhf(f32 x):f32
 
-#linkid cosh
+pub #linkid cosh
 fn cosh(f64 x):f64
 
-#linkid coshf
+pub #linkid coshf
 fn coshf(f32 x):f32
 
-#linkid sinh
+pub #linkid sinh
 fn sinh(f64 x):f64
 
-#linkid sinhf
+pub #linkid sinhf
 fn sinhf(f32 x):f32
 
-#linkid sqrt
+pub #linkid sqrt
 fn sqrt(f64 x):f64
 
-#linkid sqrtf
+pub #linkid sqrtf
 fn sqrtf(f32 x):f32
 
-#linkid tanh
+pub #linkid tanh
 fn tanh(f64 x):f64
 
-#linkid tanhf
+pub #linkid tanhf
 fn tanhf(f32 x):f32
 
-#linkid exp
+pub #linkid exp
 fn exp(f64 x):f64
 
-#linkid expf
+pub #linkid expf
 fn expf(f32 x):f32
 
-#linkid exp2
+pub #linkid exp2
 fn exp2(f64 x):f64
 
-#linkid exp2f
+pub #linkid exp2f
 fn exp2f(f32 x):f32
 
-#linkid expm1
+pub #linkid expm1
 fn expm1(f64 x):f64
 
-#linkid expm1f
+pub #linkid expm1f
 fn expm1f(f32 x):f32
 
-#linkid fabs
+pub #linkid fabs
 fn fabs(f64 x):f64
 
-#linkid fabsf
+pub #linkid fabsf
 fn fabsf(f32 x):f32
 
-#linkid log
+pub #linkid log
 fn log(f64 x):f64
 
-#linkid logf
+pub #linkid logf
 fn logf(f32 x):f32
 
-#linkid log10
+pub #linkid log10
 fn log10(f64 x):f64
 
-#linkid log10f
+pub #linkid log10f
 fn log10f(f32 x):f32
 
-#linkid log1p
+pub #linkid log1p
 fn log1p(f64 x):f64
 
-#linkid log1pf
+pub #linkid log1pf
 fn log1pf(f32 x):f32
 
-#linkid log2
+pub #linkid log2
 fn log2(f64 x):f64
 
-#linkid log2f
+pub #linkid log2f
 fn log2f(f32 x):f32
 
-#linkid logb
+pub #linkid logb
 fn logb(f64 x):f64
 
-#linkid logbf
+pub #linkid logbf
 fn logbf(f32 x):f32
 
 // 幂函数
-#linkid pow
+pub #linkid pow
 fn pow(f64 x, f64 y):f64
 
-#linkid powf
+pub #linkid powf
 fn powf(f32 x, f32 y):f32
 
-#linkid cbrt
+pub #linkid cbrt
 fn cbrt(f64 x):f64
 
-#linkid cbrtf
+pub #linkid cbrtf
 fn cbrtf(f32 x):f32
 
-#linkid hypot
+pub #linkid hypot
 fn hypot(f64 x, f64 y):f64
 
-#linkid hypotf
+pub #linkid hypotf
 fn hypotf(f32 x, f32 y):f32
 
-#linkid ceil
+pub #linkid ceil
 fn ceil(f64 x):f64
 
-#linkid ceilf
+pub #linkid ceilf
 fn ceilf(f32 x):f32
 
-#linkid floor
+pub #linkid floor
 fn floor(f64 x):f64
 
-#linkid floorf
+pub #linkid floorf
 fn floorf(f32 x):f32
 
-#linkid trunc
+pub #linkid trunc
 fn trunc(f64 x):f64
 
-#linkid truncf
+pub #linkid truncf
 fn truncf(f32 x):f32
 
-#linkid rint
+pub #linkid rint
 fn rint(f64 x):f64
 
-#linkid rintf
+pub #linkid rintf
 fn rintf(f32 x):f32
 
-#linkid nearbyint
+pub #linkid nearbyint
 fn nearbyint(f64 x):f64
 
-#linkid nearbyintf
+pub #linkid nearbyintf
 fn nearbyintf(f32 x):f32
 
-#linkid lrint
+pub #linkid lrint
 fn lrint(f64 x):i64
 
-#linkid lrintf
+pub #linkid lrintf
 fn lrintf(f32 x):i64
 
-#linkid llrint
+pub #linkid llrint
 fn llrint(f64 x):i64
 
-#linkid llrintf
+pub #linkid llrintf
 fn llrintf(f32 x):i64
 
-#linkid lround
+pub #linkid lround
 fn lround(f64 x):i64
 
-#linkid lroundf
+pub #linkid lroundf
 fn lroundf(f32 x):i64
 
-#linkid llround
+pub #linkid llround
 fn llround(f64 x):i64
 
-#linkid llroundf
+pub #linkid llroundf
 fn llroundf(f32 x):i64
 
-#linkid copysign
+pub #linkid copysign
 fn copysign(f64 x, f64 y):f64
 
-#linkid copysignf
+pub #linkid copysignf
 fn copysignf(f32 x, f32 y):f32
 
-#linkid frexp
+pub #linkid frexp
 fn frexp(f64 x, ptr<i32> exp):f64
 
-#linkid frexpf
+pub #linkid frexpf
 fn frexpf(f32 x, ptr<i32> exp):f32
 
-#linkid ldexp
+pub #linkid ldexp
 fn ldexp(f64 x, i32 exp):f64
 
-#linkid ldexpf
+pub #linkid ldexpf
 fn ldexpf(f32 x, i32 exp):f32
 
-#linkid modf
+pub #linkid modf
 fn modf(f64 x, ptr<f64> iptr):f64
 
-#linkid modff
+pub #linkid modff
 fn modff(f32 x, ptr<f32> iptr):f32
 
-#linkid scalbn
+pub #linkid scalbn
 fn scalbn(f64 x, i32 n):f64
 
-#linkid scalbnf
+pub #linkid scalbnf
 fn scalbnf(f32 x, i32 n):f32
 
-#linkid scalbln
+pub #linkid scalbln
 fn scalbln(f64 x, i64 n):f64
 
-#linkid scalblnf
+pub #linkid scalblnf
 fn scalblnf(f32 x, i64 n):f32
 
-#linkid round
+pub #linkid round
 fn round(f64 x):f64
 
-#linkid roundf
+pub #linkid roundf
 fn roundf(f32 x):f32
 
-#linkid ilogb
+pub #linkid ilogb
 fn ilogb(f64 x):i32
 
-#linkid ilogbf
+pub #linkid ilogbf
 fn ilogbf(f32 x):i32
 
 // 浮点余数和商函数
-#linkid fmod
+pub #linkid fmod
 fn fmod(f64 x, f64 y):f64
 
-#linkid fmodf
+pub #linkid fmodf
 fn fmodf(f32 x, f32 y):f32
 
-#linkid remainder
+pub #linkid remainder
 fn remainder(f64 x, f64 y):f64
 
-#linkid remainderf
+pub #linkid remainderf
 fn remainderf(f32 x, f32 y):f32
 
-#linkid remquo
+pub #linkid remquo
 fn remquo(f64 x, f64 y, ptr<i32> quo):f64
 
-#linkid remquof
+pub #linkid remquof
 fn remquof(f32 x, f32 y, ptr<i32> quo):f32
 
-#linkid fmax
+pub #linkid fmax
 fn fmax(f64 x, f64 y):f64
 
-#linkid fmaxf
+pub #linkid fmaxf
 fn fmaxf(f32 x, f32 y):f32
 
-#linkid fmin
+pub #linkid fmin
 fn fmin(f64 x, f64 y):f64
 
-#linkid fminf
+pub #linkid fminf
 fn fminf(f32 x, f32 y):f32
 
-#linkid fdim
+pub #linkid fdim
 fn fdim(f64 x, f64 y):f64
 
-#linkid fdimf
+pub #linkid fdimf
 fn fdimf(f32 x, f32 y):f32
 
 // 融合乘加函数
-#linkid fma
+pub #linkid fma
 fn fma(f64 x, f64 y, f64 z):f64
 
-#linkid fmaf
+pub #linkid fmaf
 fn fmaf(f32 x, f32 y, f32 z):f32
 
 // 特殊函数
-#linkid erf
+pub #linkid erf
 fn erf(f64 x):f64
 
-#linkid erff
+pub #linkid erff
 fn erff(f32 x):f32
 
-#linkid erfc
+pub #linkid erfc
 fn erfc(f64 x):f64
 
-#linkid erfcf
+pub #linkid erfcf
 fn erfcf(f32 x):f32
 
-#linkid lgamma
+pub #linkid lgamma
 fn lgamma(f64 x):f64
 
-#linkid lgammaf
+pub #linkid lgammaf
 fn lgammaf(f32 x):f32
 
-#linkid tgamma
+pub #linkid tgamma
 fn tgamma(f64 x):f64
 
-#linkid tgammaf
+pub #linkid tgammaf
 fn tgammaf(f32 x):f32
 
 // NaN 函数
-#linkid nan
+pub #linkid nan
 fn nan(cstr tagp):f64
 
-#linkid nanf
+pub #linkid nanf
 fn nanf(cstr tagp):f32
 
 // 下一个可表示值函数
-#linkid nextafter
+pub #linkid nextafter
 fn nextafter(f64 x, f64 y):f64
 
-#linkid nextafterf
+pub #linkid nextafterf
 fn nextafterf(f32 x, f32 y):f32
 
-#linkid nexttoward
+pub #linkid nexttoward
 fn nexttoward(f64 x, f64 y):f64
 
-#linkid nexttowardf
+pub #linkid nexttowardf
 fn nexttowardf(f32 x, f64 y):f32
 
 // Bessel 函数 (POSIX 扩展)
-#linkid j0
+pub #linkid j0
 fn j0(f64 x):f64
 
-#linkid j0f
+pub #linkid j0f
 fn j0f(f32 x):f32
 
-#linkid j1
+pub #linkid j1
 fn j1(f64 x):f64
 
-#linkid j1f
+pub #linkid j1f
 fn j1f(f32 x):f32
 
-#linkid jn
+pub #linkid jn
 fn jn(i32 n, f64 x):f64
 
-#linkid jnf
+pub #linkid jnf
 fn jnf(i32 n, f32 x):f32
 
-#linkid y0
+pub #linkid y0
 fn y0(f64 x):f64
 
-#linkid y0f
+pub #linkid y0f
 fn y0f(f32 x):f32
 
-#linkid y1
+pub #linkid y1
 fn y1(f64 x):f64
 
-#linkid y1f
+pub #linkid y1f
 fn y1f(f32 x):f32
 
-#linkid yn
+pub #linkid yn
 fn yn(i32 n, f64 x):f64
 
-#linkid ynf
+pub #linkid ynf
 fn ynf(i32 n, f32 x):f32
 
 // GNU/BSD 扩展
-#linkid drem
+pub #linkid drem
 fn drem(f64 x, f64 y):f64
 
-#linkid dremf
+pub #linkid dremf
 fn dremf(f32 x, f32 y):f32
 
-#linkid finite
+pub #linkid finite
 fn finite(f64 x):i32
 
-#linkid finitef
+pub #linkid finitef
 fn finitef(f32 x):i32
 
-#linkid scalb
+pub #linkid scalb
 fn scalb(f64 x, f64 n):f64
 
-#linkid scalbf
+pub #linkid scalbf
 fn scalbf(f32 x, f32 n):f32
 
-#linkid significand
+pub #linkid significand
 fn significand(f64 x):f64
 
-#linkid significandf
+pub #linkid significandf
 fn significandf(f32 x):f32
 
-#linkid lgamma_r
+pub #linkid lgamma_r
 fn lgamma_r(f64 x, ptr<i32> signgamp):f64
 
-#linkid lgammaf_r
+pub #linkid lgammaf_r
 fn lgammaf_r(f32 x, ptr<i32> signgamp):f32
 
-#linkid sincos
+pub #linkid sincos
 fn sincos(f64 x, ptr<f64> sin, ptr<f64> cos):void
 
-#linkid sincosf
+pub #linkid sincosf
 fn sincosf(f32 x, ptr<f32> sin, ptr<f32> cos):void
 
-#linkid exp10
+pub #linkid exp10
 fn exp10(f64 x):f64
 
-#linkid exp10f
+pub #linkid exp10f
 fn exp10f(f32 x):f32
 
-#linkid pow10
+pub #linkid pow10
 fn pow10(f64 x):f64
 
-#linkid pow10f
+pub #linkid pow10f
 fn pow10f(f32 x):f32
 
 
 // time.h
 // Time types
-type time_t = i64
+pub type time_t = i64
 type clock_t = i64
-type clockid_t = i32
-type timer_t = anyptr
+pub type clockid_t = i32
+pub type timer_t = anyptr
 
 // Time constants
-const CLOCKS_PER_SEC = 1000000
-const TIME_UTC = 1
+pub const CLOCKS_PER_SEC = 1000000
+pub const TIME_UTC = 1
 
 // Clock types
-const CLOCK_REALTIME = 0
-const CLOCK_MONOTONIC = 1
-const CLOCK_PROCESS_CPUTIME_ID = 2
-const CLOCK_THREAD_CPUTIME_ID = 3
-const CLOCK_MONOTONIC_RAW = 4
-const CLOCK_REALTIME_COARSE = 5
-const CLOCK_MONOTONIC_COARSE = 6
-const CLOCK_BOOTTIME = 7
+pub const CLOCK_REALTIME = 0
+pub const CLOCK_MONOTONIC = 1
+pub const CLOCK_PROCESS_CPUTIME_ID = 2
+pub const CLOCK_THREAD_CPUTIME_ID = 3
+pub const CLOCK_MONOTONIC_RAW = 4
+pub const CLOCK_REALTIME_COARSE = 5
+pub const CLOCK_MONOTONIC_COARSE = 6
+pub const CLOCK_BOOTTIME = 7
 const CLOCK_REALTIME_ALARM = 8
-const CLOCK_BOOTTIME_ALARM = 9
+pub const CLOCK_BOOTTIME_ALARM = 9
 const CLOCK_SGI_CYCLE = 10
-const CLOCK_TAI = 11
+pub const CLOCK_TAI = 11
 
 // Timer constants
-const TIMER_ABSTIME = 1
+pub const TIMER_ABSTIME = 1
 
 // Time structures
-type timespec = struct {
+pub type timespec = struct {
     i64 tv_sec
     i64 tv_nsec
 }
 
-type itimerspec = struct {
+pub type itimerspec = struct {
     timespec it_interval
     timespec it_value
 }
 
 /* ISO C `broken-down time' structure.  */
-type tm = struct {
+pub type tm = struct {
     i32 tm_sec
     i32 tm_min
     i32 tm_hour
@@ -1172,235 +1172,235 @@ type tm = struct {
 }
 
 // Basic time functions
-#linkid time
+pub #linkid time
 fn time(ptr<time_t> t):time_t
 
-#linkid clock
+pub #linkid clock
 fn clock():clock_t
 
-#linkid difftime
+pub #linkid difftime
 fn difftime(time_t time1, time_t time0):f64
 
-#linkid mktime
+pub #linkid mktime
 fn mktime(ptr<tm> time_info):time_t
 
 // Time formatting
-#linkid strftime
+pub #linkid strftime
 fn strftime(cstr s, u64 size, cstr format, ptr<tm> time_info):u64
 
-#linkid strftime_l
+pub #linkid strftime_l
 fn strftime_l(cstr s, u64 size, cstr format, ptr<tm> time_info, locale_t locale):u64
 
 // Time conversion functions
-fn localtime(ptr<time_t> timestamp):ptr<tm> {
+pub fn localtime(ptr<time_t> timestamp):ptr<tm> {
     return cross.localtime(timestamp as anyptr) as ptr<tm>
 }
 
-fn gmtime(ptr<time_t> timestamp):ptr<tm> {
+pub fn gmtime(ptr<time_t> timestamp):ptr<tm> {
     return cross.gmtime(timestamp as anyptr) as ptr<tm>
 }
 
-#linkid asctime
+pub #linkid asctime
 fn asctime(ptr<tm> tm):cstr
 
-#linkid ctime
+pub #linkid ctime
 fn ctime(ptr<time_t> timestamp):cstr
 
 // Thread-safe versions
-#linkid localtime_r
+pub #linkid localtime_r
 fn localtime_r(ptr<time_t> timestamp, ptr<tm> result):ptr<tm>
 
-#linkid gmtime_r
+pub #linkid gmtime_r
 fn gmtime_r(ptr<time_t> timestamp, ptr<tm> result):ptr<tm>
 
-#linkid asctime_r
+pub #linkid asctime_r
 fn asctime_r(ptr<tm> tm, cstr buf):cstr
 
-#linkid ctime_r
+pub #linkid ctime_r
 fn ctime_r(ptr<time_t> timestamp, cstr buf):cstr
 
 // Time parsing
-#linkid strptime
+pub #linkid strptime
 fn strptime(cstr s, cstr format, ptr<tm> tm):cstr
 
 // High-resolution time functions
-#linkid timespec_get
+pub #linkid timespec_get
 fn timespec_get(ptr<timespec> ts, i32 base):i32
 
-#linkid nanosleep
+pub #linkid nanosleep
 fn nanosleep(ptr<timespec> req, ptr<timespec> rem):i32
 
 // Clock functions
-#linkid clock_getres
+pub #linkid clock_getres
 fn clock_getres(clockid_t clk_id, ptr<timespec> res):i32
 
-#linkid clock_gettime
+pub #linkid clock_gettime
 fn clock_gettime(clockid_t clk_id, ptr<timespec> tp):i32
 
-#linkid clock_settime
+pub #linkid clock_settime
 fn clock_settime(clockid_t clk_id, ptr<timespec> tp):i32
 
-#linkid clock_nanosleep
+pub #linkid clock_nanosleep
 fn clock_nanosleep(clockid_t clk_id, i32 flags, ptr<timespec> req, ptr<timespec> rem):i32
 
-#linkid clock_getcpuclockid
+pub #linkid clock_getcpuclockid
 fn clock_getcpuclockid(i32 pid, ptr<clockid_t> clk_id):i32
 
 // Timer functions
-#linkid timer_create
+pub #linkid timer_create
 fn timer_create(clockid_t clk_id, anyptr sevp, ptr<timer_t> timerid):i32
 
-#linkid timer_delete
+pub #linkid timer_delete
 fn timer_delete(timer_t timerid):i32
 
-#linkid timer_settime
+pub #linkid timer_settime
 fn timer_settime(timer_t timerid, i32 flags, ptr<itimerspec> new_value, ptr<itimerspec> old_value):i32
 
-#linkid timer_gettime
+pub #linkid timer_gettime
 fn timer_gettime(timer_t timerid, ptr<itimerspec> curr_value):i32
 
-#linkid timer_getoverrun
+pub #linkid timer_getoverrun
 fn timer_getoverrun(timer_t timerid):i32
 
 // Timezone functions
-#linkid tzset
+pub #linkid tzset
 fn tzset():void
 
 // GNU/BSD extensions
-#linkid stime
+pub #linkid stime
 fn stime(ptr<time_t> t):i32
 
-fn timegm(ptr<tm> value):time_t {
+pub fn timegm(ptr<tm> value):time_t {
     return cross.timegm(value as anyptr) as time_t
 }
 
-#linkid getdate
+pub #linkid getdate
 fn getdate(cstr str):ptr<tm>
 
 // unistd.h - File operations
-#linkid pipe
+pub #linkid pipe
 fn pipe(anyptr pipefd):i32
 
-#linkid pipe2
+pub #linkid pipe2
 fn pipe2(anyptr pipefd, i32 flags):i32
 
-#linkid close
+pub #linkid close
 fn close(i32 fd):i32
 
-#linkid posix_close
+pub #linkid posix_close
 fn posix_close(i32 fd, i32 flags):i32
 
-#linkid dup
+pub #linkid dup
 fn dup(i32 oldfd):i32
 
-#linkid dup2
+pub #linkid dup2
 fn dup2(i32 oldfd, i32 newfd):i32
 
-#linkid dup3
+pub #linkid dup3
 fn dup3(i32 oldfd, i32 newfd, i32 flags):i32
 
-#linkid lseek
+pub #linkid lseek
 fn lseek(i32 fd, i64 offset, i32 whence):i64
 
-#linkid fsync
+pub #linkid fsync
 fn fsync(i32 fd):i32
 
-#linkid fdatasync
+pub #linkid fdatasync
 fn fdatasync(i32 fd):i32
 
-#linkid read
+pub #linkid read
 fn read(i32 fd, anyptr buf, u64 count):i64
 
-#linkid write
+pub #linkid write
 fn write(i32 fd, anyptr buf, u64 count):i64
 
-#linkid pread
+pub #linkid pread
 fn pread(i32 fd, anyptr buf, u64 count, i64 offset):i64
 
-#linkid pwrite
+pub #linkid pwrite
 fn pwrite(i32 fd, anyptr buf, u64 count, i64 offset):i64
 
 // unistd.h - File ownership and permissions
-#linkid chown
+pub #linkid chown
 fn chown(cstr path, u32 owner, u32 group):i32
 
-#linkid fchown
+pub #linkid fchown
 fn fchown(i32 fd, u32 owner, u32 group):i32
 
-#linkid lchown
+pub #linkid lchown
 fn lchown(cstr path, u32 owner, u32 group):i32
 
-#linkid fchownat
+pub #linkid fchownat
 fn fchownat(i32 dirfd, cstr path, u32 owner, u32 group, i32 flags):i32
 
 // unistd.h - File linking
-#linkid link
+pub #linkid link
 fn link(cstr oldpath, cstr newpath):i32
 
-#linkid linkat
+pub #linkid linkat
 fn linkat(i32 olddirfd, cstr oldpath, i32 newdirfd, cstr newpath, i32 flags):i32
 
-#linkid symlink
+pub #linkid symlink
 fn symlink(cstr target, cstr linkpath):i32
 
-#linkid symlinkat
+pub #linkid symlinkat
 fn symlinkat(cstr target, i32 newdirfd, cstr linkpath):i32
 
-#linkid readlink
+pub #linkid readlink
 fn readlink(cstr path, cstr buf, u64 bufsiz):i64
 
-#linkid readlinkat
+pub #linkid readlinkat
 fn readlinkat(i32 dirfd, cstr path, cstr buf, u64 bufsiz):i64
 
-#linkid unlink
+pub #linkid unlink
 fn unlink(cstr path):i32
 
-#linkid unlinkat
+pub #linkid unlinkat
 fn unlinkat(i32 dirfd, cstr path, i32 flags):i32
 
-#linkid rmdir
+pub #linkid rmdir
 fn rmdir(cstr path):i32
 
-#linkid truncate
+pub #linkid truncate
 fn truncate(cstr path, i64 length):i32
 
-#linkid ftruncate
+pub #linkid ftruncate
 fn ftruncate(i32 fd, i64 length):i32
 
 // unistd.h - File access
-#linkid access
+pub #linkid access
 fn access(cstr path, i32 mode):i32
 
-#linkid faccessat
+pub #linkid faccessat
 fn faccessat(i32 dirfd, cstr path, i32 mode, i32 flags):i32
 
 // unistd.h - Directory operations
-#linkid chdir
+pub #linkid chdir
 fn chdir(cstr path):i32
 
-#linkid fchdir
+pub #linkid fchdir
 fn fchdir(i32 fd):i32
 
 // unistd.h - Process control
-#linkid alarm
+pub #linkid alarm
 fn alarm(u32 seconds):u32
 
-#linkid sleep
+pub #linkid sleep
 fn sleep(int second)
 
-#linkid usleep
+pub #linkid usleep
 fn usleep(u32 usec):i32
 
-#linkid pause
+pub #linkid pause
 fn pause():i32
 
-#linkid _Fork
+pub #linkid _Fork
 fn _fork():i32
 
-#linkid execve
+pub #linkid execve
 fn execve(cstr filename, ptr<cstr> argv, ptr<cstr> envp):i32
 
-#linkid execv
+pub #linkid execv
 fn execv(cstr path, ptr<cstr> argv):i32
 
 // not support
@@ -1420,237 +1420,237 @@ fn execv(cstr path, ptr<cstr> argv):i32
 // fn fexecve(i32 fd, ptr<cstr> argv, ptr<cstr> envp):i32
 
 // unistd.h - Process identification
-#linkid getpid
+pub #linkid getpid
 fn getpid():i32
 
-#linkid getppid
+pub #linkid getppid
 fn getppid():i32
 
-#linkid getpgrp
+pub #linkid getpgrp
 fn getpgrp():i32
 
-#linkid getpgid
+pub #linkid getpgid
 fn getpgid(i32 pid):i32
 
-#linkid setpgid
+pub #linkid setpgid
 fn setpgid(i32 pid, i32 pgid):i32
 
-#linkid setsid
+pub #linkid setsid
 fn setsid():i32
 
-#linkid getsid
+pub #linkid getsid
 fn getsid(i32 pid):i32
 
-#linkid ttyname
+pub #linkid ttyname
 fn ttyname(i32 fd):cstr
 
-#linkid ttyname_r
+pub #linkid ttyname_r
 fn ttyname_r(i32 fd, cstr buf, u64 buflen):i32
 
-#linkid isatty
+pub #linkid isatty
 fn isatty(i32 fd):i32
 
-#linkid tcgetpgrp
+pub #linkid tcgetpgrp
 fn tcgetpgrp(i32 fd):i32
 
-#linkid tcsetpgrp
+pub #linkid tcsetpgrp
 fn tcsetpgrp(i32 fd, i32 pgrp):i32
 
 // unistd.h - User and group identification
-#linkid getuid
+pub #linkid getuid
 fn getuid():u32
 
-#linkid geteuid
+pub #linkid geteuid
 fn geteuid():u32
 
-#linkid getgid
+pub #linkid getgid
 fn getgid():u32
 
-#linkid getegid
+pub #linkid getegid
 fn getegid():u32
 
-#linkid getgroups
+pub #linkid getgroups
 fn getgroups(i32 size, ptr<u32> list):i32
 
-#linkid setuid
+pub #linkid setuid
 fn setuid(u32 uid):i32
 
-#linkid seteuid
+pub #linkid seteuid
 fn seteuid(u32 euid):i32
 
-#linkid setgid
+pub #linkid setgid
 fn setgid(u32 gid):i32
 
-#linkid setegid
+pub #linkid setegid
 fn setegid(u32 egid):i32
 
 // unistd.h - Login and hostname
-#linkid getlogin
+pub #linkid getlogin
 fn getlogin():cstr
 
-#linkid getlogin_r
+pub #linkid getlogin_r
 fn getlogin_r(cstr buf, u64 bufsize):i32
 
-#linkid gethostname
+pub #linkid gethostname
 fn gethostname(cstr name, u64 len):i32
 
-#linkid ctermid
+pub #linkid ctermid
 fn ctermid(cstr s):cstr
 
 // unistd.h - Command line options
-#linkid getopt
+pub #linkid getopt
 fn getopt(i32 argc, ptr<cstr> argv, cstr optstring):i32
 
 // unistd.h - Configuration
-#linkid pathconf
+pub #linkid pathconf
 fn pathconf(cstr path, i32 name):i64
 
-#linkid fpathconf
+pub #linkid fpathconf
 fn fpathconf(i32 fd, i32 name):i64
 
-#linkid sysconf
+pub #linkid sysconf
 fn sysconf(i32 name):i64
 
-#linkid confstr
+pub #linkid confstr
 fn confstr(i32 name, cstr buf, u64 len):u64
 
 // unistd.h - POSIX extensions
-#linkid setreuid
+pub #linkid setreuid
 fn setreuid(u32 ruid, u32 euid):i32
 
-#linkid setregid
+pub #linkid setregid
 fn setregid(u32 rgid, u32 egid):i32
 
-#linkid lockf
+pub #linkid lockf
 fn lockf(i32 fd, i32 cmd, i64 len):i32
 
-#linkid gethostid
+pub #linkid gethostid
 fn gethostid():i64
 
-#linkid nice
+pub #linkid nice
 fn nice(i32 inc):i32
 
-#linkid sync
+pub #linkid sync
 fn sync():void
 
-#linkid setpgrp
+pub #linkid setpgrp
 fn setpgrp():i32
 
-#linkid crypt
+pub #linkid crypt
 fn crypt(cstr key, cstr salt):cstr
 
-#linkid encrypt
+pub #linkid encrypt
 fn encrypt(cstr block, i32 edflag):void
 
-#linkid swab
+pub #linkid swab
 fn swab(anyptr from, anyptr to, i64 n):void
 
-#linkid ualarm
+pub #linkid ualarm
 fn ualarm(u32 value, u32 interval):u32
 
 // unistd.h - BSD/GNU extensions
-#linkid brk
+pub #linkid brk
 fn brk(anyptr addr):i32
 
-#linkid sbrk
+pub #linkid sbrk
 fn sbrk(i64 increment):anyptr
 
-#linkid vfork
+pub #linkid vfork
 fn vfork():i32
 
-#linkid vhangup
+pub #linkid vhangup
 fn vhangup():i32
 
-#linkid chroot
+pub #linkid chroot
 fn chroot(cstr path):i32
 
-#linkid getpagesize
+pub #linkid getpagesize
 fn getpagesize():i32
 
-#linkid getdtablesize
+pub #linkid getdtablesize
 fn getdtablesize():i32
 
-#linkid sethostname
+pub #linkid sethostname
 fn sethostname(cstr name, u64 len):i32
 
-#linkid getdomainname
+pub #linkid getdomainname
 fn getdomainname(cstr name, u64 len):i32
 
-#linkid setdomainname
+pub #linkid setdomainname
 fn setdomainname(cstr name, u64 len):i32
 
-#linkid setgroups
+pub #linkid setgroups
 fn setgroups(u64 size, ptr<u32> list):i32
 
-#linkid getpass
+pub #linkid getpass
 fn getpass(cstr prompt):cstr
 
-#linkid daemon
+pub #linkid daemon
 fn daemon(i32 nochdir, i32 noclose):i32
 
-#linkid setusershell
+pub #linkid setusershell
 fn setusershell():void
 
-#linkid endusershell
+pub #linkid endusershell
 fn endusershell():void
 
-#linkid getusershell
+pub #linkid getusershell
 fn getusershell():cstr
 
-#linkid acct
+pub #linkid acct
 fn acct(cstr filename):i32
 
 // #linkid syscall
 // fn syscall(i64 number, ...):i64
 
-#linkid execvpe
+pub #linkid execvpe
 fn execvpe(cstr file, ptr<cstr> argv, ptr<cstr> envp):i32
 
-#linkid issetugid
+pub #linkid issetugid
 fn issetugid():i32
 
-#linkid getentropy
+pub #linkid getentropy
 fn getentropy(anyptr buffer, u64 length):i32
 
 // unistd.h - GNU extensions
-#os linux #linkid setresuid
+pub #os linux #linkid setresuid
 fn setresuid(u32 ruid, u32 euid, u32 suid):i32
 
-#os linux #linkid setresgid
+pub #os linux #linkid setresgid
 fn setresgid(u32 rgid, u32 egid, u32 sgid):i32
 
-#linkid getresuid
+pub #linkid getresuid
 fn getresuid(ptr<u32> ruid, ptr<u32> euid, ptr<u32> suid):i32
 
-#os linux #linkid getresgid
+pub #os linux #linkid getresgid
 fn getresgid(ptr<u32> rgid, ptr<u32> egid, ptr<u32> sgid):i32
 
-#linkid get_current_dir_name
+pub #linkid get_current_dir_name
 fn get_current_dir_name():cstr
 
-#linkid syncfs
+pub #linkid syncfs
 fn syncfs(i32 fd):i32
 
-#linkid euidaccess
+pub #linkid euidaccess
 fn euidaccess(cstr pathname, i32 mode):i32
 
-#linkid eaccess
+pub #linkid eaccess
 fn eaccess(cstr pathname, i32 mode):i32
 
-#linkid copy_file_range
+pub #linkid copy_file_range
 fn copy_file_range(i32 fd_in, ptr<i64> off_in, i32 fd_out, ptr<i64> off_out, u64 len, u32 flags):i64
 
-#linkid gettid
+pub #linkid gettid
 fn gettid():i32
 
 // fcntl.h
 // Type definitions
-type off_t = i64
-type pid_t = i32
-type mode_t = u32
+pub type off_t = i64
+pub type pid_t = i32
+pub type mode_t = u32
 
 // File lock structure
-type flock = struct {
+pub type flock = struct {
     i16 l_type
     i16 l_whence
     off_t l_start
@@ -1659,241 +1659,241 @@ type flock = struct {
 }
 
 // File access modes
-const O_ACCMODE = 0o3
-const O_RDONLY = 0o0
-const O_WRONLY = 0o1
-const O_RDWR = 0o2
+pub const O_ACCMODE = 0o3
+pub const O_RDONLY = 0o0
+pub const O_WRONLY = 0o1
+pub const O_RDWR = 0o2
 const O_SEARCH = 0o200000000
-const O_EXEC = 0o200000000
-const O_PATH = 0o200000000
-const O_TTY_INIT = 0
+pub const O_EXEC = 0o200000000
+pub const O_PATH = 0o200000000
+pub const O_TTY_INIT = 0
 
 // File creation flags
-const O_CREAT = 0o100
-const O_EXCL = 0o200
+pub const O_CREAT = 0o100
+pub const O_EXCL = 0o200
 const O_NOCTTY = 0o400
-const O_TRUNC = 0o1000
+pub const O_TRUNC = 0o1000
 
 // File status flags
-const O_APPEND = 0o2000
+pub const O_APPEND = 0o2000
 const O_ASYNC = 0o20000
-const O_DSYNC = 0o10000
-const O_NONBLOCK = 0o4000
+pub const O_DSYNC = 0o10000
+pub const O_NONBLOCK = 0o4000
 const O_NDELAY = 0o4000
-const O_SYNC = 0o4010000
+pub const O_SYNC = 0o4010000
 
 // fcntl commands
-const F_DUPFD = 0
-const F_GETFD = 1
-const F_SETFD = 2
-const F_GETFL = 3
-const F_SETFL = 4
-const F_GETLK = 5
-const F_SETLK = 6
-const F_SETLKW = 7
-const F_GETOWN = 9
-const F_SETOWN = 8
+pub const F_DUPFD = 0
+pub const F_GETFD = 1
+pub const F_SETFD = 2
+pub const F_GETFL = 3
+pub const F_SETFL = 4
+pub const F_GETLK = 5
+pub const F_SETLK = 6
+pub const F_SETLKW = 7
+pub const F_GETOWN = 9
+pub const F_SETOWN = 8
 
 // OFD locks
-const F_OFD_GETLK = 36
-const F_OFD_SETLK = 37
-const F_OFD_SETLKW = 38
+pub const F_OFD_GETLK = 36
+pub const F_OFD_SETLK = 37
+pub const F_OFD_SETLKW = 38
 
 // Additional fcntl commands
-const F_DUPFD_CLOEXEC = 1030
+pub const F_DUPFD_CLOEXEC = 1030
 
 // Lock types
-const F_RDLCK = 0
-const F_WRLCK = 1
-const F_UNLCK = 2
+pub const F_RDLCK = 0
+pub const F_WRLCK = 1
+pub const F_UNLCK = 2
 
 // File descriptor flags
-const FD_CLOEXEC = 1
+pub const FD_CLOEXEC = 1
 
 // AT constants
-const AT_FDCWD = -100
-const AT_SYMLINK_NOFOLLOW = 0x100
-const AT_REMOVEDIR = 0x200
-const AT_SYMLINK_FOLLOW = 0x400
-const AT_EACCESS = 0x200
-const AT_NO_AUTOMOUNT = 0x800
-const AT_EMPTY_PATH = 0x1000
-const AT_STATX_SYNC_TYPE = 0x6000
-const AT_STATX_SYNC_AS_STAT = 0x0000
-const AT_STATX_FORCE_SYNC = 0x2000
-const AT_STATX_DONT_SYNC = 0x4000
-const AT_RECURSIVE = 0x8000
+pub const AT_FDCWD = -100
+pub const AT_SYMLINK_NOFOLLOW = 0x100
+pub const AT_REMOVEDIR = 0x200
+pub const AT_SYMLINK_FOLLOW = 0x400
+pub const AT_EACCESS = 0x200
+pub const AT_NO_AUTOMOUNT = 0x800
+pub const AT_EMPTY_PATH = 0x1000
+pub const AT_STATX_SYNC_TYPE = 0x6000
+pub const AT_STATX_SYNC_AS_STAT = 0x0000
+pub const AT_STATX_FORCE_SYNC = 0x2000
+pub const AT_STATX_DONT_SYNC = 0x4000
+pub const AT_RECURSIVE = 0x8000
 
 // POSIX advisory information constants
-const POSIX_FADV_NORMAL = 0
-const POSIX_FADV_RANDOM = 1
-const POSIX_FADV_SEQUENTIAL = 2
-const POSIX_FADV_WILLNEED = 3
-const POSIX_FADV_DONTNEED = 4
-const POSIX_FADV_NOREUSE = 5
+pub const POSIX_FADV_NORMAL = 0
+pub const POSIX_FADV_RANDOM = 1
+pub const POSIX_FADV_SEQUENTIAL = 2
+pub const POSIX_FADV_WILLNEED = 3
+pub const POSIX_FADV_DONTNEED = 4
+pub const POSIX_FADV_NOREUSE = 5
 
 
 // File mode constants
-const S_ISUID = 0o4000
-const S_ISGID = 0o2000
-const S_ISVTX = 0o1000
-const S_IRUSR = 0o400
-const S_IWUSR = 0o200
-const S_IXUSR = 0o100
-const S_IRWXU = 0o700
-const S_IRGRP = 0o40
-const S_IWGRP = 0o20
-const S_IXGRP = 0o10
-const S_IRWXG = 0o70
-const S_IROTH = 0o4
-const S_IWOTH = 0o2
-const S_IXOTH = 0o1
-const S_IRWXO = 0o7
+pub const S_ISUID = 0o4000
+pub const S_ISGID = 0o2000
+pub const S_ISVTX = 0o1000
+pub const S_IRUSR = 0o400
+pub const S_IWUSR = 0o200
+pub const S_IXUSR = 0o100
+pub const S_IRWXU = 0o700
+pub const S_IRGRP = 0o40
+pub const S_IWGRP = 0o20
+pub const S_IXGRP = 0o10
+pub const S_IRWXG = 0o70
+pub const S_IROTH = 0o4
+pub const S_IWOTH = 0o2
+pub const S_IXOTH = 0o1
+pub const S_IRWXO = 0o7
 
 // Access mode constants
-const F_OK = 0
-const R_OK = 4
-const W_OK = 2
-const X_OK = 1
+pub const F_OK = 0
+pub const R_OK = 4
+pub const W_OK = 2
+pub const X_OK = 1
 
 // File locking constants
-const F_ULOCK = 0
-const F_LOCK = 1
-const F_TLOCK = 2
-const F_TEST = 3
+pub const F_ULOCK = 0
+pub const F_LOCK = 1
+pub const F_TLOCK = 2
+pub const F_TEST = 3
 
 // Additional fcntl commands (GNU/Linux extensions)
-const F_SETLEASE = 1024
-const F_GETLEASE = 1025
-const F_NOTIFY = 1026
-const F_CANCELLK = 1029
-const F_SETPIPE_SZ = 1031
-const F_GETPIPE_SZ = 1032
-const F_ADD_SEALS = 1033
-const F_GET_SEALS = 1034
+pub const F_SETLEASE = 1024
+pub const F_GETLEASE = 1025
+pub const F_NOTIFY = 1026
+pub const F_CANCELLK = 1029
+pub const F_SETPIPE_SZ = 1031
+pub const F_GETPIPE_SZ = 1032
+pub const F_ADD_SEALS = 1033
+pub const F_GET_SEALS = 1034
 
 // File sealing constants
-const F_SEAL_SEAL = 0x0001
-const F_SEAL_SHRINK = 0x0002
-const F_SEAL_GROW = 0x0004
-const F_SEAL_WRITE = 0x0008
-const F_SEAL_FUTURE_WRITE = 0x0010
+pub const F_SEAL_SEAL = 0x0001
+pub const F_SEAL_SHRINK = 0x0002
+pub const F_SEAL_GROW = 0x0004
+pub const F_SEAL_WRITE = 0x0008
+pub const F_SEAL_FUTURE_WRITE = 0x0010
 
 // Read/write hint constants
-const F_GET_RW_HINT = 1035
-const F_SET_RW_HINT = 1036
-const F_GET_FILE_RW_HINT = 1037
-const F_SET_FILE_RW_HINT = 1038
+pub const F_GET_RW_HINT = 1035
+pub const F_SET_RW_HINT = 1036
+pub const F_GET_FILE_RW_HINT = 1037
+pub const F_SET_FILE_RW_HINT = 1038
 
-const RWF_WRITE_LIFE_NOT_SET = 0
-const RWH_WRITE_LIFE_NONE = 1
-const RWH_WRITE_LIFE_SHORT = 2
-const RWH_WRITE_LIFE_MEDIUM = 3
-const RWH_WRITE_LIFE_LONG = 4
-const RWH_WRITE_LIFE_EXTREME = 5
+pub const RWF_WRITE_LIFE_NOT_SET = 0
+pub const RWH_WRITE_LIFE_NONE = 1
+pub const RWH_WRITE_LIFE_SHORT = 2
+pub const RWH_WRITE_LIFE_MEDIUM = 3
+pub const RWH_WRITE_LIFE_LONG = 4
+pub const RWH_WRITE_LIFE_EXTREME = 5
 
 // Directory notification constants
-const DN_ACCESS = 0x00000001
-const DN_MODIFY = 0x00000002
-const DN_CREATE = 0x00000004
-const DN_DELETE = 0x00000008
-const DN_RENAME = 0x00000010
-const DN_ATTRIB = 0x00000020
-const DN_MULTISHOT = 0x80000000
+pub const DN_ACCESS = 0x00000001
+pub const DN_MODIFY = 0x00000002
+pub const DN_CREATE = 0x00000004
+pub const DN_DELETE = 0x00000008
+pub const DN_RENAME = 0x00000010
+pub const DN_ATTRIB = 0x00000020
+pub const DN_MULTISHOT = 0x80000000
 
 // File owner types
-const F_OWNER_TID = 0
-const F_OWNER_PID = 1
-const F_OWNER_PGRP = 2
-const F_OWNER_GID = 2
+pub const F_OWNER_TID = 0
+pub const F_OWNER_PID = 1
+pub const F_OWNER_PGRP = 2
+pub const F_OWNER_GID = 2
 
 
 // Fallocate flags
-const FALLOC_FL_KEEP_SIZE = 1
-const FALLOC_FL_PUNCH_HOLE = 2
-const MAX_HANDLE_SZ = 128
+pub const FALLOC_FL_KEEP_SIZE = 1
+pub const FALLOC_FL_PUNCH_HOLE = 2
+pub const MAX_HANDLE_SZ = 128
 
 // Sync file range flags
-const SYNC_FILE_RANGE_WAIT_BEFORE = 1
-const SYNC_FILE_RANGE_WRITE = 2
-const SYNC_FILE_RANGE_WAIT_AFTER = 4
+pub const SYNC_FILE_RANGE_WAIT_BEFORE = 1
+pub const SYNC_FILE_RANGE_WRITE = 2
+pub const SYNC_FILE_RANGE_WAIT_AFTER = 4
 
 // Splice flags
-const SPLICE_F_MOVE = 1
-const SPLICE_F_NONBLOCK = 2
-const SPLICE_F_MORE = 4
-const SPLICE_F_GIFT = 8
+pub const SPLICE_F_MOVE = 1
+pub const SPLICE_F_NONBLOCK = 2
+pub const SPLICE_F_MORE = 4
+pub const SPLICE_F_GIFT = 8
 
 // Basic file operations
-#linkid creat
+pub #linkid creat
 fn creat(cstr pathname, mode_t mode):i32
 
-#linkid fcntl
+pub #linkid fcntl
 fn fcntl(i32 fd, i32 cmd, anyptr flag):i32
 
-#linkid open
+pub #linkid open
 fn open(cstr pathname, i32 flags, u32 mode):i32
 
-#linkid openat
+pub #linkid openat
 fn openat(i32 dirfd, cstr pathname, i32 flags, u32 mode):i32
 
 // POSIX advisory functions
-#linkid posix_fadvise
+pub #linkid posix_fadvise
 fn posix_fadvise(i32 fd, off_t offset, off_t len, i32 advice):i32
 
-#linkid posix_fallocate
+pub #linkid posix_fallocate
 fn posix_fallocate(i32 fd, off_t offset, off_t len):i32
 
 // GNU/Linux extensions
-#linkid fallocate
+pub #linkid fallocate
 fn fallocate(i32 fd, i32 mode, off_t offset, off_t len):i32
 
-#linkid name_to_handle_at
+pub #linkid name_to_handle_at
 fn name_to_handle_at(i32 dirfd, cstr pathname, anyptr handle, ptr<i32> mount_id, i32 flags):i32
 
-#linkid open_by_handle_at
+pub #linkid open_by_handle_at
 fn open_by_handle_at(i32 mount_fd, anyptr handle, i32 flags):i32
 
-#linkid readahead
+pub #linkid readahead
 fn readahead(i32 fd, off_t offset, u64 count):i64
 
-#linkid sync_file_range
+pub #linkid sync_file_range
 fn sync_file_range(i32 fd, off_t offset, off_t nbytes, u32 flags):i32
 
 // Splice operations
-#linkid vmsplice
+pub #linkid vmsplice
 fn vmsplice(i32 fd, anyptr iov, u64 nr_segs, u32 flags):i64
 
-#linkid splice
+pub #linkid splice
 fn splice(i32 fd_in, ptr<off_t> off_in, i32 fd_out, ptr<off_t> off_out, u64 len, u32 flags):i64
 
-#linkid tee
+pub #linkid tee
 fn tee(i32 fd_in, i32 fd_out, u64 len, u32 flags):i64
 
 
 
 // signal.h
-#linkid std_args
+pub #linkid std_args
 fn std_args():[string]
 
 // 主机顺序转网络顺序
-#linkid htons
+pub #linkid htons
 fn htons(u16 host):u16
 
-#linkid htonl
+pub #linkid htonl
 fn htonl(u32 host):u32
 
 // 网络顺序转主机顺序
-#linkid ntohs
+pub #linkid ntohs
 fn ntohs(u16 x):u16
 
-#linkid ntohl
+pub #linkid ntohl
 fn ntohl(u32 x):u32
 
-#linkid inet_pton
+pub #linkid inet_pton
 fn inet_pton(i32 family, anyptr src_str, anyptr dst_buf):i32
 
-#linkid inet_ntop
+pub #linkid inet_ntop
 fn inet_ntop(i32 family, anyptr src_buf, anyptr dst_str, i32 len):i32
 
 /*
@@ -1917,15 +1917,15 @@ int MAP_PRIVATE = 0x2
 int MAP_RENAME = 0x20
 
 // 通过空值 options 实现阻塞和非阻塞模式
-#linkid waitpid
+pub #linkid waitpid
 fn waitpid(int pid, ptr<int> status, int options):int
 
 // --- signal 相关 <sys/signalfd.h> 和 <signal.h>
-type sigset_t = struct {
+pub type sigset_t = struct {
     [u64;16] __val
 }
 
-type signalfd_siginfo_t = struct {
+pub type signalfd_siginfo_t = struct {
     u32 ssi_signo
     i32 ssi_errno
     i32 ssi_code
@@ -1950,48 +1950,48 @@ type signalfd_siginfo_t = struct {
     [u8;48] __pad
 }
 
-#linkid sigemptyset
+pub #linkid sigemptyset
 fn sigemptyset(ref<sigset_t> sigset):i32
 
-#linkid sigaddset
+pub #linkid sigaddset
 fn sigaddset(ref<sigset_t> sigset, i32 signo):i32
 
-#linkid sigfillset
+pub #linkid sigfillset
 fn sigfillset(ref<sigset_t> sigset):i32
 
-#linkid sigprocmask
+pub #linkid sigprocmask
 fn sigprocmask(i32 how, ref<sigset_t> sigset, ptr<sigset_t> oldset):i32
 
-#linkid signalfd
+pub #linkid signalfd
 fn signalfd(int fd, ref<sigset_t> mask, i32 flags):i32
 
-#linkid prctl
+pub #linkid prctl
 fn prctl(int option, u64 arg2, u64 arg3, u64 arg4, u64 arg5):int
 
-#linkid uv_hrtime
+pub #linkid uv_hrtime
 fn uv_hrtime():u64
 
 // 读取当前全局的 errno 编码
-#linkid rt_errno
+pub #linkid rt_errno
 fn errno():int
 
-#linkid rt_get_envs
+pub #linkid rt_get_envs
 fn get_envs():[string]
 
-#linkid fork
+pub #linkid fork
 fn fork():int
 
-#linkid getcwd
+pub #linkid getcwd
 fn getcwd(cstr path, uint size):cstr
 
-#linkid mmap
+pub #linkid mmap
 fn mmap(anyptr addr, int len, int prot, int flags, int fd, int off):anyptr
 
-#linkid munmap
+pub #linkid munmap
 fn munmap(anyptr addr, int len)
 
-#linkid isprint
+pub #linkid isprint
 fn isprint(u8 c):bool
 
-#linkid isspace
+pub #linkid isspace
 fn isspace(u8 c):bool

--- a/std/mem/mem.n
+++ b/std/mem/mem.n
@@ -2,7 +2,7 @@ mod mem
 
 import libc
 
-fn copy<T>([u8] buf, ptr<T> dst):void! {
+pub fn copy<T>([u8] buf, ptr<T> dst):void! {
     int size = @sizeof(T)
     if size == 0 {
         throw errorf('type size failed')   
@@ -14,18 +14,18 @@ fn copy<T>([u8] buf, ptr<T> dst):void! {
     libc.memmove(dst as anyptr, buf.ref(), size as u64)
 }
 
-fn write_u8_le(u8 i):[u8]! {
+pub fn write_u8_le(u8 i):[u8]! {
     return [i]
 }
 
-fn write_u16_le(u16 i):[u8]! {
+pub fn write_u16_le(u16 i):[u8]! {
     return [
         (i & 0xFF) as u8,
         ((i >> 8) & 0xFF) as u8,
     ]
 }
 
-fn write_u32_le(u32 i):[u8]! {
+pub fn write_u32_le(u32 i):[u8]! {
     return [
         (i & 0xFF) as u8,
         ((i >> 8) & 0xFF) as u8,
@@ -34,7 +34,7 @@ fn write_u32_le(u32 i):[u8]! {
     ]
 }
 
-fn write_u64_le(u64 i):[u8]! {
+pub fn write_u64_le(u64 i):[u8]! {
     return [
         (i & 0xFF) as u8,
         ((i >> 8) & 0xFF) as u8,
@@ -47,18 +47,18 @@ fn write_u64_le(u64 i):[u8]! {
     ]
 }
 
-fn write_i8_le(i8 i):[u8]! {
+pub fn write_i8_le(i8 i):[u8]! {
     return [i as u8]
 }
 
-fn write_i16_le(i16 i):[u8]! {
+pub fn write_i16_le(i16 i):[u8]! {
     return [
         (i & 0xFF) as u8,
         ((i >> 8) & 0xFF) as u8,
     ]
 }
 
-fn write_i32_le(i32 i):[u8]! {
+pub fn write_i32_le(i32 i):[u8]! {
     return [
         (i & 0xFF) as u8,
         ((i >> 8) & 0xFF) as u8,
@@ -67,7 +67,7 @@ fn write_i32_le(i32 i):[u8]! {
     ]
 }
 
-fn write_i64_le(i64 i):[u8]! {
+pub fn write_i64_le(i64 i):[u8]! {
     return [
         (i & 0xFF) as u8,
         ((i >> 8) & 0xFF) as u8,
@@ -80,32 +80,32 @@ fn write_i64_le(i64 i):[u8]! {
     ]
 }
 
-fn write_f32_le(f32 f):[u8]! {
+pub fn write_f32_le(f32 f):[u8]! {
     u32 bits = 0
     libc.memmove(&bits as anyptr, &f as anyptr, 4)
     
     return write_u32_le(bits)
 }
 
-fn write_f64_le(f64 f):[u8]! {
+pub fn write_f64_le(f64 f):[u8]! {
     u64 bits = 0
     libc.memmove(&bits as anyptr, &f as anyptr, 8)
     
     return write_u64_le(bits)
 }
 
-fn write_u8_be(u8 i):[u8]! {
+pub fn write_u8_be(u8 i):[u8]! {
     return [i]
 }
 
-fn write_u16_be(u16 i):[u8]! {
+pub fn write_u16_be(u16 i):[u8]! {
     return [
         ((i >> 8) & 0xFF) as u8,
         (i & 0xFF) as u8,
     ]
 }
 
-fn write_u32_be(u32 i):[u8]! {
+pub fn write_u32_be(u32 i):[u8]! {
     return [
         ((i >> 24) & 0xFF) as u8,
         ((i >> 16) & 0xFF) as u8,
@@ -114,7 +114,7 @@ fn write_u32_be(u32 i):[u8]! {
     ]
 }
 
-fn write_u64_be(u64 i):[u8]! {
+pub fn write_u64_be(u64 i):[u8]! {
     return [
         ((i >> 56) & 0xFF) as u8,
         ((i >> 48) & 0xFF) as u8,
@@ -127,18 +127,18 @@ fn write_u64_be(u64 i):[u8]! {
     ]
 }
 
-fn write_i8_be(i8 i):[u8]! {
+pub fn write_i8_be(i8 i):[u8]! {
     return [i as u8]
 }
 
-fn write_i16_be(i16 i):[u8]! {
+pub fn write_i16_be(i16 i):[u8]! {
     return [
         ((i >> 8) & 0xFF) as u8,
         (i & 0xFF) as u8,
     ]
 }
 
-fn write_i32_be(i32 i):[u8]! {
+pub fn write_i32_be(i32 i):[u8]! {
     return [
         ((i >> 24) & 0xFF) as u8,
         ((i >> 16) & 0xFF) as u8,
@@ -147,7 +147,7 @@ fn write_i32_be(i32 i):[u8]! {
     ]
 }
 
-fn write_i64_be(i64 i):[u8]! {
+pub fn write_i64_be(i64 i):[u8]! {
     return [
         ((i >> 56) & 0xFF) as u8,
         ((i >> 48) & 0xFF) as u8,
@@ -160,21 +160,21 @@ fn write_i64_be(i64 i):[u8]! {
     ]
 }
 
-fn write_f32_be(f32 f):[u8]! {
+pub fn write_f32_be(f32 f):[u8]! {
     u32 bits = 0
     libc.memmove(&bits as anyptr, &f as anyptr, 4)
     
     return write_u32_be(bits)
 }
 
-fn write_f64_be(f64 f):[u8]! {
+pub fn write_f64_be(f64 f):[u8]! {
     u64 bits = 0
     libc.memmove(&bits as anyptr, &f as anyptr, 8)
     
     return write_u64_be(bits)
 }
 
-fn read_u8_le([u8] buf):u8! {
+pub fn read_u8_le([u8] buf):u8! {
     if buf.len() < 1 {
         throw errorf('buffer too small')
     }
@@ -182,21 +182,21 @@ fn read_u8_le([u8] buf):u8! {
     return buf[0]
 }
 
-fn read_u16_le([u8] buf):u16! {
+pub fn read_u16_le([u8] buf):u16! {
     if buf.len() < 2 {
         throw errorf('buffer too small')
     }
     return (buf[1] as u16) << 8 | (buf[0] as u16)
 }
 
-fn read_u32_le([u8] buf):u32! {
+pub fn read_u32_le([u8] buf):u32! {
     if buf.len() < 4 {
         throw errorf('buffer too small')
     }
     return (buf[3] as u32) << 24 | (buf[2] as u32) << 16 | (buf[1] as u32) << 8 | (buf[0] as u32)
 }
 
-fn read_u64_le([u8] buf):u64! {
+pub fn read_u64_le([u8] buf):u64! {
     if buf.len() < 8 {
         throw errorf('buffer too small')
     }
@@ -204,28 +204,28 @@ fn read_u64_le([u8] buf):u64! {
            (buf[3] as u64) << 24 | (buf[2] as u64) << 16 | (buf[1] as u64) << 8  | (buf[0] as u64)
 }
 
-fn read_i8_le([u8] buf):i8! {
+pub fn read_i8_le([u8] buf):i8! {
     if buf.len() < 1 {
         throw errorf('buffer too small')
     }
     return buf[0] as i8
 }
 
-fn read_i16_le([u8] buf):i16! {
+pub fn read_i16_le([u8] buf):i16! {
     if buf.len() < 2 {
         throw errorf('buffer too small')
     }
     return ((buf[1] as i16) << 8 | (buf[0] as i16)) as i16
 }
 
-fn read_i32_le([u8] buf):i32! {
+pub fn read_i32_le([u8] buf):i32! {
     if buf.len() < 4 {
         throw errorf('buffer too small')
     }
     return ((buf[3] as i32) << 24 | (buf[2] as i32) << 16 | (buf[1] as i32) << 8 | (buf[0] as i32)) as i32
 }
 
-fn read_i64_le([u8] buf):i64! {
+pub fn read_i64_le([u8] buf):i64! {
     if buf.len() < 8 {
         throw errorf('buffer too small')
     }
@@ -235,28 +235,28 @@ fn read_i64_le([u8] buf):i64! {
 
 
 
-fn read_u8_be([u8] buf):u8! {
+pub fn read_u8_be([u8] buf):u8! {
     if buf.len() < 1 {
         throw errorf('buffer too small')
     }
     return buf[0]
 }
 
-fn read_u16_be([u8] buf):u16! {
+pub fn read_u16_be([u8] buf):u16! {
     if buf.len() < 2 {
         throw errorf('buffer too small')
     }
     return (buf[0] as u16) << 8 | (buf[1] as u16)
 }
 
-fn read_u32_be([u8] buf):u32! {
+pub fn read_u32_be([u8] buf):u32! {
     if buf.len() < 4 {
         throw errorf('buffer too small')
     }
     return (buf[0] as u32) << 24 | (buf[1] as u32) << 16 | (buf[2] as u32) << 8 | (buf[3] as u32)
 }
 
-fn read_u64_be([u8] buf):u64! {
+pub fn read_u64_be([u8] buf):u64! {
     if buf.len() < 8 {
         throw errorf('buffer too small')
     }
@@ -264,28 +264,28 @@ fn read_u64_be([u8] buf):u64! {
            (buf[4] as u64) << 24 | (buf[5] as u64) << 16 | (buf[6] as u64) << 8  | (buf[7] as u64)
 }
 
-fn read_i8_be([u8] buf):i8! {
+pub fn read_i8_be([u8] buf):i8! {
     if buf.len() < 1 {
         throw errorf('buffer too small')
     }
     return buf[0] as i8
 }
 
-fn read_i16_be([u8] buf):i16! {
+pub fn read_i16_be([u8] buf):i16! {
     if buf.len() < 2 {
         throw errorf('buffer too small')
     }
     return ((buf[0] as i16) << 8 | (buf[1] as i16)) as i16
 }
 
-fn read_i32_be([u8] buf):i32! {
+pub fn read_i32_be([u8] buf):i32! {
     if buf.len() < 4 {
         throw errorf('buffer too small')
     }
     return ((buf[0] as i32) << 24 | (buf[1] as i32) << 16 | (buf[2] as i32) << 8 | (buf[3] as i32)) as i32
 }
 
-fn read_i64_be([u8] buf):i64! {
+pub fn read_i64_be([u8] buf):i64! {
     if buf.len() < 8 {
         throw errorf('buffer too small')
     }
@@ -294,7 +294,7 @@ fn read_i64_be([u8] buf):i64! {
 }
 
 
-fn read_f32_le([u8] buf):f32! {
+pub fn read_f32_le([u8] buf):f32! {
     if buf.len() < 4 {
         throw errorf('buffer too small')
     }
@@ -307,7 +307,7 @@ fn read_f32_le([u8] buf):f32! {
     return result
 }
 
-fn read_f64_le([u8] buf):f64! {
+pub fn read_f64_le([u8] buf):f64! {
     if buf.len() < 8 {
         throw errorf('buffer too small')
     }
@@ -321,7 +321,7 @@ fn read_f64_le([u8] buf):f64! {
     return result
 }
 
-fn read_f32_be([u8] buf):f32! {
+pub fn read_f32_be([u8] buf):f32! {
     if buf.len() < 4 {
         throw errorf('buffer too small')
     }
@@ -334,7 +334,7 @@ fn read_f32_be([u8] buf):f32! {
     return result
 }
 
-fn read_f64_be([u8] buf):f64! {
+pub fn read_f64_be([u8] buf):f64! {
     if buf.len() < 8 {
         throw errorf('buffer too small')
     }

--- a/std/net/dns.n
+++ b/std/net/dns.n
@@ -2,7 +2,7 @@
 #linkid rt_uv_dns_lookup
 fn uv_dns_lookup(string host):[string]!
 
-fn lookup(string host):[string]! {
+pub fn lookup(string host):[string]! {
     var ips = uv_dns_lookup(host)
 
     return ips

--- a/std/net/tcp.n
+++ b/std/net/tcp.n
@@ -4,7 +4,7 @@ import io
 import co.cross
 import net.types
 
-type server_t = struct{
+pub type server_t = struct{
     string ip
     int port
     bool closed
@@ -12,7 +12,7 @@ type server_t = struct{
     anyptr inner
 }
 
-type conn_t:types.connable = struct{
+pub type conn_t:types.connable = struct{
     anyptr conn
     bool closed
     int read_timeout_ms
@@ -24,30 +24,30 @@ fn uv_tcp_listen(ref<server_t> s):void!
 #linkid rt_uv_tcp_connect
 fn uv_tcp_connect(ref<conn_t> conn, string ip, int port, int timeout):void!
 
-#linkid rt_uv_tcp_server_close
+pub #linkid rt_uv_tcp_server_close
 fn server_t.close(&self)
 
 #linkid rt_uv_tcp_accept
 fn uv_tcp_accept(ref<server_t> server, ref<conn_t> conn):void!
 
-#linkid rt_uv_tcp_read
+pub #linkid rt_uv_tcp_read
 fn conn_t.read(&self, [u8] buf):int!
 
-#linkid rt_uv_tcp_write
+pub #linkid rt_uv_tcp_write
 fn conn_t.write(&self, [u8] buf):int!
 
-#linkid rt_uv_tcp_conn_close
+pub #linkid rt_uv_tcp_conn_close
 fn conn_t.close(&self)
 
-fn conn_t.set_read_timeout(&self, int timeout_ms) {
+pub fn conn_t.set_read_timeout(&self, int timeout_ms) {
     self.read_timeout_ms = timeout_ms
 }
 
-fn conn_t.read_timeout(&self):int {
+pub fn conn_t.read_timeout(&self):int {
     return self.read_timeout_ms
 }
 
-fn server_t.accept(&self):ref<conn_t>! {
+pub fn server_t.accept(&self):ref<conn_t>! {
     if self.closed {
         throw errorf('server closed')
     }
@@ -58,7 +58,7 @@ fn server_t.accept(&self):ref<conn_t>! {
 }
 
 // host like 127.0.0.1:8080 or :8080
-fn listen(string host):ref<server_t>! {
+pub fn listen(string host):ref<server_t>! {
     var (ip, port) = utils.split_host(host)
 
     var s = new server_t(ip, port)
@@ -67,12 +67,12 @@ fn listen(string host):ref<server_t>! {
     return s
 }
 
-fn connect(string host):ref<conn_t>! {
+pub fn connect(string host):ref<conn_t>! {
     return connect_timeout(host, 0)
 }
 
 
-fn connect_timeout(string host, int timeout):ref<conn_t>! {
+pub fn connect_timeout(string host, int timeout):ref<conn_t>! {
     var (ip, port) = utils.split_host(host)
     var conn = new conn_t()
     uv_tcp_connect(conn, ip, port, timeout)

--- a/std/net/tcp.n
+++ b/std/net/tcp.n
@@ -24,20 +24,20 @@ fn uv_tcp_listen(ref<server_t> s):void!
 #linkid rt_uv_tcp_connect
 fn uv_tcp_connect(ref<conn_t> conn, string ip, int port, int timeout):void!
 
-pub #linkid rt_uv_tcp_server_close
-fn server_t.close(&self)
+#linkid rt_uv_tcp_server_close
+pub fn server_t.close(&self)
 
 #linkid rt_uv_tcp_accept
 fn uv_tcp_accept(ref<server_t> server, ref<conn_t> conn):void!
 
-pub #linkid rt_uv_tcp_read
-fn conn_t.read(&self, [u8] buf):int!
+#linkid rt_uv_tcp_read
+pub fn conn_t.read(&self, [u8] buf):int!
 
-pub #linkid rt_uv_tcp_write
-fn conn_t.write(&self, [u8] buf):int!
+#linkid rt_uv_tcp_write
+pub fn conn_t.write(&self, [u8] buf):int!
 
-pub #linkid rt_uv_tcp_conn_close
-fn conn_t.close(&self)
+#linkid rt_uv_tcp_conn_close
+pub fn conn_t.close(&self)
 
 pub fn conn_t.set_read_timeout(&self, int timeout_ms) {
     self.read_timeout_ms = timeout_ms

--- a/std/net/tls.n
+++ b/std/net/tls.n
@@ -3,7 +3,7 @@ import strings
 import io
 import net.types
 
-type conn_t:types.connable = struct{
+pub type conn_t:types.connable = struct{
     anyptr conn
     bool closed
     int read_timeout_ms
@@ -12,28 +12,28 @@ type conn_t:types.connable = struct{
 #linkid rt_uv_tls_connect
 fn uv_tls_connect(ref<conn_t> conn, string ip, int port, int timeout):void!
 
-#linkid rt_uv_tls_read
+pub #linkid rt_uv_tls_read
 fn conn_t.read(&self, [u8] buf):int!
 
-#linkid rt_uv_tls_write
+pub #linkid rt_uv_tls_write
 fn conn_t.write(&self, [u8] buf):int!
 
-#linkid rt_uv_tls_conn_close
+pub #linkid rt_uv_tls_conn_close
 fn conn_t.close(&self)
 
-fn conn_t.set_read_timeout(&self, int timeout_ms) {
+pub fn conn_t.set_read_timeout(&self, int timeout_ms) {
     self.read_timeout_ms = timeout_ms
 }
 
-fn conn_t.read_timeout(&self):int {
+pub fn conn_t.read_timeout(&self):int {
     return self.read_timeout_ms
 }
 
-fn connect(string host):ref<conn_t>! {
+pub fn connect(string host):ref<conn_t>! {
     return connect_timeout(host, 0)
 }
 
-fn connect_timeout(string host, int timeout):ref<conn_t>! {
+pub fn connect_timeout(string host, int timeout):ref<conn_t>! {
     var (ip, port) = utils.split_host(host)
     var conn = new conn_t()
     uv_tls_connect(conn, ip, port, timeout)

--- a/std/net/tls.n
+++ b/std/net/tls.n
@@ -12,14 +12,14 @@ pub type conn_t:types.connable = struct{
 #linkid rt_uv_tls_connect
 fn uv_tls_connect(ref<conn_t> conn, string ip, int port, int timeout):void!
 
-pub #linkid rt_uv_tls_read
-fn conn_t.read(&self, [u8] buf):int!
+#linkid rt_uv_tls_read
+pub fn conn_t.read(&self, [u8] buf):int!
 
-pub #linkid rt_uv_tls_write
-fn conn_t.write(&self, [u8] buf):int!
+#linkid rt_uv_tls_write
+pub fn conn_t.write(&self, [u8] buf):int!
 
-pub #linkid rt_uv_tls_conn_close
-fn conn_t.close(&self)
+#linkid rt_uv_tls_conn_close
+pub fn conn_t.close(&self)
 
 pub fn conn_t.set_read_timeout(&self, int timeout_ms) {
     self.read_timeout_ms = timeout_ms

--- a/std/net/types.n
+++ b/std/net/types.n
@@ -3,7 +3,7 @@ import io
 // A network connection can be read, written, and explicitly closed. Keeping
 // close in the common interface lets higher-level streaming protocols release
 // a connection as soon as their body is complete or cancelled.
-type connable:io.writer,io.reader = interface{
+pub type connable:io.writer,io.reader = interface{
     fn close()
     fn set_read_timeout(int timeout_ms)
     fn read_timeout():int

--- a/std/net/udp.n
+++ b/std/net/udp.n
@@ -49,8 +49,8 @@ pub fn bind(string host):ref<socket_t>! {
     return s
 }
 
-pub #linkid rt_uv_udp_close
-fn socket_t.close(&self)
+#linkid rt_uv_udp_close
+pub fn socket_t.close(&self)
 
 pub fn socket_t.recvfrom(&self, [u8] buf):(int, addr_t)! {
     if self.closed {

--- a/std/net/udp.n
+++ b/std/net/udp.n
@@ -12,7 +12,7 @@ type addr_t = struct{
     bool v4
 }
 
-type socket_t = struct{
+pub type socket_t = struct{
     addr_t addr
 
     anyptr handle
@@ -21,7 +21,7 @@ type socket_t = struct{
     uint fd
 }
 
-type conn_t:io.reader, io.writer = struct{
+pub type conn_t:io.reader, io.writer = struct{
     ref<socket_t> socket
     addr_t remote_addr
 }
@@ -32,7 +32,7 @@ fn uv_udp_bind(ref<socket_t> s):void!
 #linkid rt_uv_udp_recvfrom
 fn uv_udp_recvfrom(ref<socket_t> s, [u8] buf, ptr<addr_t> addr):int!
 
-fn bind(string host):ref<socket_t>! {
+pub fn bind(string host):ref<socket_t>! {
     var (ip, port) = utils.split_host(host)
     var addr = addr_t{port: port, v4: utils.is_ipv4(ip)}
 
@@ -49,10 +49,10 @@ fn bind(string host):ref<socket_t>! {
     return s
 }
 
-#linkid rt_uv_udp_close
+pub #linkid rt_uv_udp_close
 fn socket_t.close(&self)
 
-fn socket_t.recvfrom(&self, [u8] buf):(int, addr_t)! {
+pub fn socket_t.recvfrom(&self, [u8] buf):(int, addr_t)! {
     if self.closed {
         throw errorf('socket closed')
     }
@@ -65,7 +65,7 @@ fn socket_t.recvfrom(&self, [u8] buf):(int, addr_t)! {
 #linkid rt_uv_udp_sendto
 fn uv_sendto(ref<socket_t> s, [u8] buf, addr_t addr):int!
 
-fn socket_t.sendto(&self, [u8] buf, string host):int! {
+pub fn socket_t.sendto(&self, [u8] buf, string host):int! {
     if self.closed {
        throw errorf('socket closed')
     }
@@ -82,7 +82,7 @@ fn socket_t.sendto(&self, [u8] buf, string host):int! {
     return uv_sendto(self, buf, addr)
 }
 
-fn socket_t.connect(&self, string host):ref<conn_t>! {
+pub fn socket_t.connect(&self, string host):ref<conn_t>! {
     if self.closed {
         throw errorf('socket closed')
     }
@@ -103,12 +103,12 @@ fn socket_t.connect(&self, string host):ref<conn_t>! {
     return conn
 }
 
-fn connect(string host):ref<conn_t>! {
+pub fn connect(string host):ref<conn_t>! {
     var s = bind('0.0.0.0:0')
     return s.connect(host)
 }
 
-fn conn_t.write(&self, [u8] buf):int! {
+pub fn conn_t.write(&self, [u8] buf):int! {
     if self.socket.closed {
         throw errorf('socket closed')
     }
@@ -116,7 +116,7 @@ fn conn_t.write(&self, [u8] buf):int! {
     return uv_sendto(self.socket, buf, self.remote_addr)
 }
 
-fn conn_t.read(&self, [u8] buf):int! {
+pub fn conn_t.read(&self, [u8] buf):int! {
     if self.socket.closed {
         throw errorf('socket closed')
     }
@@ -125,7 +125,7 @@ fn conn_t.read(&self, [u8] buf):int! {
 }
 
 
-fn conn_t.close(&self) {
+pub fn conn_t.close(&self) {
     self.socket.close()
 }
 
@@ -143,6 +143,6 @@ fn addr_t.ip(*self):string {
     return data[..len] as string
 }
 
-fn addr_t.to_string(*self):string {
+pub fn addr_t.to_string(*self):string {
     return fmt.sprintf('%s:%d', self.ip(), self.port)
 }

--- a/std/net/url.n
+++ b/std/net/url.n
@@ -1,4 +1,4 @@
-type url_t = struct{
+pub type url_t = struct{
     string url
     string scheme
     string authority
@@ -18,7 +18,7 @@ const QUERY = 4
 const FRAGMENT = 5
 
 
-fn parse(string url):url_t! {
+pub fn parse(string url):url_t! {
     if url.len() == 0 {
         throw errorf('url cannot empty')
     }
@@ -130,7 +130,7 @@ fn parse_authority(ptr<url_t> result, string authority) {
     }
 }
 
-fn query_t.get(self, string key):string {
+pub fn query_t.get(self, string key):string {
     if !self.contains(key) {
         return ''
     }
@@ -138,7 +138,7 @@ fn query_t.get(self, string key):string {
     return self[key][0]
 }
 
-fn url_t.query(*self):query_t {
+pub fn url_t.query(*self):query_t {
     query_t result = {}
     
     if self.raw_query.len() == 0 {
@@ -170,7 +170,7 @@ fn url_t.query(*self):query_t {
     return result
 }
 
-fn url_t.request_uri(*self):string {
+pub fn url_t.request_uri(*self):string {
     if self.raw_query.len() > 0 {
         return self.path + '?' + self.raw_query
     } else {
@@ -178,7 +178,7 @@ fn url_t.request_uri(*self):string {
     }
 }
 
-fn decode(string s):string {
+pub fn decode(string s):string {
     if s.len() == 0 {
         return s
     }
@@ -227,7 +227,7 @@ fn hex_to_int(u8 ch):int {
 }
 
 
-fn encode(string s):string {
+pub fn encode(string s):string {
     if s.len() == 0 {
         return s
     }

--- a/std/net/utils.n
+++ b/std/net/utils.n
@@ -1,6 +1,6 @@
 import libc
 
-fn split_host(string host):(string, int)! {
+pub fn split_host(string host):(string, int)! {
     var list = host.split(':')
     if list[0] == '' {
         list[0] = '0.0.0.0'
@@ -9,7 +9,7 @@ fn split_host(string host):(string, int)! {
     return (list[0], list[1].to_int())
 }
 
-fn is_ipv4(string ip):bool {
+pub fn is_ipv4(string ip):bool {
     u32 in_addr = 0
     return libc.inet_pton(libc.AF_INET, ip.ref(), &in_addr as anyptr) == 1
 }

--- a/std/os/os.n
+++ b/std/os/os.n
@@ -8,7 +8,7 @@ import runtime
 
 type signal = u8
 
-fn args():[string] {
+pub fn args():[string] {
     return libc.std_args()
 }
 
@@ -34,7 +34,7 @@ fn dirs_sort([string] dirs) {
 
 // unsafe ptr
 // The order of return is uncertain
-fn listdir(string path):[string]! {
+pub fn listdir(string path):[string]! {
     [string] result = []
 
     var dir = dirent.opendir(path.ref())
@@ -65,7 +65,7 @@ fn listdir(string path):[string]! {
 
 // use dir.split(dir, '/')
 // join and syscall.mkdir(dir, mode)
-fn mkdirs(string dir, u32 mode):void! {
+pub fn mkdirs(string dir, u32 mode):void! {
     if dir == '' {
         throw errorf('dir is empty')
     }
@@ -83,7 +83,7 @@ fn mkdirs(string dir, u32 mode):void! {
 }
 
 // use remove file
-fn remove(string full_path):void! {
+pub fn remove(string full_path):void! {
     if !path.exists(full_path) {
         return
     }
@@ -91,7 +91,7 @@ fn remove(string full_path):void! {
     syscall.unlink(full_path)
 }
 
-fn rmdir(string dir, bool recursive):void! {
+pub fn rmdir(string dir, bool recursive):void! {
     if !recursive {
         return syscall.rmdir(dir)
     }

--- a/std/os/os.windows_amd64.n
+++ b/std/os/os.windows_amd64.n
@@ -19,7 +19,7 @@ fn windows_find_close(anyptr handle): i32
 #local #linkid GetLastError
 fn windows_last_error(): u32
 
-fn args():[string] {
+pub fn args():[string] {
     return libc.std_args()
 }
 
@@ -40,7 +40,7 @@ fn dirs_sort([string] dirs) {
     }
 }
 
-fn listdir(string dir_path):[string]! {
+pub fn listdir(string dir_path):[string]! {
     [string] result = []
     string pattern = dir_path
     if pattern == '' {
@@ -78,7 +78,7 @@ fn listdir(string dir_path):[string]! {
     return result
 }
 
-fn mkdirs(string dir, u32 mode):void! {
+pub fn mkdirs(string dir, u32 mode):void! {
     if dir == '' {
         throw errorf('dir is empty')
     }
@@ -93,14 +93,14 @@ fn mkdirs(string dir, u32 mode):void! {
     syscall.mkdir(dir, mode)
 }
 
-fn remove(string full_path):void! {
+pub fn remove(string full_path):void! {
     if !path.exists(full_path) {
         return
     }
     syscall.unlink(full_path)
 }
 
-fn rmdir(string dir, bool recursive):void! {
+pub fn rmdir(string dir, bool recursive):void! {
     if !recursive {
         return syscall.rmdir(dir)
     }

--- a/std/os/signal.n
+++ b/std/os/signal.n
@@ -4,8 +4,8 @@ import syscall
 
 pub type sig_t = int
 
-pub #linkid signal_notify
-fn notify(chan<sig_t> sig_ch, ...[int] signals)
+#linkid signal_notify
+pub fn notify(chan<sig_t> sig_ch, ...[int] signals)
 
 #linkid signal_stop
 fn stop(chan<sig_t> sig_ch)

--- a/std/os/signal.n
+++ b/std/os/signal.n
@@ -2,9 +2,9 @@ import co
 import co.mutex
 import syscall
 
-type sig_t = int
+pub type sig_t = int
 
-#linkid signal_notify
+pub #linkid signal_notify
 fn notify(chan<sig_t> sig_ch, ...[int] signals)
 
 #linkid signal_stop

--- a/std/path/path.n
+++ b/std/path/path.n
@@ -4,7 +4,7 @@ import strings
 import fmt.utils as *
 import syscall
 
-fn exists(string path):bool {
+pub fn exists(string path):bool {
    var _ =  syscall.stat(path) catch err {
         return false
    }
@@ -12,7 +12,7 @@ fn exists(string path):bool {
 }
 
 // refer golang path.base
-fn base(string path):string {
+pub fn base(string path):string {
     if path == '' {
         return '.'
     }
@@ -32,7 +32,7 @@ fn base(string path):string {
 }
 
 // ref golang path.dir
-fn dir(string path):string {
+pub fn dir(string path):string {
   if path == '' {
      return '.'
   }
@@ -59,7 +59,7 @@ fn dir(string path):string {
   return path.slice(0, i)
 }
 
-fn join(string dst, ...[string] list):string {
+pub fn join(string dst, ...[string] list):string {
     for src in list {
         dst = _join(dst, src)
     }
@@ -106,7 +106,7 @@ fn _join(string dst, string src):string {
     return result
 }
 
-fn isdir(string path):bool {
+pub fn isdir(string path):bool {
    var s = syscall.stat(path) catch err {
          return false
     }

--- a/std/process/process.n
+++ b/std/process/process.n
@@ -38,7 +38,7 @@ type command_t = struct{
     io.writer stderr // interface
 }
 
-fn run(string name, [string] args):ref<state_t>! {
+pub fn run(string name, [string] args):ref<state_t>! {
     var stdout_buffer = new io.buffer()
     var stderr_buffer = new io.buffer()
 
@@ -52,13 +52,13 @@ fn run(string name, [string] args):ref<state_t>! {
     return new state_t(stdout, stderr, exit_code = p.exit_code, term_sig = p.term_sig)
 }
 
-fn command(string name, [string] args):ref<command_t>! {
+pub fn command(string name, [string] args):ref<command_t>! {
     var cmd = new command_t(name, args, stdin = fs.discard(), stdout = fs.stdout(), stderr = fs.stderr())
 
     return cmd
 }
 
-fn command_t.spawn(&self):ref<process_t>! {
+pub fn command_t.spawn(&self):ref<process_t>! {
     var p = self.uv_spawn(self)
 
     // Scheduling in the current thread will not cause competition
@@ -92,7 +92,7 @@ fn process_t.handle_stderr(&self):void! {
     }
 }
 
-#linkid rt_uv_process_wait
+pub #linkid rt_uv_process_wait
 fn process_t.wait(&self):void!
 
 #linkid rt_uv_process_read_stdout

--- a/std/process/process.n
+++ b/std/process/process.n
@@ -92,8 +92,8 @@ fn process_t.handle_stderr(&self):void! {
     }
 }
 
-pub #linkid rt_uv_process_wait
-fn process_t.wait(&self):void!
+#linkid rt_uv_process_wait
+pub fn process_t.wait(&self):void!
 
 #linkid rt_uv_process_read_stdout
 fn process_t.read_stdout(&self):string!

--- a/std/reflect/reflect.n
+++ b/std/reflect/reflect.n
@@ -3,30 +3,30 @@ mod reflect
 import unsafe
 import libc
 
-const NULL = 1
-const BOOL = 2
-const I8 = 3
-const U8 = 4
-const I16 = 5
-const U16 = 6
-const I32 = 7
-const U32 = 8
-const I64 = 9
-const U64 = 10
+pub const NULL = 1
+pub const BOOL = 2
+pub const I8 = 3
+pub const U8 = 4
+pub const I16 = 5
+pub const U16 = 6
+pub const I32 = 7
+pub const U32 = 8
+pub const I64 = 9
+pub const U64 = 10
 const INT = 9 // trans i64 in compiler time
 const UINT = 10 // trans u64 in compiler time
 
-const F32 = 11
-const F64 = 12
+pub const F32 = 11
+pub const F64 = 12
 const FLOAT = 12 // trans f64 in compiler time
 
-const STRING = 13
-const VEC = 14
+pub const STRING = 13
+pub const VEC = 14
 const ARR = 15
-const MAP = 16
+pub const MAP = 16
 const SET = 17
 const TUP = 18
-const STRUCT = 19
+pub const STRUCT = 19
 const FN = 20
 const CHAN = 21
 const COROUTINE_T = 22
@@ -35,27 +35,27 @@ const REF = 23
 const PTR = 24
 const ANYPTR = 25
 
-const ANY = 26
-const UNION = 27
+pub const ANY = 26
+pub const UNION = 27
 const INTERFACE = 28
 const TAGGED_UNION = 29
 const ENUM = 30
 
 const PTR_SIZE = 8
 
-type storage_kind_t = enum:u32 {
+pub type storage_kind_t = enum:u32 {
     IND = 1,
     PTR,
     DIR,
 }
 
-type field_t = struct{
+pub type field_t = struct{
     string name
     int hash
     int offset
 }
 
-type type_t = struct{
+pub type type_t = struct{
     int size
     int hash
     int kind
@@ -99,7 +99,7 @@ fn find_data(int offset):anyptr
 #linkid rt_find_strtable
 fn find_strtable(int offset):libc.cstr
 
-fn typeof_hash(i64 hash):ref<type_t>! {
+pub fn typeof_hash(i64 hash):ref<type_t>! {
     if hash <= 0 {
         throw errorf('hash must be greater than 0')
     }
@@ -141,13 +141,13 @@ fn typeof_hash(i64 hash):ref<type_t>! {
     return t
 }
 
-fn typeof<T>(T v):ref<type_t>! {
+pub fn typeof<T>(T v):ref<type_t>! {
     var hash = @reflect_hash(T)
     return typeof_hash(hash)
 }
 
 // kind base to string
-fn type_t.to_string(&self):string {
+pub fn type_t.to_string(&self):string {
     return match self.kind {
         NULL -> 'null'
         BOOL -> 'bool'
@@ -181,7 +181,7 @@ fn type_t.to_string(&self):string {
 }
 
 // ----------------------------------------------- value of ------------------------------------------------------------
-type vec_t = struct{
+pub type vec_t = struct{
     anyptr data
     i64 length
     i64 capacity
@@ -192,7 +192,7 @@ type vec_t = struct{
 
 type string_t = vec_t
 
-type map_t = struct{
+pub type map_t = struct{
     anyptr hash_table
     anyptr key_data
     anyptr value_data
@@ -210,12 +210,12 @@ type set_t = struct{
     i64 capacity
 }
 
-type union_t = struct{
+pub type union_t = struct{
     ptr<rtype_t> rtype
     anyptr value
 }
 
-type any_t = struct{
+pub type any_t = struct{
     ptr<rtype_t> rtype
     anyptr value
 }
@@ -225,7 +225,7 @@ type value_t = struct{
     anyptr v
 }
 
-fn valueof<T>(T v):ref<value_t>! {
+pub fn valueof<T>(T v):ref<value_t>! {
     var t = typeof<T>(v)
     if t.kind != VEC && t.kind != MAP && t.kind != SET {
         throw errorf('not value support type')
@@ -239,7 +239,7 @@ fn valueof<T>(T v):ref<value_t>! {
     return result
 }
 
-fn value_t.len(&self):int {
+pub fn value_t.len(&self):int {
     if self.t.kind == VEC {
         var v = self.v as ptr<vec_t>
         return v.length as int

--- a/std/runtime/runtime.n
+++ b/std/runtime/runtime.n
@@ -1,88 +1,88 @@
 mod runtime
 
-pub #linkid rt_vec_new
-fn vec_new<T>(int hash, int element_hash, int len, anyptr value_ref):vec<T>!
+#linkid rt_vec_new
+pub fn vec_new<T>(int hash, int element_hash, int len, anyptr value_ref):vec<T>!
 
-pub #linkid rt_vec_cap
-fn vec_cap<T>(int hash, int element_hash, int cap):vec<T>!
+#linkid rt_vec_cap
+pub fn vec_cap<T>(int hash, int element_hash, int cap):vec<T>!
 
 #linkid rt_vec_alloc
 fn vec_alloc(int hash, int element_hash, int cap):anyptr!
 
-pub #linkid rt_vec_new_out
-fn vec_new_out(anyptr out, int hash, int element_hash, int cap)
+#linkid rt_vec_new_out
+pub fn vec_new_out(anyptr out, int hash, int element_hash, int cap)
 
-pub #linkid rt_vec_push
-fn vec_push(anyptr list, int element_hash, anyptr val)
+#linkid rt_vec_push
+pub fn vec_push(anyptr list, int element_hash, anyptr val)
 
-pub #linkid rt_vec_grow
-fn vec_grow(anyptr list, int element_hash, int custom_capacity)
+#linkid rt_vec_grow
+pub fn vec_grow(anyptr list, int element_hash, int custom_capacity)
 
-pub #linkid rt_vec_slice
-fn vec_slice<T>(anyptr list, int start, int end):vec<T>!
+#linkid rt_vec_slice
+pub fn vec_slice<T>(anyptr list, int start, int end):vec<T>!
 
-pub #linkid rt_vec_append
-fn vec_append(anyptr list1, anyptr list2, int element_hash)
+#linkid rt_vec_append
+pub fn vec_append(anyptr list1, anyptr list2, int element_hash)
 
-pub #linkid rt_vec_concat
-fn vec_concat<T>(anyptr list1, anyptr list2, int element_hash):vec<T>
+#linkid rt_vec_concat
+pub fn vec_concat<T>(anyptr list1, anyptr list2, int element_hash):vec<T>
 
-pub #linkid rt_set_new
-fn set_new<T>(int hash, int key_hash):set<T>
+#linkid rt_set_new
+pub fn set_new<T>(int hash, int key_hash):set<T>
 
-pub #linkid rt_set_add
-fn set_add(anyptr s, anyptr key):bool
+#linkid rt_set_add
+pub fn set_add(anyptr s, anyptr key):bool
 
-pub #linkid rt_set_contains
-fn set_contains(anyptr s, anyptr key):bool
+#linkid rt_set_contains
+pub fn set_contains(anyptr s, anyptr key):bool
 
-pub #linkid rt_set_delete
-fn set_delete(anyptr s, anyptr key)
+#linkid rt_set_delete
+pub fn set_delete(anyptr s, anyptr key)
 
 #linkid rt_set_new_out
 fn set_new_out(anyptr out, int hash, int key_hash)
 
-pub #linkid rt_map_new
-fn map_new<K,V>(int hash, int key_hash, int value_hash):map<K,V>
+#linkid rt_map_new
+pub fn map_new<K,V>(int hash, int key_hash, int value_hash):map<K,V>
 
 #linkid rt_map_alloc
 fn map_alloc(int hash, int key_hash, int value_hash):anyptr
 
-pub #linkid rt_map_new_out
-fn map_new_out(anyptr out, int hash, int key_hash, int value_hash)
+#linkid rt_map_new_out
+pub fn map_new_out(anyptr out, int hash, int key_hash, int value_hash)
 
-pub #linkid rt_map_delete
-fn map_delete(anyptr m, anyptr key)
+#linkid rt_map_delete
+pub fn map_delete(anyptr m, anyptr key)
 
-pub #linkid rt_map_contains
-fn map_contains(anyptr m, anyptr key):bool
+#linkid rt_map_contains
+pub fn map_contains(anyptr m, anyptr key):bool
 
-pub #linkid rt_map_assign
-fn map_assign(anyptr m, anyptr key_ref):anyptr
+#linkid rt_map_assign
+pub fn map_assign(anyptr m, anyptr key_ref):anyptr
 
 #linkid rt_string_ref
 fn string_ref(anyptr s):anyptr
 
-pub #linkid rt_processor_index
-fn processor_index():int
+#linkid rt_processor_index
+pub fn processor_index():int
 
-pub #linkid runtime_force_gc
-fn gc()
+#linkid runtime_force_gc
+pub fn gc()
 
-pub #linkid runtime_malloc_bytes
-fn malloc_bytes():i64
+#linkid runtime_malloc_bytes
+pub fn malloc_bytes():i64
 
-pub #linkid gc_malloc
-fn gc_malloc(int hash):anyptr
+#linkid gc_malloc
+pub fn gc_malloc(int hash):anyptr
 
 #linkid gc_malloc_size
 fn gc_malloc_size(int size):anyptr
 
-pub #linkid rt_string_new
-fn string_new(anyptr s):string
+#linkid rt_string_new
+pub fn string_new(anyptr s):string
 
-pub #linkid rt_string_ref_new
-fn string_ref_new(anyptr s, int len):string
+#linkid rt_string_ref_new
+pub fn string_ref_new(anyptr s, int len):string
 
-pub #linkid rt_in_heap
-fn in_heap(anyptr addr):bool
+#linkid rt_in_heap
+pub fn in_heap(anyptr addr):bool

--- a/std/runtime/runtime.n
+++ b/std/runtime/runtime.n
@@ -1,88 +1,88 @@
 mod runtime
 
-#linkid rt_vec_new
+pub #linkid rt_vec_new
 fn vec_new<T>(int hash, int element_hash, int len, anyptr value_ref):vec<T>!
 
-#linkid rt_vec_cap
+pub #linkid rt_vec_cap
 fn vec_cap<T>(int hash, int element_hash, int cap):vec<T>!
 
 #linkid rt_vec_alloc
 fn vec_alloc(int hash, int element_hash, int cap):anyptr!
 
-#linkid rt_vec_new_out
+pub #linkid rt_vec_new_out
 fn vec_new_out(anyptr out, int hash, int element_hash, int cap)
 
-#linkid rt_vec_push
+pub #linkid rt_vec_push
 fn vec_push(anyptr list, int element_hash, anyptr val)
 
-#linkid rt_vec_grow
+pub #linkid rt_vec_grow
 fn vec_grow(anyptr list, int element_hash, int custom_capacity)
 
-#linkid rt_vec_slice
+pub #linkid rt_vec_slice
 fn vec_slice<T>(anyptr list, int start, int end):vec<T>!
 
-#linkid rt_vec_append
+pub #linkid rt_vec_append
 fn vec_append(anyptr list1, anyptr list2, int element_hash)
 
-#linkid rt_vec_concat
+pub #linkid rt_vec_concat
 fn vec_concat<T>(anyptr list1, anyptr list2, int element_hash):vec<T>
 
-#linkid rt_set_new
+pub #linkid rt_set_new
 fn set_new<T>(int hash, int key_hash):set<T>
 
-#linkid rt_set_add
+pub #linkid rt_set_add
 fn set_add(anyptr s, anyptr key):bool
 
-#linkid rt_set_contains
+pub #linkid rt_set_contains
 fn set_contains(anyptr s, anyptr key):bool
 
-#linkid rt_set_delete
+pub #linkid rt_set_delete
 fn set_delete(anyptr s, anyptr key)
 
 #linkid rt_set_new_out
 fn set_new_out(anyptr out, int hash, int key_hash)
 
-#linkid rt_map_new
+pub #linkid rt_map_new
 fn map_new<K,V>(int hash, int key_hash, int value_hash):map<K,V>
 
 #linkid rt_map_alloc
 fn map_alloc(int hash, int key_hash, int value_hash):anyptr
 
-#linkid rt_map_new_out
+pub #linkid rt_map_new_out
 fn map_new_out(anyptr out, int hash, int key_hash, int value_hash)
 
-#linkid rt_map_delete
+pub #linkid rt_map_delete
 fn map_delete(anyptr m, anyptr key)
 
-#linkid rt_map_contains
+pub #linkid rt_map_contains
 fn map_contains(anyptr m, anyptr key):bool
 
-#linkid rt_map_assign
+pub #linkid rt_map_assign
 fn map_assign(anyptr m, anyptr key_ref):anyptr
 
 #linkid rt_string_ref
 fn string_ref(anyptr s):anyptr
 
-#linkid rt_processor_index
+pub #linkid rt_processor_index
 fn processor_index():int
 
-#linkid runtime_force_gc
+pub #linkid runtime_force_gc
 fn gc()
 
-#linkid runtime_malloc_bytes
+pub #linkid runtime_malloc_bytes
 fn malloc_bytes():i64
 
-#linkid gc_malloc
+pub #linkid gc_malloc
 fn gc_malloc(int hash):anyptr
 
 #linkid gc_malloc_size
 fn gc_malloc_size(int size):anyptr
 
-#linkid rt_string_new
+pub #linkid rt_string_new
 fn string_new(anyptr s):string
 
-#linkid rt_string_ref_new
+pub #linkid rt_string_ref_new
 fn string_ref_new(anyptr s, int len):string
 
-#linkid rt_in_heap
+pub #linkid rt_in_heap
 fn in_heap(anyptr addr):bool

--- a/std/strings/strings.n
+++ b/std/strings/strings.n
@@ -5,7 +5,7 @@ import libc
 import runtime
 
 // 基于 c 字符串创建一个 nature 字符串 
-fn from(anyptr p):string! {
+pub fn from(anyptr p):string! {
     return runtime.string_new(p)
 }
 

--- a/std/strings/strings.n
+++ b/std/strings/strings.n
@@ -20,7 +20,7 @@ fn string.find_char(self, u8 char, int after):int {
     return -1
 }
 
-fn string.find_after(self, string sub, int after):int {
+pub fn string.find_after(self, string sub, int after):int {
     var n = sub.len()
 
     if (n == 0) {
@@ -41,7 +41,7 @@ fn string.find_after(self, string sub, int after):int {
     return index as int
 }
 
-fn string.reverse(self):string {
+pub fn string.reverse(self):string {
     var result = vec<u8>.new(0, self.len())
 
     for i,c in self {
@@ -51,7 +51,7 @@ fn string.reverse(self):string {
     return result as string
 }
 
-fn string.rfind(self, string sub):int {
+pub fn string.rfind(self, string sub):int {
     if sub.len() == 0 {
         return -1
     }
@@ -77,7 +77,7 @@ fn string.rfind(self, string sub):int {
 }
 
 
-fn string.ends_with(self, string ends):bool {
+pub fn string.ends_with(self, string ends):bool {
     if ends.len() > self.len() {
         return false
     }
@@ -93,7 +93,7 @@ fn string.ends_with(self, string ends):bool {
     return true
 }
 
-fn string.starts_with(self, string starts):bool {
+pub fn string.starts_with(self, string starts):bool {
     if (starts.len() > self.len()) {
         return false
     }
@@ -107,7 +107,7 @@ fn string.starts_with(self, string starts):bool {
     return true
 }
 
-fn string.contains(self, string sub):bool {
+pub fn string.contains(self, string sub):bool {
     return self.find(sub) != -1
 }
 
@@ -119,17 +119,17 @@ fn string.finish(self, string cap):string {
     return self + cap
 }
 
-fn string.find(self, string sub):int {
+pub fn string.find(self, string sub):int {
     return self.find_after(sub, 0)
 }
 
-fn string.slice(self, int start, int end):string {
+pub fn string.slice(self, int start, int end):string {
     var list = self as [u8]
     list = list[start..end]
     return list as string
 }
 
-fn string.split(self, string separator):[string] {
+pub fn string.split(self, string separator):[string] {
     [string] result = []
 
     if separator == '' {
@@ -166,7 +166,7 @@ fn string.split(self, string separator):[string] {
     return result
 }
 
-fn join([string] list, string separator):string {
+pub fn join([string] list, string separator):string {
     [u8] result = []
 
     if list.len() == 0 {
@@ -199,7 +199,7 @@ fn string.ascii(self):u8 {
     return list[0]
 }
 
-fn string.ltrim(self, [string] list):string {
+pub fn string.ltrim(self, [string] list):string {
     {u8} cut = {}
     for sub in list {
         cut.add(sub[0])
@@ -214,7 +214,7 @@ fn string.ltrim(self, [string] list):string {
     return ''
 }
 
-fn string.rtrim(self, [string] list):string {
+pub fn string.rtrim(self, [string] list):string {
     {u8} cut = {}
     for sub in list {
         cut.add(sub[0])
@@ -229,11 +229,11 @@ fn string.rtrim(self, [string] list):string {
     return ''
 }
 
-fn string.trim(self, [string] list):string {
+pub fn string.trim(self, [string] list):string {
     return self.ltrim(list).rtrim(list)
 }
 
-fn string.replace(self, string sub_old, string sub_new):string {
+pub fn string.replace(self, string sub_old, string sub_new):string {
     var result = ""
 
     if sub_old.len() == 0 || self.len() < sub_old.len() {
@@ -257,7 +257,7 @@ fn string.replace(self, string sub_old, string sub_new):string {
     return result
 }
 
-fn string.to_int(self):int! {
+pub fn string.to_int(self):int! {
     if self.len() == 0 {
         throw errorf('cannot convert empty string to int')
     }
@@ -301,7 +301,7 @@ fn string.to_int(self):int! {
     return result
 }
 
-fn string.to_float(self):float! {
+pub fn string.to_float(self):float! {
     if self.len() == 0 {
         throw errorf('cannot convert empty string to float')
     }
@@ -367,7 +367,7 @@ fn string.to_float(self):float! {
 }
 
 
-fn string.to_lower(self):string {
+pub fn string.to_lower(self):string {
     var result = vec<u8>.new(0, self.len())
     
     for i, c in self {
@@ -381,7 +381,7 @@ fn string.to_lower(self):string {
     return result as string
 }
 
-fn string.to_upper(self):string {
+pub fn string.to_upper(self):string {
     var result = vec<u8>.new(0, self.len())
     
     for i, c in self {

--- a/std/syscall/syscall.darwin.n
+++ b/std/syscall/syscall.darwin.n
@@ -623,8 +623,8 @@ int SOCK_RDM = 0x4
 int SOCK_SEQPACKET = 0x5
 pub int SOCK_STREAM = 0x1
 
-pub #linkid syscall_call6
-fn call6(int number, anyptr a1, anyptr a2, anyptr a3, anyptr a4, anyptr a5, anyptr a6):int!
+#linkid syscall_call6
+pub fn call6(int number, anyptr a1, anyptr a2, anyptr a3, anyptr a4, anyptr a5, anyptr a6):int!
 
 #linkid syscall_getcwd
 fn syscall_getcwd():string
@@ -670,8 +670,8 @@ pub fn fork():int! {
 
 // path is full path
 // argv[0] = /proc/:pid/comm
-pub #linkid syscall_exec
-fn exec(string path, [string] argv, [string] envp):void!
+#linkid syscall_exec
+pub fn exec(string path, [string] argv, [string] envp):void!
 
 type timespec_t = struct {
     i64 sec

--- a/std/syscall/syscall.darwin.n
+++ b/std/syscall/syscall.darwin.n
@@ -4,497 +4,497 @@ import libc
 import runtime
 
 // 文件系统相关常量
-u32 MS_ASYNC = 0x1
+pub u32 MS_ASYNC = 0x1
 u32 MS_INVALIDATE = 0x2
 u32 MS_SYNC = 0x10
 
 // 打开文件的标志
-int O_RDONLY = 0x0000
-int O_WRONLY = 0x0001
-int O_RDWR   = 0x0002
-int O_APPEND = 0x0008
-int O_CREAT  = 0x0200
-int O_EXCL   = 0x0800
-int O_TRUNC  = 0x0400
+pub int O_RDONLY = 0x0000
+pub int O_WRONLY = 0x0001
+pub int O_RDWR   = 0x0002
+pub int O_APPEND = 0x0008
+pub int O_CREAT  = 0x0200
+pub int O_EXCL   = 0x0800
+pub int O_TRUNC  = 0x0400
 
 // 文件seek的位置
-int SEEK_SET = 0
-int SEEK_CUR = 1
-int SEEK_END = 2
+pub int SEEK_SET = 0
+pub int SEEK_CUR = 1
+pub int SEEK_END = 2
 
 // 标准文件描述符
-int STDIN = 0
-int STDOUT = 1
-int STDERR = 2
+pub int STDIN = 0
+pub int STDOUT = 1
+pub int STDERR = 2
 
-fn null_device():string {
+pub fn null_device():string {
     return '/dev/null'
 }
 
 // Darwin系统调用编号
-const SYS_SYSCALL = 0
-const SYS_EXIT = 1
-const SYS_FORK = 2
-const SYS_READ = 3
-const SYS_WRITE = 4
-const SYS_OPEN = 5
-const SYS_CLOSE = 6
-const SYS_WAIT4 = 7
-const SYS_LINK = 9
-const SYS_UNLINK = 10
-const SYS_CHDIR = 12
-const SYS_FCHDIR = 13
-const SYS_MKNOD = 14
-const SYS_CHMOD = 15
-const SYS_CHOWN = 16
-const SYS_GETFSSTAT = 18
-const SYS_GETPID = 20
-const SYS_SETUID = 23
-const SYS_GETUID = 24
-const SYS_GETEUID = 25
-const SYS_PTRACE = 26
-const SYS_RECVMSG = 27
-const SYS_SENDMSG = 28
-const SYS_RECVFROM = 29
-const SYS_ACCEPT = 30
-const SYS_GETPEERNAME = 31
-const SYS_GETSOCKNAME = 32
-const SYS_ACCESS = 33
-const SYS_CHFLAGS = 34
-const SYS_FCHFLAGS = 35
-const SYS_SYNC = 36
-const SYS_KILL = 37
-const SYS_GETPPID = 39
-const SYS_DUP = 41
-const SYS_PIPE = 42
-const SYS_GETEGID = 43
-const SYS_SIGACTION = 46
-const SYS_GETGID = 47
-const SYS_SIGPROCMASK = 48
-const SYS_GETLOGIN = 49
-const SYS_SETLOGIN = 50
-const SYS_ACCT = 51
-const SYS_SIGPENDING = 52
-const SYS_SIGALTSTACK = 53
-const SYS_IOCTL = 54
-const SYS_REBOOT = 55
-const SYS_REVOKE = 56
-const SYS_SYMLINK = 57
-const SYS_READLINK = 58
-const SYS_EXECVE = 59
-const SYS_UMASK = 60
-const SYS_CHROOT = 61
-const SYS_MSYNC = 65
-const SYS_VFORK = 66
-const SYS_MUNMAP = 73
-const SYS_MPROTECT = 74
-const SYS_MADVISE = 75
-const SYS_MINCORE = 78
-const SYS_GETGROUPS = 79
-const SYS_SETGROUPS = 80
-const SYS_GETPGRP = 81
-const SYS_SETPGID = 82
-const SYS_SETITIMER = 83
-const SYS_SWAPON = 85
-const SYS_GETITIMER = 86
-const SYS_GETDTABLESIZE = 89
-const SYS_DUP2 = 90
-const SYS_FCNTL = 92
-const SYS_SELECT = 93
-const SYS_FSYNC = 95
-const SYS_SETPRIORITY = 96
-const SYS_SOCKET = 97
-const SYS_CONNECT = 98
-const SYS_GETPRIORITY = 100
-const SYS_BIND = 104
-const SYS_SETSOCKOPT = 105
-const SYS_LISTEN = 106
-const SYS_SIGSUSPEND = 111
-const SYS_GETTIMEOFDAY = 116
-const SYS_GETRUSAGE = 117
-const SYS_GETSOCKOPT = 118
-const SYS_READV = 120
-const SYS_WRITEV = 121
-const SYS_SETTIMEOFDAY = 122
-const SYS_FCHOWN = 123
-const SYS_FCHMOD = 124
-const SYS_SETREUID = 126
-const SYS_SETREGID = 127
-const SYS_RENAME = 128
-const SYS_FLOCK = 131
-const SYS_MKFIFO = 132
-const SYS_SENDTO = 133
-const SYS_SHUTDOWN = 134
-const SYS_SOCKETPAIR = 135
-const SYS_MKDIR = 136
-const SYS_RMDIR = 137
-const SYS_UTIMES = 138
-const SYS_FUTIMES = 139
-const SYS_ADJTIME = 140
-const SYS_GETHOSTUUID = 142
-const SYS_SETSID = 147
-const SYS_GETPGID = 151
-const SYS_SETPRIVEXEC = 152
-const SYS_PREAD = 153
-const SYS_PWRITE = 154
-const SYS_NFSSVC = 155
-const SYS_STATFS = 157
-const SYS_FSTATFS = 158
-const SYS_UNMOUNT = 159
-const SYS_GETFH = 161
-const SYS_QUOTACTL = 165
-const SYS_MOUNT = 167
-const SYS_CSOPS = 169
-const SYS_CSOPS_AUDITTOKEN = 170
-const SYS_WAITID = 173
-const SYS_KDEBUG_TYPEFILTER = 177
-const SYS_KDEBUG_TRACE_STRING = 178
-const SYS_KDEBUG_TRACE64 = 179
-const SYS_KDEBUG_TRACE = 180
-const SYS_SETGID = 181
-const SYS_SETEGID = 182
-const SYS_SETEUID = 183
-const SYS_SIGRETURN = 184
-const SYS_THREAD_SELFCOUNTS = 186
-const SYS_FDATASYNC = 187
-const SYS_STAT = 188
-const SYS_FSTAT = 189
-const SYS_LSTAT = 190
-const SYS_PATHCONF = 191
-const SYS_FPATHCONF = 192
-const SYS_GETRLIMIT = 194
-const SYS_SETRLIMIT = 195
-const SYS_GETDIRENTRIES = 196
-const SYS_MMAP = 197
-const SYS_LSEEK = 199
-const SYS_TRUNCATE = 200
-const SYS_FTRUNCATE = 201
-const SYS_SYSCTL = 202
-const SYS_MLOCK = 203
-const SYS_MUNLOCK = 204
-const SYS_UNDELETE = 205
-const SYS_OPEN_DPROTECTED_NP = 216
-const SYS_FSGETPATH_EXT = 217
-const SYS_GETATTRLIST = 220
-const SYS_SETATTRLIST = 221
-const SYS_GETDIRENTRIESATTR = 222
-const SYS_EXCHANGEDATA = 223
-const SYS_SEARCHFS = 225
-const SYS_DELETE = 226
-const SYS_COPYFILE = 227
-const SYS_FGETATTRLIST = 228
-const SYS_FSETATTRLIST = 229
-const SYS_POLL = 230
-const SYS_GETXATTR = 234
-const SYS_FGETXATTR = 235
-const SYS_SETXATTR = 236
-const SYS_FSETXATTR = 237
-const SYS_REMOVEXATTR = 238
-const SYS_FREMOVEXATTR = 239
-const SYS_LISTXATTR = 240
-const SYS_FLISTXATTR = 241
-const SYS_FSCTL = 242
-const SYS_INITGROUPS = 243
-const SYS_POSIX_SPAWN = 244
-const SYS_FFSCTL = 245
-const SYS_NFSCLNT = 247
-const SYS_FHOPEN = 248
-const SYS_MINHERIT = 250
-const SYS_SEMSYS = 251
-const SYS_MSGSYS = 252
-const SYS_SHMSYS = 253
-const SYS_SEMCTL = 254
-const SYS_SEMGET = 255
-const SYS_SEMOP = 256
-const SYS_MSGCTL = 258
-const SYS_MSGGET = 259
-const SYS_MSGSND = 260
-const SYS_MSGRCV = 261
-const SYS_SHMAT = 262
-const SYS_SHMCTL = 263
-const SYS_SHMDT = 264
-const SYS_SHMGET = 265
-const SYS_SHM_OPEN = 266
-const SYS_SHM_UNLINK = 267
-const SYS_SEM_OPEN = 268
-const SYS_SEM_CLOSE = 269
-const SYS_SEM_UNLINK = 270
-const SYS_SEM_WAIT = 271
-const SYS_SEM_TRYWAIT = 272
-const SYS_SEM_POST = 273
-const SYS_SYSCTLBYNAME = 274
-const SYS_OPEN_EXTENDED = 277
-const SYS_UMASK_EXTENDED = 278
-const SYS_STAT_EXTENDED = 279
-const SYS_LSTAT_EXTENDED = 280
-const SYS_FSTAT_EXTENDED = 281
-const SYS_CHMOD_EXTENDED = 282
-const SYS_FCHMOD_EXTENDED = 283
-const SYS_ACCESS_EXTENDED = 284
-const SYS_SETTID = 285
-const SYS_GETTID = 286
-const SYS_SETSGROUPS = 287
-const SYS_GETSGROUPS = 288
-const SYS_SETWGROUPS = 289
-const SYS_GETWGROUPS = 290
-const SYS_MKFIFO_EXTENDED = 291
-const SYS_MKDIR_EXTENDED = 292
-const SYS_IDENTITYSVC = 293
-const SYS_SHARED_REGION_CHECK_NP = 294
-const SYS_VM_PRESSURE_MONITOR = 296
-const SYS_PSYNCH_RW_LONGRDLOCK = 297
-const SYS_PSYNCH_RW_YIELDWRLOCK = 298
-const SYS_PSYNCH_RW_DOWNGRADE = 299
-const SYS_PSYNCH_RW_UPGRADE = 300
-const SYS_PSYNCH_MUTEXWAIT = 301
-const SYS_PSYNCH_MUTEXDROP = 302
-const SYS_PSYNCH_CVBROAD = 303
-const SYS_PSYNCH_CVSIGNAL = 304
-const SYS_PSYNCH_CVWAIT = 305
-const SYS_PSYNCH_RW_RDLOCK = 306
-const SYS_PSYNCH_RW_WRLOCK = 307
-const SYS_PSYNCH_RW_UNLOCK = 308
-const SYS_PSYNCH_RW_UNLOCK2 = 309
-const SYS_GETSID = 310
-const SYS_SETTID_WITH_PID = 311
-const SYS_PSYNCH_CVCLRPREPOST = 312
-const SYS_AIO_FSYNC = 313
-const SYS_AIO_RETURN = 314
-const SYS_AIO_SUSPEND = 315
-const SYS_AIO_CANCEL = 316
-const SYS_AIO_ERROR = 317
-const SYS_AIO_READ = 318
-const SYS_AIO_WRITE = 319
-const SYS_LIO_LISTIO = 320
-const SYS_IOPOLICYSYS = 322
-const SYS_PROCESS_POLICY = 323
-const SYS_MLOCKALL = 324
-const SYS_MUNLOCKALL = 325
-const SYS_ISSETUGID = 327
-const SYS___PTHREAD_KILL = 328
-const SYS___PTHREAD_SIGMASK = 329
-const SYS___SIGWAIT = 330
-const SYS___DISABLE_THREADSIGNAL = 331
-const SYS___PTHREAD_MARKCANCEL = 332
-const SYS___PTHREAD_CANCELED = 333
-const SYS___SEMWAIT_SIGNAL = 334
-const SYS_PROC_INFO = 336
-const SYS_SENDFILE = 337
-const SYS_STAT64 = 338
-const SYS_FSTAT64 = 339
-const SYS_LSTAT64 = 340
-const SYS_STAT64_EXTENDED = 341
-const SYS_LSTAT64_EXTENDED = 342
-const SYS_FSTAT64_EXTENDED = 343
-const SYS_GETDIRENTRIES64 = 344
-const SYS_STATFS64 = 345
-const SYS_FSTATFS64 = 346
-const SYS_GETFSSTAT64 = 347
-const SYS___PTHREAD_CHDIR = 348
-const SYS___PTHREAD_FCHDIR = 349
-const SYS_AUDIT = 350
-const SYS_AUDITON = 351
-const SYS_GETAUID = 353
-const SYS_SETAUID = 354
-const SYS_GETAUDIT_ADDR = 357
-const SYS_SETAUDIT_ADDR = 358
-const SYS_AUDITCTL = 359
-const SYS_BSDTHREAD_CREATE = 360
-const SYS_BSDTHREAD_TERMINATE = 361
-const SYS_KQUEUE = 362
-const SYS_KEVENT = 363
-const SYS_LCHOWN = 364
-const SYS_BSDTHREAD_REGISTER = 366
-const SYS_WORKQ_OPEN = 367
-const SYS_WORKQ_KERNRETURN = 368
-const SYS_KEVENT64 = 369
-const SYS___OLD_SEMWAIT_SIGNAL = 370
-const SYS___OLD_SEMWAIT_SIGNAL_NOCANCEL = 371
-const SYS_THREAD_SELFID = 372
-const SYS_LEDGER = 373
-const SYS_KEVENT_QOS = 374
-const SYS_KEVENT_ID = 375
+pub const SYS_SYSCALL = 0
+pub const SYS_EXIT = 1
+pub const SYS_FORK = 2
+pub const SYS_READ = 3
+pub const SYS_WRITE = 4
+pub const SYS_OPEN = 5
+pub const SYS_CLOSE = 6
+pub const SYS_WAIT4 = 7
+pub const SYS_LINK = 9
+pub const SYS_UNLINK = 10
+pub const SYS_CHDIR = 12
+pub const SYS_FCHDIR = 13
+pub const SYS_MKNOD = 14
+pub const SYS_CHMOD = 15
+pub const SYS_CHOWN = 16
+pub const SYS_GETFSSTAT = 18
+pub const SYS_GETPID = 20
+pub const SYS_SETUID = 23
+pub const SYS_GETUID = 24
+pub const SYS_GETEUID = 25
+pub const SYS_PTRACE = 26
+pub const SYS_RECVMSG = 27
+pub const SYS_SENDMSG = 28
+pub const SYS_RECVFROM = 29
+pub const SYS_ACCEPT = 30
+pub const SYS_GETPEERNAME = 31
+pub const SYS_GETSOCKNAME = 32
+pub const SYS_ACCESS = 33
+pub const SYS_CHFLAGS = 34
+pub const SYS_FCHFLAGS = 35
+pub const SYS_SYNC = 36
+pub const SYS_KILL = 37
+pub const SYS_GETPPID = 39
+pub const SYS_DUP = 41
+pub const SYS_PIPE = 42
+pub const SYS_GETEGID = 43
+pub const SYS_SIGACTION = 46
+pub const SYS_GETGID = 47
+pub const SYS_SIGPROCMASK = 48
+pub const SYS_GETLOGIN = 49
+pub const SYS_SETLOGIN = 50
+pub const SYS_ACCT = 51
+pub const SYS_SIGPENDING = 52
+pub const SYS_SIGALTSTACK = 53
+pub const SYS_IOCTL = 54
+pub const SYS_REBOOT = 55
+pub const SYS_REVOKE = 56
+pub const SYS_SYMLINK = 57
+pub const SYS_READLINK = 58
+pub const SYS_EXECVE = 59
+pub const SYS_UMASK = 60
+pub const SYS_CHROOT = 61
+pub const SYS_MSYNC = 65
+pub const SYS_VFORK = 66
+pub const SYS_MUNMAP = 73
+pub const SYS_MPROTECT = 74
+pub const SYS_MADVISE = 75
+pub const SYS_MINCORE = 78
+pub const SYS_GETGROUPS = 79
+pub const SYS_SETGROUPS = 80
+pub const SYS_GETPGRP = 81
+pub const SYS_SETPGID = 82
+pub const SYS_SETITIMER = 83
+pub const SYS_SWAPON = 85
+pub const SYS_GETITIMER = 86
+pub const SYS_GETDTABLESIZE = 89
+pub const SYS_DUP2 = 90
+pub const SYS_FCNTL = 92
+pub const SYS_SELECT = 93
+pub const SYS_FSYNC = 95
+pub const SYS_SETPRIORITY = 96
+pub const SYS_SOCKET = 97
+pub const SYS_CONNECT = 98
+pub const SYS_GETPRIORITY = 100
+pub const SYS_BIND = 104
+pub const SYS_SETSOCKOPT = 105
+pub const SYS_LISTEN = 106
+pub const SYS_SIGSUSPEND = 111
+pub const SYS_GETTIMEOFDAY = 116
+pub const SYS_GETRUSAGE = 117
+pub const SYS_GETSOCKOPT = 118
+pub const SYS_READV = 120
+pub const SYS_WRITEV = 121
+pub const SYS_SETTIMEOFDAY = 122
+pub const SYS_FCHOWN = 123
+pub const SYS_FCHMOD = 124
+pub const SYS_SETREUID = 126
+pub const SYS_SETREGID = 127
+pub const SYS_RENAME = 128
+pub const SYS_FLOCK = 131
+pub const SYS_MKFIFO = 132
+pub const SYS_SENDTO = 133
+pub const SYS_SHUTDOWN = 134
+pub const SYS_SOCKETPAIR = 135
+pub const SYS_MKDIR = 136
+pub const SYS_RMDIR = 137
+pub const SYS_UTIMES = 138
+pub const SYS_FUTIMES = 139
+pub const SYS_ADJTIME = 140
+pub const SYS_GETHOSTUUID = 142
+pub const SYS_SETSID = 147
+pub const SYS_GETPGID = 151
+pub const SYS_SETPRIVEXEC = 152
+pub const SYS_PREAD = 153
+pub const SYS_PWRITE = 154
+pub const SYS_NFSSVC = 155
+pub const SYS_STATFS = 157
+pub const SYS_FSTATFS = 158
+pub const SYS_UNMOUNT = 159
+pub const SYS_GETFH = 161
+pub const SYS_QUOTACTL = 165
+pub const SYS_MOUNT = 167
+pub const SYS_CSOPS = 169
+pub const SYS_CSOPS_AUDITTOKEN = 170
+pub const SYS_WAITID = 173
+pub const SYS_KDEBUG_TYPEFILTER = 177
+pub const SYS_KDEBUG_TRACE_STRING = 178
+pub const SYS_KDEBUG_TRACE64 = 179
+pub const SYS_KDEBUG_TRACE = 180
+pub const SYS_SETGID = 181
+pub const SYS_SETEGID = 182
+pub const SYS_SETEUID = 183
+pub const SYS_SIGRETURN = 184
+pub const SYS_THREAD_SELFCOUNTS = 186
+pub const SYS_FDATASYNC = 187
+pub const SYS_STAT = 188
+pub const SYS_FSTAT = 189
+pub const SYS_LSTAT = 190
+pub const SYS_PATHCONF = 191
+pub const SYS_FPATHCONF = 192
+pub const SYS_GETRLIMIT = 194
+pub const SYS_SETRLIMIT = 195
+pub const SYS_GETDIRENTRIES = 196
+pub const SYS_MMAP = 197
+pub const SYS_LSEEK = 199
+pub const SYS_TRUNCATE = 200
+pub const SYS_FTRUNCATE = 201
+pub const SYS_SYSCTL = 202
+pub const SYS_MLOCK = 203
+pub const SYS_MUNLOCK = 204
+pub const SYS_UNDELETE = 205
+pub const SYS_OPEN_DPROTECTED_NP = 216
+pub const SYS_FSGETPATH_EXT = 217
+pub const SYS_GETATTRLIST = 220
+pub const SYS_SETATTRLIST = 221
+pub const SYS_GETDIRENTRIESATTR = 222
+pub const SYS_EXCHANGEDATA = 223
+pub const SYS_SEARCHFS = 225
+pub const SYS_DELETE = 226
+pub const SYS_COPYFILE = 227
+pub const SYS_FGETATTRLIST = 228
+pub const SYS_FSETATTRLIST = 229
+pub const SYS_POLL = 230
+pub const SYS_GETXATTR = 234
+pub const SYS_FGETXATTR = 235
+pub const SYS_SETXATTR = 236
+pub const SYS_FSETXATTR = 237
+pub const SYS_REMOVEXATTR = 238
+pub const SYS_FREMOVEXATTR = 239
+pub const SYS_LISTXATTR = 240
+pub const SYS_FLISTXATTR = 241
+pub const SYS_FSCTL = 242
+pub const SYS_INITGROUPS = 243
+pub const SYS_POSIX_SPAWN = 244
+pub const SYS_FFSCTL = 245
+pub const SYS_NFSCLNT = 247
+pub const SYS_FHOPEN = 248
+pub const SYS_MINHERIT = 250
+pub const SYS_SEMSYS = 251
+pub const SYS_MSGSYS = 252
+pub const SYS_SHMSYS = 253
+pub const SYS_SEMCTL = 254
+pub const SYS_SEMGET = 255
+pub const SYS_SEMOP = 256
+pub const SYS_MSGCTL = 258
+pub const SYS_MSGGET = 259
+pub const SYS_MSGSND = 260
+pub const SYS_MSGRCV = 261
+pub const SYS_SHMAT = 262
+pub const SYS_SHMCTL = 263
+pub const SYS_SHMDT = 264
+pub const SYS_SHMGET = 265
+pub const SYS_SHM_OPEN = 266
+pub const SYS_SHM_UNLINK = 267
+pub const SYS_SEM_OPEN = 268
+pub const SYS_SEM_CLOSE = 269
+pub const SYS_SEM_UNLINK = 270
+pub const SYS_SEM_WAIT = 271
+pub const SYS_SEM_TRYWAIT = 272
+pub const SYS_SEM_POST = 273
+pub const SYS_SYSCTLBYNAME = 274
+pub const SYS_OPEN_EXTENDED = 277
+pub const SYS_UMASK_EXTENDED = 278
+pub const SYS_STAT_EXTENDED = 279
+pub const SYS_LSTAT_EXTENDED = 280
+pub const SYS_FSTAT_EXTENDED = 281
+pub const SYS_CHMOD_EXTENDED = 282
+pub const SYS_FCHMOD_EXTENDED = 283
+pub const SYS_ACCESS_EXTENDED = 284
+pub const SYS_SETTID = 285
+pub const SYS_GETTID = 286
+pub const SYS_SETSGROUPS = 287
+pub const SYS_GETSGROUPS = 288
+pub const SYS_SETWGROUPS = 289
+pub const SYS_GETWGROUPS = 290
+pub const SYS_MKFIFO_EXTENDED = 291
+pub const SYS_MKDIR_EXTENDED = 292
+pub const SYS_IDENTITYSVC = 293
+pub const SYS_SHARED_REGION_CHECK_NP = 294
+pub const SYS_VM_PRESSURE_MONITOR = 296
+pub const SYS_PSYNCH_RW_LONGRDLOCK = 297
+pub const SYS_PSYNCH_RW_YIELDWRLOCK = 298
+pub const SYS_PSYNCH_RW_DOWNGRADE = 299
+pub const SYS_PSYNCH_RW_UPGRADE = 300
+pub const SYS_PSYNCH_MUTEXWAIT = 301
+pub const SYS_PSYNCH_MUTEXDROP = 302
+pub const SYS_PSYNCH_CVBROAD = 303
+pub const SYS_PSYNCH_CVSIGNAL = 304
+pub const SYS_PSYNCH_CVWAIT = 305
+pub const SYS_PSYNCH_RW_RDLOCK = 306
+pub const SYS_PSYNCH_RW_WRLOCK = 307
+pub const SYS_PSYNCH_RW_UNLOCK = 308
+pub const SYS_PSYNCH_RW_UNLOCK2 = 309
+pub const SYS_GETSID = 310
+pub const SYS_SETTID_WITH_PID = 311
+pub const SYS_PSYNCH_CVCLRPREPOST = 312
+pub const SYS_AIO_FSYNC = 313
+pub const SYS_AIO_RETURN = 314
+pub const SYS_AIO_SUSPEND = 315
+pub const SYS_AIO_CANCEL = 316
+pub const SYS_AIO_ERROR = 317
+pub const SYS_AIO_READ = 318
+pub const SYS_AIO_WRITE = 319
+pub const SYS_LIO_LISTIO = 320
+pub const SYS_IOPOLICYSYS = 322
+pub const SYS_PROCESS_POLICY = 323
+pub const SYS_MLOCKALL = 324
+pub const SYS_MUNLOCKALL = 325
+pub const SYS_ISSETUGID = 327
+pub const SYS___PTHREAD_KILL = 328
+pub const SYS___PTHREAD_SIGMASK = 329
+pub const SYS___SIGWAIT = 330
+pub const SYS___DISABLE_THREADSIGNAL = 331
+pub const SYS___PTHREAD_MARKCANCEL = 332
+pub const SYS___PTHREAD_CANCELED = 333
+pub const SYS___SEMWAIT_SIGNAL = 334
+pub const SYS_PROC_INFO = 336
+pub const SYS_SENDFILE = 337
+pub const SYS_STAT64 = 338
+pub const SYS_FSTAT64 = 339
+pub const SYS_LSTAT64 = 340
+pub const SYS_STAT64_EXTENDED = 341
+pub const SYS_LSTAT64_EXTENDED = 342
+pub const SYS_FSTAT64_EXTENDED = 343
+pub const SYS_GETDIRENTRIES64 = 344
+pub const SYS_STATFS64 = 345
+pub const SYS_FSTATFS64 = 346
+pub const SYS_GETFSSTAT64 = 347
+pub const SYS___PTHREAD_CHDIR = 348
+pub const SYS___PTHREAD_FCHDIR = 349
+pub const SYS_AUDIT = 350
+pub const SYS_AUDITON = 351
+pub const SYS_GETAUID = 353
+pub const SYS_SETAUID = 354
+pub const SYS_GETAUDIT_ADDR = 357
+pub const SYS_SETAUDIT_ADDR = 358
+pub const SYS_AUDITCTL = 359
+pub const SYS_BSDTHREAD_CREATE = 360
+pub const SYS_BSDTHREAD_TERMINATE = 361
+pub const SYS_KQUEUE = 362
+pub const SYS_KEVENT = 363
+pub const SYS_LCHOWN = 364
+pub const SYS_BSDTHREAD_REGISTER = 366
+pub const SYS_WORKQ_OPEN = 367
+pub const SYS_WORKQ_KERNRETURN = 368
+pub const SYS_KEVENT64 = 369
+pub const SYS___OLD_SEMWAIT_SIGNAL = 370
+pub const SYS___OLD_SEMWAIT_SIGNAL_NOCANCEL = 371
+pub const SYS_THREAD_SELFID = 372
+pub const SYS_LEDGER = 373
+pub const SYS_KEVENT_QOS = 374
+pub const SYS_KEVENT_ID = 375
 
-const SYS___MAC_EXECVE = 380
-const SYS___MAC_SYSCALL = 381
-const SYS___MAC_GET_FILE = 382
-const SYS___MAC_SET_FILE = 383
-const SYS___MAC_GET_LINK = 384
-const SYS___MAC_SET_LINK = 385
-const SYS___MAC_GET_PROC = 386
-const SYS___MAC_SET_PROC = 387
-const SYS___MAC_GET_FD = 388
-const SYS___MAC_SET_FD = 389
-const SYS___MAC_GET_PID = 390
-const SYS_PSELECT = 394
+pub const SYS___MAC_EXECVE = 380
+pub const SYS___MAC_SYSCALL = 381
+pub const SYS___MAC_GET_FILE = 382
+pub const SYS___MAC_SET_FILE = 383
+pub const SYS___MAC_GET_LINK = 384
+pub const SYS___MAC_SET_LINK = 385
+pub const SYS___MAC_GET_PROC = 386
+pub const SYS___MAC_SET_PROC = 387
+pub const SYS___MAC_GET_FD = 388
+pub const SYS___MAC_SET_FD = 389
+pub const SYS___MAC_GET_PID = 390
+pub const SYS_PSELECT = 394
 
-const SYS_PSELECT_NOCANCEL = 395
-const SYS_READ_NOCANCEL = 396
-const SYS_WRITE_NOCANCEL = 397
-const SYS_OPEN_NOCANCEL = 398
-const SYS_CLOSE_NOCANCEL = 399
-const SYS_WAIT4_NOCANCEL = 400
-const SYS_RECVMSG_NOCANCEL = 401
-const SYS_SENDMSG_NOCANCEL = 402
-const SYS_RECVFROM_NOCANCEL = 403
-const SYS_ACCEPT_NOCANCEL = 404
-const SYS_MSYNC_NOCANCEL = 405
-const SYS_FCNTL_NOCANCEL = 406
-const SYS_SELECT_NOCANCEL = 407
-const SYS_FSYNC_NOCANCEL = 408
-const SYS_CONNECT_NOCANCEL = 409
-const SYS_SIGSUSPEND_NOCANCEL = 410
-const SYS_READV_NOCANCEL = 411
-const SYS_WRITEV_NOCANCEL = 412
-const SYS_SENDTO_NOCANCEL = 413
-const SYS_PREAD_NOCANCEL = 414
-const SYS_PWRITE_NOCANCEL = 415
-const SYS_WAITID_NOCANCEL = 416
-const SYS_POLL_NOCANCEL = 417
-const SYS_MSGSND_NOCANCEL = 418
-const SYS_MSGRCV_NOCANCEL = 419
-const SYS_SEM_WAIT_NOCANCEL = 420
-const SYS_AIO_SUSPEND_NOCANCEL = 421
-const SYS___SIGWAIT_NOCANCEL = 422
-const SYS___SEMWAIT_SIGNAL_NOCANCEL = 423
-const SYS___MAC_MOUNT = 424
-const SYS___MAC_GET_MOUNT = 425
-const SYS___MAC_GETFSSTAT = 426
-const SYS_FSGETPATH = 427
-const SYS_AUDIT_SESSION_SELF = 428
-const SYS_AUDIT_SESSION_JOIN = 429
-const SYS_FILEPORT_MAKEPORT = 430
-const SYS_FILEPORT_MAKEFD = 431
-const SYS_AUDIT_SESSION_PORT = 432
-const SYS_PID_SUSPEND = 433
-const SYS_PID_RESUME = 434
-const SYS_PID_HIBERNATE = 435
-const SYS_PID_SHUTDOWN_SOCKETS = 436
-const SYS_SHARED_REGION_MAP_AND_SLIDE_NP = 438
-const SYS_KAS_INFO = 439
-const SYS_MEMORYSTATUS_CONTROL = 440
-const SYS_GUARDED_OPEN_NP = 441
-const SYS_GUARDED_CLOSE_NP = 442
-const SYS_GUARDED_KQUEUE_NP = 443
-const SYS_CHANGE_FDGUARD_NP = 444
-const SYS_USRCTL = 445
-const SYS_PROC_RLIMIT_CONTROL = 446
-const SYS_CONNECTX = 447
-const SYS_DISCONNECTX = 448
-const SYS_PEELOFF = 449
-const SYS_SOCKET_DELEGATE = 450
-const SYS_TELEMETRY = 451
-const SYS_PROC_UUID_POLICY = 452
-const SYS_MEMORYSTATUS_GET_LEVEL = 453
-const SYS_SYSTEM_OVERRIDE = 454
-const SYS_VFS_PURGE = 455
-const SYS_SFI_CTL = 456
-const SYS_SFI_PIDCTL = 457
-const SYS_COALITION = 458
-const SYS_COALITION_INFO = 459
-const SYS_NECP_MATCH_POLICY = 460
-const SYS_GETATTRLISTBULK = 461
-const SYS_CLONEFILEAT = 462
-const SYS_OPENAT = 463
-const SYS_OPENAT_NOCANCEL = 464
-const SYS_RENAMEAT = 465
-const SYS_FACCESSAT = 466
-const SYS_FCHMODAT = 467
-const SYS_FCHOWNAT = 468
-const SYS_FSTATAT = 469
-const SYS_FSTATAT64 = 470
-const SYS_LINKAT = 471
-const SYS_UNLINKAT = 472
-const SYS_READLINKAT = 473
-const SYS_SYMLINKAT = 474
-const SYS_MKDIRAT = 475
-const SYS_GETATTRLISTAT = 476
-const SYS_PROC_TRACE_LOG = 477
-const SYS_BSDTHREAD_CTL = 478
-const SYS_OPENBYID_NP = 479
-const SYS_RECVMSG_X = 480
-const SYS_SENDMSG_X = 481
-const SYS_THREAD_SELFUSAGE = 482
-const SYS_CSRCTL = 483
-const SYS_GUARDED_OPEN_DPROTECTED_NP = 484
-const SYS_GUARDED_WRITE_NP = 485
-const SYS_GUARDED_PWRITE_NP = 486
-const SYS_GUARDED_WRITEV_NP = 487
-const SYS_RENAMEATX_NP = 488
-const SYS_MREMAP_ENCRYPTED = 489
-const SYS_NETAGENT_TRIGGER = 490
-const SYS_STACK_SNAPSHOT_WITH_CONFIG = 491
-const SYS_MICROSTACKSHOT = 492
-const SYS_GRAB_PGO_DATA = 493
-const SYS_PERSONA = 494
-const SYS_MACH_EVENTLINK_SIGNAL = 496
-const SYS_MACH_EVENTLINK_WAIT_UNTIL = 497
-const SYS_MACH_EVENTLINK_SIGNAL_WAIT_UNTIL = 498
-const SYS_WORK_INTERVAL_CTL = 499
-const SYS_GETENTROPY = 500
-const SYS_NECP_OPEN = 501
-const SYS_NECP_CLIENT_ACTION = 502
-const SYS___NEXUS_OPEN = 503
-const SYS___NEXUS_REGISTER = 504
-const SYS___NEXUS_DEREGISTER = 505
-const SYS___NEXUS_CREATE = 506
-const SYS___NEXUS_DESTROY = 507
-const SYS___NEXUS_GET_OPT = 508
-const SYS___NEXUS_SET_OPT = 509
-const SYS___CHANNEL_OPEN = 510
-const SYS___CHANNEL_GET_INFO = 511
-const SYS___CHANNEL_SYNC = 512
-const SYS___CHANNEL_GET_OPT = 513
-const SYS___CHANNEL_SET_OPT = 514
-const SYS_ULOCK_WAIT = 515
-const SYS_ULOCK_WAKE = 516
-const SYS_FCLONEFILEAT = 517
-const SYS_FS_SNAPSHOT = 518
-const SYS_REGISTER_UEXC_HANDLER = 519
-const SYS_TERMINATE_WITH_PAYLOAD = 520
-const SYS_ABORT_WITH_PAYLOAD = 521
-const SYS_NECP_SESSION_OPEN = 522
-const SYS_NECP_SESSION_ACTION = 523
-const SYS_SETATTRLISTAT = 524
-const SYS_NET_QOS_GUIDELINE = 525
-const SYS_FMOUNT = 526
-const SYS_NTP_ADJTIME = 527
-const SYS_NTP_GETTIME = 528
-const SYS_OS_FAULT_WITH_PAYLOAD = 529
-const SYS_KQUEUE_WORKLOOP_CTL = 530
-const SYS___MACH_BRIDGE_REMOTE_TIME = 531
-const SYS_COALITION_LEDGER = 532
-const SYS_LOG_DATA = 533
-const SYS_MEMORYSTATUS_AVAILABLE_MEMORY = 534
-const SYS_SHARED_REGION_MAP_AND_SLIDE_2_NP = 536
-const SYS_PIVOT_ROOT = 537
-const SYS_TASK_INSPECT_FOR_PID = 538
-const SYS_TASK_READ_FOR_PID = 539
-const SYS_PREADV = 540
-const SYS_PWRITEV = 541
-const SYS_PREADV_NOCANCEL = 542
-const SYS_PWRITEV_NOCANCEL = 543
-const SYS_ULOCK_WAIT2 = 544
-const SYS_PROC_INFO_EXTENDED_ID = 545
-const SYS_MAXSYSCALL = 546
-const SYS_INVALID = 63
+pub const SYS_PSELECT_NOCANCEL = 395
+pub const SYS_READ_NOCANCEL = 396
+pub const SYS_WRITE_NOCANCEL = 397
+pub const SYS_OPEN_NOCANCEL = 398
+pub const SYS_CLOSE_NOCANCEL = 399
+pub const SYS_WAIT4_NOCANCEL = 400
+pub const SYS_RECVMSG_NOCANCEL = 401
+pub const SYS_SENDMSG_NOCANCEL = 402
+pub const SYS_RECVFROM_NOCANCEL = 403
+pub const SYS_ACCEPT_NOCANCEL = 404
+pub const SYS_MSYNC_NOCANCEL = 405
+pub const SYS_FCNTL_NOCANCEL = 406
+pub const SYS_SELECT_NOCANCEL = 407
+pub const SYS_FSYNC_NOCANCEL = 408
+pub const SYS_CONNECT_NOCANCEL = 409
+pub const SYS_SIGSUSPEND_NOCANCEL = 410
+pub const SYS_READV_NOCANCEL = 411
+pub const SYS_WRITEV_NOCANCEL = 412
+pub const SYS_SENDTO_NOCANCEL = 413
+pub const SYS_PREAD_NOCANCEL = 414
+pub const SYS_PWRITE_NOCANCEL = 415
+pub const SYS_WAITID_NOCANCEL = 416
+pub const SYS_POLL_NOCANCEL = 417
+pub const SYS_MSGSND_NOCANCEL = 418
+pub const SYS_MSGRCV_NOCANCEL = 419
+pub const SYS_SEM_WAIT_NOCANCEL = 420
+pub const SYS_AIO_SUSPEND_NOCANCEL = 421
+pub const SYS___SIGWAIT_NOCANCEL = 422
+pub const SYS___SEMWAIT_SIGNAL_NOCANCEL = 423
+pub const SYS___MAC_MOUNT = 424
+pub const SYS___MAC_GET_MOUNT = 425
+pub const SYS___MAC_GETFSSTAT = 426
+pub const SYS_FSGETPATH = 427
+pub const SYS_AUDIT_SESSION_SELF = 428
+pub const SYS_AUDIT_SESSION_JOIN = 429
+pub const SYS_FILEPORT_MAKEPORT = 430
+pub const SYS_FILEPORT_MAKEFD = 431
+pub const SYS_AUDIT_SESSION_PORT = 432
+pub const SYS_PID_SUSPEND = 433
+pub const SYS_PID_RESUME = 434
+pub const SYS_PID_HIBERNATE = 435
+pub const SYS_PID_SHUTDOWN_SOCKETS = 436
+pub const SYS_SHARED_REGION_MAP_AND_SLIDE_NP = 438
+pub const SYS_KAS_INFO = 439
+pub const SYS_MEMORYSTATUS_CONTROL = 440
+pub const SYS_GUARDED_OPEN_NP = 441
+pub const SYS_GUARDED_CLOSE_NP = 442
+pub const SYS_GUARDED_KQUEUE_NP = 443
+pub const SYS_CHANGE_FDGUARD_NP = 444
+pub const SYS_USRCTL = 445
+pub const SYS_PROC_RLIMIT_CONTROL = 446
+pub const SYS_CONNECTX = 447
+pub const SYS_DISCONNECTX = 448
+pub const SYS_PEELOFF = 449
+pub const SYS_SOCKET_DELEGATE = 450
+pub const SYS_TELEMETRY = 451
+pub const SYS_PROC_UUID_POLICY = 452
+pub const SYS_MEMORYSTATUS_GET_LEVEL = 453
+pub const SYS_SYSTEM_OVERRIDE = 454
+pub const SYS_VFS_PURGE = 455
+pub const SYS_SFI_CTL = 456
+pub const SYS_SFI_PIDCTL = 457
+pub const SYS_COALITION = 458
+pub const SYS_COALITION_INFO = 459
+pub const SYS_NECP_MATCH_POLICY = 460
+pub const SYS_GETATTRLISTBULK = 461
+pub const SYS_CLONEFILEAT = 462
+pub const SYS_OPENAT = 463
+pub const SYS_OPENAT_NOCANCEL = 464
+pub const SYS_RENAMEAT = 465
+pub const SYS_FACCESSAT = 466
+pub const SYS_FCHMODAT = 467
+pub const SYS_FCHOWNAT = 468
+pub const SYS_FSTATAT = 469
+pub const SYS_FSTATAT64 = 470
+pub const SYS_LINKAT = 471
+pub const SYS_UNLINKAT = 472
+pub const SYS_READLINKAT = 473
+pub const SYS_SYMLINKAT = 474
+pub const SYS_MKDIRAT = 475
+pub const SYS_GETATTRLISTAT = 476
+pub const SYS_PROC_TRACE_LOG = 477
+pub const SYS_BSDTHREAD_CTL = 478
+pub const SYS_OPENBYID_NP = 479
+pub const SYS_RECVMSG_X = 480
+pub const SYS_SENDMSG_X = 481
+pub const SYS_THREAD_SELFUSAGE = 482
+pub const SYS_CSRCTL = 483
+pub const SYS_GUARDED_OPEN_DPROTECTED_NP = 484
+pub const SYS_GUARDED_WRITE_NP = 485
+pub const SYS_GUARDED_PWRITE_NP = 486
+pub const SYS_GUARDED_WRITEV_NP = 487
+pub const SYS_RENAMEATX_NP = 488
+pub const SYS_MREMAP_ENCRYPTED = 489
+pub const SYS_NETAGENT_TRIGGER = 490
+pub const SYS_STACK_SNAPSHOT_WITH_CONFIG = 491
+pub const SYS_MICROSTACKSHOT = 492
+pub const SYS_GRAB_PGO_DATA = 493
+pub const SYS_PERSONA = 494
+pub const SYS_MACH_EVENTLINK_SIGNAL = 496
+pub const SYS_MACH_EVENTLINK_WAIT_UNTIL = 497
+pub const SYS_MACH_EVENTLINK_SIGNAL_WAIT_UNTIL = 498
+pub const SYS_WORK_INTERVAL_CTL = 499
+pub const SYS_GETENTROPY = 500
+pub const SYS_NECP_OPEN = 501
+pub const SYS_NECP_CLIENT_ACTION = 502
+pub const SYS___NEXUS_OPEN = 503
+pub const SYS___NEXUS_REGISTER = 504
+pub const SYS___NEXUS_DEREGISTER = 505
+pub const SYS___NEXUS_CREATE = 506
+pub const SYS___NEXUS_DESTROY = 507
+pub const SYS___NEXUS_GET_OPT = 508
+pub const SYS___NEXUS_SET_OPT = 509
+pub const SYS___CHANNEL_OPEN = 510
+pub const SYS___CHANNEL_GET_INFO = 511
+pub const SYS___CHANNEL_SYNC = 512
+pub const SYS___CHANNEL_GET_OPT = 513
+pub const SYS___CHANNEL_SET_OPT = 514
+pub const SYS_ULOCK_WAIT = 515
+pub const SYS_ULOCK_WAKE = 516
+pub const SYS_FCLONEFILEAT = 517
+pub const SYS_FS_SNAPSHOT = 518
+pub const SYS_REGISTER_UEXC_HANDLER = 519
+pub const SYS_TERMINATE_WITH_PAYLOAD = 520
+pub const SYS_ABORT_WITH_PAYLOAD = 521
+pub const SYS_NECP_SESSION_OPEN = 522
+pub const SYS_NECP_SESSION_ACTION = 523
+pub const SYS_SETATTRLISTAT = 524
+pub const SYS_NET_QOS_GUIDELINE = 525
+pub const SYS_FMOUNT = 526
+pub const SYS_NTP_ADJTIME = 527
+pub const SYS_NTP_GETTIME = 528
+pub const SYS_OS_FAULT_WITH_PAYLOAD = 529
+pub const SYS_KQUEUE_WORKLOOP_CTL = 530
+pub const SYS___MACH_BRIDGE_REMOTE_TIME = 531
+pub const SYS_COALITION_LEDGER = 532
+pub const SYS_LOG_DATA = 533
+pub const SYS_MEMORYSTATUS_AVAILABLE_MEMORY = 534
+pub const SYS_SHARED_REGION_MAP_AND_SLIDE_2_NP = 536
+pub const SYS_PIVOT_ROOT = 537
+pub const SYS_TASK_INSPECT_FOR_PID = 538
+pub const SYS_TASK_READ_FOR_PID = 539
+pub const SYS_PREADV = 540
+pub const SYS_PWRITEV = 541
+pub const SYS_PREADV_NOCANCEL = 542
+pub const SYS_PWRITEV_NOCANCEL = 543
+pub const SYS_ULOCK_WAIT2 = 544
+pub const SYS_PROC_INFO_EXTENDED_ID = 545
+pub const SYS_MAXSYSCALL = 546
+pub const SYS_INVALID = 63
 
 // sigkill 相关信号
 int SIGHUP = 1       /* hangup */
-int SIGINT = 2       /* interrupt */
+pub int SIGINT = 2       /* interrupt */
 int SIGQUIT = 3      /* quit */
 int SIGILL = 4       /* illegal instruction (not reset when caught) */
 int SIGTRAP = 5      /* trace trap (not reset when caught) */
 int SIGABRT = 6      /* abort() */
 int SIGEMT = 7       /* EMT instruction */
 int SIGFPE = 8       /* floating point exception */
-int SIGKILL = 9      /* kill (cannot be caught or ignored) */
+pub int SIGKILL = 9      /* kill (cannot be caught or ignored) */
 int SIGBUS = 10      /* bus error */
 int SIGSEGV = 11     /* segmentation violation */
 int SIGSYS = 12      /* bad argument to system call */
 int SIGPIPE = 13     /* write on a pipe with no one to read it */
 int SIGALRM = 14     /* alarm clock */
-int SIGTERM = 15     /* software termination signal from kill */
+pub int SIGTERM = 15     /* software termination signal from kill */
 int SIGURG = 16      /* urgent condition on IO channel */
 int SIGSTOP = 17     /* sendable stop signal not from tty */
 int SIGTSTP = 18     /* stop signal from tty */
@@ -509,8 +509,8 @@ int SIGVTALRM = 26   /* virtual time alarm */
 int SIGPROF = 27     /* profiling time alarm */
 int SIGWINCH = 28    /* window size changes */
 int SIGINFO = 29     /* information request */
-int SIGUSR1 = 30     /* user defined signal 1 */
-int SIGUSR2 = 31     /* user defined signal 2 */
+pub int SIGUSR1 = 30     /* user defined signal 1 */
+pub int SIGUSR2 = 31     /* user defined signal 2 */
 
 // 网络相关
 int AF_ALG = 0x26
@@ -527,8 +527,8 @@ int AF_DECnet = 0xc
 int AF_ECONET = 0x13
 int AF_FILE = 0x1
 int AF_IEEE802154 = 0x24
-int AF_INET = 0x2
-int AF_INET6 = 0xa
+pub int AF_INET = 0x2
+pub int AF_INET6 = 0xa
 int AF_IPX = 0x4
 int AF_IRDA = 0x17
 int AF_ISDN = 0x22
@@ -621,9 +621,9 @@ int SOCK_PACKET = 0xa
 int SOCK_RAW = 0x3
 int SOCK_RDM = 0x4
 int SOCK_SEQPACKET = 0x5
-int SOCK_STREAM = 0x1
+pub int SOCK_STREAM = 0x1
 
-#linkid syscall_call6
+pub #linkid syscall_call6
 fn call6(int number, anyptr a1, anyptr a2, anyptr a3, anyptr a4, anyptr a5, anyptr a6):int!
 
 #linkid syscall_getcwd
@@ -635,42 +635,42 @@ fn getenv(anyptr key):anyptr
 #linkid setenv
 fn setenv(anyptr key, anyptr value, i32 overwrite):i32
 
-fn open(string filename, int flags, int perm):int! {
+pub fn open(string filename, int flags, int perm):int! {
     return call6(SYS_OPEN, filename.ref(), flags as anyptr, perm as anyptr, 0, 0, 0)
 }
 
-fn read(int fd, anyptr buf, int len):int! {
+pub fn read(int fd, anyptr buf, int len):int! {
     return call6(SYS_READ, fd as anyptr, buf, len as anyptr, 0, 0, 0)
 }
 
-fn readlink(string file, [u8] buf):int! {
+pub fn readlink(string file, [u8] buf):int! {
     return call6(SYS_READLINK, file.ref(), buf.ref(), buf.len() as anyptr, 0, 0, 0)
 }
 
-fn write(int fd, anyptr buf, int len):int! {
+pub fn write(int fd, anyptr buf, int len):int! {
     return call6(SYS_WRITE, fd as anyptr, buf, len as anyptr, 0, 0, 0)
 }
 
-fn close(int fd):void! {
+pub fn close(int fd):void! {
     call6(SYS_CLOSE, fd as anyptr, 0, 0, 0, 0, 0)
 }
 
-fn unlink(string path):void! {
+pub fn unlink(string path):void! {
     call6(SYS_UNLINK, path.ref(), 0, 0, 0, 0, 0)
 }
 
-fn seek(int fd, int offset, int whence):int! {
+pub fn seek(int fd, int offset, int whence):int! {
     return call6(SYS_LSEEK, fd as anyptr, offset as anyptr, whence as anyptr, 0, 0, 0)
 }
 
-fn fork():int! {
+pub fn fork():int! {
     return libc.fork()
     // return call6(SYS_FORK, 0, 0, 0, 0, 0, 0)
 }
 
 // path is full path
 // argv[0] = /proc/:pid/comm
-#linkid syscall_exec
+pub #linkid syscall_exec
 fn exec(string path, [string] argv, [string] envp):void!
 
 type timespec_t = struct {
@@ -678,7 +678,7 @@ type timespec_t = struct {
     i64 nsec
 }
 
-type stat_t = struct {
+pub type stat_t = struct {
     i32 dev
     u16 mode
     u16 nlink
@@ -716,7 +716,7 @@ fn stat_is_chr(u16 mode):bool {
     return (mode & S_IFMT) == S_IFCHR
 }
 
-fn stat_is_dir(u16 mode):bool {
+pub fn stat_is_dir(u16 mode):bool {
     return (mode & S_IFMT) == S_IFDIR
 }
 
@@ -728,34 +728,34 @@ fn stat_is_lnk(u16 mode):bool {
     return (mode & S_IFMT) == S_IFLNK
 }
 
-fn stat_is_reg(u16 mode):bool {
+pub fn stat_is_reg(u16 mode):bool {
     return (mode & S_IFMT) == S_IFREG
 }
 
 fn stat_is_sock(u16 mode):bool {
     return (mode & S_IFMT) == S_IFSOCK
 }
-fn stat(string filename):stat_t! {
+pub fn stat(string filename):stat_t! {
     var st = stat_t{}
     call6(SYS_STAT64, filename.ref(), st as anyptr, 0, 0, 0, 0)
     return st
 }
 
-fn fstat(int fd):stat_t! {
+pub fn fstat(int fd):stat_t! {
     var st = stat_t{}
     call6(SYS_FSTAT64, fd as anyptr, st as anyptr, 0, 0, 0, 0)
     return st
 }
 
-fn mkdir(string path, u32 mode):void! {
+pub fn mkdir(string path, u32 mode):void! {
     call6(SYS_MKDIR, path.ref(), mode as anyptr, 0, 0, 0, 0)
 }
 
-fn rmdir(string path):void! {
+pub fn rmdir(string path):void! {
     call6(SYS_RMDIR, path.ref(), 0, 0, 0, 0, 0)
 }
 
-fn rename(string oldpath, string newpath):void! {
+pub fn rename(string oldpath, string newpath):void! {
     call6(SYS_RENAME, oldpath.ref(), newpath.ref(), 0, 0, 0, 0)
 }
 
@@ -763,15 +763,15 @@ fn exit(int status):void! {
     call6(SYS_EXIT, status as anyptr, 0, 0, 0, 0, 0)
 }
 
-fn getpid():int! {
+pub fn getpid():int! {
     return call6(SYS_GETPID, 0, 0, 0, 0, 0, 0)
 }
 
-fn getppid():int! {
+pub fn getppid():int! {
     return call6(SYS_GETPPID, 0, 0, 0, 0, 0, 0)
 }
 
-fn getcwd():string! {
+pub fn getcwd():string! {
     var buf = vec<u8>.new(0, 1024) // 1024 是 path max
 
     libc.cstr raw_path = libc.getcwd(buf.ref() as libc.cstr, buf.len() as uint)
@@ -781,11 +781,11 @@ fn getcwd():string! {
     return buf as string
 }
 
-fn kill(int pid, int sig):void! {
+pub fn kill(int pid, int sig):void! {
     call6(SYS_KILL, pid as anyptr, sig as anyptr, 0, 0, 0, 0)
 }
 
-fn wait(int pid, int option):(int, int)! {
+pub fn wait(int pid, int option):(int, int)! {
     var status = 0
     int result = call6(SYS_WAIT4, pid as anyptr, &status as anyptr, option as anyptr, 0, 0, 0)
     if result == -1 {
@@ -806,7 +806,7 @@ fn chown(string path, u32 uid, u32 gid):void! {
     call6(SYS_CHOWN, path.ref(), uid as anyptr, gid as anyptr, 0, 0, 0)
 }
 
-fn chmod(string path, u32 mode):void! {
+pub fn chmod(string path, u32 mode):void! {
     call6(SYS_CHMOD, path.ref(), mode as anyptr, 0, 0, 0, 0)
 }
 
@@ -820,7 +820,7 @@ type timezone_t = struct {
     i32 tz_dsttime
 }
 
-fn gettime():timespec_t! {
+pub fn gettime():timespec_t! {
     // Darwin 不直接支持 clock_gettime，我们需要使用 gettimeofday 代替
     var tv = timeval_t{}
     var tz = timezone_t{}
@@ -833,7 +833,7 @@ fn gettime():timespec_t! {
 }
 
 // 网络相关结构体和函数
-type sockaddr_in = struct {
+pub type sockaddr_in = struct {
     u16 sin_family
     u16 sin_port
     u32 sin_addr
@@ -855,11 +855,11 @@ type sockaddr_un = struct {
     [u8;104] sun_path
 }
 
-fn socket(int domain, int t, int protocol):int! {
+pub fn socket(int domain, int t, int protocol):int! {
     return call6(SYS_SOCKET, domain as anyptr, t as anyptr, protocol as anyptr, 0, 0, 0)
 }
 
-fn bind<T>(int sockfd, T addr):void! {
+pub fn bind<T>(int sockfd, T addr):void! {
     var len = @sizeof(T) as anyptr
     call6(SYS_BIND, sockfd as anyptr, addr as anyptr, len, 0, 0, 0)
 }
@@ -869,30 +869,30 @@ fn bind6(int sockfd, sockaddr_in6 addr):void! {
     call6(SYS_BIND, sockfd as anyptr, addr as anyptr, len, 0, 0, 0)
 }
 
-fn listen(int sockfd, int backlog):void! {
+pub fn listen(int sockfd, int backlog):void! {
     call6(SYS_LISTEN, sockfd as anyptr, backlog as anyptr, 0, 0, 0, 0)
 }
 
-fn accept<T>(int sockfd, ref<T> addr):int! {
+pub fn accept<T>(int sockfd, ref<T> addr):int! {
     var len = @sizeof(T)
     ptr<int> len_ptr = &len
     int fd = call6(SYS_ACCEPT, sockfd as anyptr, addr as anyptr, len_ptr as anyptr, 0, 0, 0)
     return fd
 }
 
-fn recvfrom(int sockfd, [u8] buf, int flags):int! {
+pub fn recvfrom(int sockfd, [u8] buf, int flags):int! {
     return call6(SYS_RECVFROM, sockfd as anyptr, buf.ref(), buf.len() as anyptr, flags as anyptr, 0, 0)
 }
 
-fn sendto(int sockfd, [u8] buf, int flags):int! {
+pub fn sendto(int sockfd, [u8] buf, int flags):int! {
     return call6(SYS_SENDTO, sockfd as anyptr, buf.ref(), buf.len() as anyptr, flags as anyptr, 0, 0)
 }
 
-fn get_envs():[string] {
+pub fn get_envs():[string] {
     return libc.get_envs()
 }
 
-fn get_env(string key):string {
+pub fn get_env(string key):string {
     anyptr ref = getenv(key.ref())
     if ref == 0 {
         return ''
@@ -900,7 +900,7 @@ fn get_env(string key):string {
     return runtime.string_new(ref)
 }
 
-fn set_env(string key, string value):void! {
+pub fn set_env(string key, string value):void! {
     var result = setenv(key.ref(), value.ref(), 1)
     if result != 0 {
         throw errorf('setenv error')

--- a/std/syscall/syscall.linux_amd64.n
+++ b/std/syscall/syscall.linux_amd64.n
@@ -3,7 +3,7 @@ mod syscall
 import libc
 import runtime
 
-u32 MS_ACTIVE = 0x40000000
+pub u32 MS_ACTIVE = 0x40000000
 u32 MS_ASYNC = 0x1
 u32 MS_BIND = 0x1000
 u32 MS_DIRSYNC = 0x80
@@ -62,28 +62,28 @@ int CLONE_NEWPID = 0x20000000
 int CLONE_NEWNET = 0x40000000
 int CLONE_IO = 0x80000000
 
-int O_RDONLY = 0x0  // 只读模式
-int O_WRONLY = 0x1  // 只写模式
-int O_RDWR   = 0x2  // 读写模式
+pub int O_RDONLY = 0x0  // 只读模式
+pub int O_WRONLY = 0x1  // 只写模式
+pub int O_RDWR   = 0x2  // 读写模式
 
-int O_APPEND = 0x8  // 追加写入
-int O_CREAT = 0x40 // 如果文件不存在则创建文件
-int O_EXCL   = 0x80 // 与 O_CREAT 一起使用，文件必须不存在
-int O_TRUNC  = 0x200 // 打开文件时清空文件内容
+pub int O_APPEND = 0x8  // 追加写入
+pub int O_CREAT = 0x40 // 如果文件不存在则创建文件
+pub int O_EXCL   = 0x80 // 与 O_CREAT 一起使用，文件必须不存在
+pub int O_TRUNC  = 0x200 // 打开文件时清空文件内容
 
-int SEEK_SET = 0  // 移动到文件开头
-int SEEK_CUR = 1 // 保持不变
-int SEEK_END = 2 // 移动到文件末尾
+pub int SEEK_SET = 0  // 移动到文件开头
+pub int SEEK_CUR = 1 // 保持不变
+pub int SEEK_END = 2 // 移动到文件末尾
 
-int STDIN = 0
-int STDOUT = 1
-int STDERR = 2
+pub int STDIN = 0
+pub int STDOUT = 1
+pub int STDERR = 2
 
-fn null_device():string {
+pub fn null_device():string {
     return '/dev/null'
 }
 
-int CLOCK_REALTIME = 0
+pub int CLOCK_REALTIME = 0
 int CLOCK_MONOTONIC = 1
 int CLOCK_PROCESS_CPUTIME_ID = 2
 int CLOCK_THREAD_CPUTIME_ID = 3
@@ -96,309 +96,309 @@ int CLOCK_BOOTTIME_ALARM = 9
 int CLOCK_TAI = 11
 
 // 系统调用编码
-const SYS_READ = 0
-const SYS_WRITE = 1
-const SYS_OPEN = 2
-const SYS_CLOSE = 3
-const SYS_STAT = 4
-const SYS_FSTAT = 5
-const SYS_LSTAT = 6
-const SYS_POLL = 7
-const SYS_LSEEK = 8
-const SYS_MMAP = 9
-const SYS_MPROTECT = 10
-const SYS_MUNMAP = 11
-const SYS_BRK = 12
-const SYS_RT_SIGACTION = 13
-const SYS_RT_SIGPROCMASK = 14
-const SYS_RT_SIGRETURN = 15
-const SYS_IOCTL = 16
-const SYS_PREAD64 = 17
-const SYS_PWRITE64 = 18
-const SYS_READV = 19
-const SYS_WRITEV = 20
-const SYS_ACCESS = 21
-const SYS_PIPE = 22
-const SYS_SELECT = 23
-const SYS_SCHED_YIELD = 24
-const SYS_MREMAP = 25
-const SYS_MSYNC = 26
-const SYS_MINCORE = 27
-const SYS_MADVISE = 28
-const SYS_SHMGET = 29
-const SYS_SHMAT = 30
-const SYS_SHMCTL = 31
-const SYS_DUP = 32
-const SYS_DUP2 = 33
-const SYS_PAUSE = 34
-const SYS_NANOSLEEP = 35
-const SYS_GETITIMER = 36
-const SYS_ALARM = 37
-const SYS_SETITIMER = 38
-const SYS_GETPID = 39
-const SYS_SENDFILE = 40
-const SYS_SOCKET = 41
-const SYS_CONNECT = 42
-const SYS_ACCEPT = 43
-const SYS_SENDTO = 44
-const SYS_RECVFROM = 45
-const SYS_SENDMSG = 46
-const SYS_RECVMSG = 47
-const SYS_SHUTDOWN = 48
-const SYS_BIND = 49
-const SYS_LISTEN = 50
-const SYS_GETSOCKNAME = 51
-const SYS_GETPEERNAME = 52
-const SYS_SOCKETPAIR = 53
-const SYS_SETSOCKOPT = 54
-const SYS_GETSOCKOPT = 55
-const SYS_CLONE = 56
-const SYS_FORK = 57
-const SYS_VFORK = 58
-const SYS_EXECVE = 59
-const SYS_EXIT = 60
-const SYS_WAIT4 = 61
-const SYS_KILL = 62
-const SYS_UNAME = 63
-const SYS_SEMGET = 64
-const SYS_SEMOP = 65
-const SYS_SEMCTL = 66
-const SYS_SHMDT = 67
-const SYS_MSGGET = 68
-const SYS_MSGSND = 69
-const SYS_MSGRCV = 70
-const SYS_MSGCTL = 71
-const SYS_FCNTL = 72
-const SYS_FLOCK = 73
-const SYS_FSYNC = 74
-const SYS_FDATASYNC = 75
-const SYS_TRUNCATE = 76
-const SYS_FTRUNCATE = 77
-const SYS_GETDENTS = 78
-const SYS_GETCWD = 79
-const SYS_CHDIR = 80
-const SYS_FCHDIR = 81
-const SYS_RENAME = 82
-const SYS_MKDIR = 83
-const SYS_RMDIR = 84
-const SYS_CREAT = 85
-const SYS_LINK = 86
-const SYS_UNLINK = 87
-const SYS_SYMLINK = 88
-const SYS_READLINK = 89
-const SYS_CHMOD = 90
-const SYS_FCHMOD = 91
-const SYS_CHOWN = 92
-const SYS_FCHOWN = 93
-const SYS_LCHOWN = 94
-const SYS_UMASK = 95
-const SYS_GETTIMEOFDAY = 96
-const SYS_GETRLIMIT = 97
-const SYS_GETRUSAGE = 98
-const SYS_SYSINFO = 99
-const SYS_TIMES = 100
-const SYS_PTRACE = 101
-const SYS_GETUID = 102
-const SYS_SYSLOG = 103
-const SYS_GETGID = 104
-const SYS_SETUID = 105
-const SYS_SETGID = 106
-const SYS_GETEUID = 107
-const SYS_GETEGID = 108
-const SYS_SETPGID = 109
-const SYS_GETPPID = 110
-const SYS_GETPGRP = 111
-const SYS_SETSID = 112
-const SYS_SETREUID = 113
-const SYS_SETREGID = 114
-const SYS_GETGROUPS = 115
-const SYS_SETGROUPS = 116
-const SYS_SETRESUID = 117
-const SYS_GETRESUID = 118
-const SYS_SETRESGID = 119
-const SYS_GETRESGID = 120
-const SYS_GETPGID = 121
-const SYS_SETFSUID = 122
-const SYS_SETFSGID = 123
-const SYS_GETSID = 124
-const SYS_CAPGET = 125
-const SYS_CAPSET = 126
-const SYS_RT_SIGPENDING = 127
-const SYS_RT_SIGTIMEDWAIT = 128
-const SYS_RT_SIGQUEUEINFO = 129
-const SYS_RT_SIGSUSPEND = 130
-const SYS_SIGALTSTACK = 131
-const SYS_UTIME = 132
-const SYS_MKNOD = 133
-const SYS_USELIB = 134
-const SYS_PERSONALITY = 135
-const SYS_USTAT = 136
-const SYS_STATFS = 137
-const SYS_FSTATFS = 138
-const SYS_SYSFS = 139
-const SYS_GETPRIORITY = 140
-const SYS_SETPRIORITY = 141
-const SYS_SCHED_SETPARAM = 142
-const SYS_SCHED_GETPARAM = 143
-const SYS_SCHED_SETSCHEDULER = 144
-const SYS_SCHED_GETSCHEDULER = 145
-const SYS_SCHED_GET_PRIORITY_MAX = 146
-const SYS_SCHED_GET_PRIORITY_MIN = 147
-const SYS_SCHED_RR_GET_INTERVAL = 148
-const SYS_MLOCK = 149
-const SYS_MUNLOCK = 150
-const SYS_MLOCKALL = 151
-const SYS_MUNLOCKALL = 152
-const SYS_VHANGUP = 153
-const SYS_MODIFY_LDT = 154
-const SYS_PIVOT_ROOT = 155
-const SYS__SYSCTL = 156
-const SYS_PRCTL = 157
-const SYS_ARCH_PRCTL = 158
-const SYS_ADJTIMEX = 159
-const SYS_SETRLIMIT = 160
-const SYS_CHROOT = 161
-const SYS_SYNC = 162
-const SYS_ACCT = 163
-const SYS_SETTIMEOFDAY = 164
-const SYS_MOUNT = 165
-const SYS_UMOUNT2 = 166
-const SYS_SWAPON = 167
-const SYS_SWAPOFF = 168
-const SYS_REBOOT = 169
-const SYS_SETHOSTNAME = 170
-const SYS_SETDOMAINNAME = 171
-const SYS_IOPL = 172
-const SYS_IOPERM = 173
-const SYS_CREATE_MODULE = 174
-const SYS_INIT_MODULE = 175
-const SYS_DELETE_MODULE = 176
-const SYS_GET_KERNEL_SYMS = 177
-const SYS_QUERY_MODULE = 178
-const SYS_QUOTACTL = 179
-const SYS_NFSSERVCTL = 180
-const SYS_GETPMSG = 181
-const SYS_PUTPMSG = 182
-const SYS_AFS_SYSCALL = 183
-const SYS_TUXCALL = 184
-const SYS_SECURITY = 185
-const SYS_GETTID = 186
-const SYS_READAHEAD = 187
-const SYS_SETXATTR = 188
-const SYS_LSETXATTR = 189
-const SYS_FSETXATTR = 190
-const SYS_GETXATTR = 191
-const SYS_LGETXATTR = 192
-const SYS_FGETXATTR = 193
-const SYS_LISTXATTR = 194
-const SYS_LLISTXATTR = 195
-const SYS_FLISTXATTR = 196
-const SYS_REMOVEXATTR = 197
-const SYS_LREMOVEXATTR = 198
-const SYS_FREMOVEXATTR = 199
-const SYS_TKILL = 200
-const SYS_TIME = 201
-const SYS_FUTEX = 202
-const SYS_SCHED_SETAFFINITY = 203
-const SYS_SCHED_GETAFFINITY = 204
-const SYS_SET_THREAD_AREA = 205
-const SYS_IO_SETUP = 206
-const SYS_IO_DESTROY = 207
-const SYS_IO_GETEVENTS = 208
-const SYS_IO_SUBMIT = 209
-const SYS_IO_CANCEL = 210
-const SYS_GET_THREAD_AREA = 211
-const SYS_LOOKUP_DCOOKIE = 212
-const SYS_EPOLL_CREATE = 213
-const SYS_EPOLL_CTL_OLD = 214
-const SYS_EPOLL_WAIT_OLD = 215
-const SYS_REMAP_FILE_PAGES = 216
-const SYS_GETDENTS64 = 217
-const SYS_SET_TID_ADDRESS = 218
-const SYS_RESTART_SYSCALL = 219
-const SYS_SEMTIMEDOP = 220
-const SYS_FADVISE64 = 221
-const SYS_TIMER_CREATE = 222
-const SYS_TIMER_SETTIME = 223
-const SYS_TIMER_GETTIME = 224
-const SYS_TIMER_GETOVERRUN = 225
-const SYS_TIMER_DELETE = 226
-const SYS_CLOCK_SETTIME = 227
-const SYS_CLOCK_GETTIME = 228
-const SYS_CLOCK_GETRES = 229
-const SYS_CLOCK_NANOSLEEP = 230
-const SYS_EXIT_GROUP = 231
-const SYS_EPOLL_WAIT = 232
-const SYS_EPOLL_CTL = 233
-const SYS_TGKILL = 234
-const SYS_UTIMES = 235
-const SYS_VSERVER = 236
-const SYS_MBIND = 237
-const SYS_SET_MEMPOLICY = 238
-const SYS_GET_MEMPOLICY = 239
-const SYS_MQ_OPEN = 240
-const SYS_MQ_UNLINK = 241
-const SYS_MQ_TIMEDSEND = 242
-const SYS_MQ_TIMEDRECEIVE = 243
-const SYS_MQ_NOTIFY = 244
-const SYS_MQ_GETSETATTR = 245
-const SYS_KEXEC_LOAD = 246
-const SYS_WAITID = 247
-const SYS_ADD_KEY = 248
-const SYS_REQUEST_KEY = 249
-const SYS_KEYCTL = 250
-const SYS_IOPRIO_SET = 251
-const SYS_IOPRIO_GET = 252
-const SYS_INOTIFY_INIT = 253
-const SYS_INOTIFY_ADD_WATCH = 254
-const SYS_INOTIFY_RM_WATCH = 255
-const SYS_MIGRATE_PAGES = 256
-const SYS_OPENAT = 257
-const SYS_MKDIRAT = 258
-const SYS_MKNODAT = 259
-const SYS_FCHOWNAT = 260
-const SYS_FUTIMESAT = 261
-const SYS_NEWFSTATAT = 262
-const SYS_UNLINKAT = 263
-const SYS_RENAMEAT = 264
-const SYS_LINKAT = 265
-const SYS_SYMLINKAT = 266
-const SYS_READLINKAT = 267
-const SYS_FCHMODAT = 268
-const SYS_FACCESSAT = 269
-const SYS_PSELECT6 = 270
-const SYS_PPOLL = 271
-const SYS_UNSHARE = 272
-const SYS_SET_ROBUST_LIST = 273
-const SYS_GET_ROBUST_LIST = 274
-const SYS_SPLICE = 275
-const SYS_TEE = 276
-const SYS_SYNC_FILE_RANGE = 277
-const SYS_VMSPLICE = 278
-const SYS_MOVE_PAGES = 279
-const SYS_UTIMENSAT = 280
-const SYS_EPOLL_PWAIT = 281
-const SYS_SIGNALFD = 282
-const SYS_TIMERFD_CREATE = 283
-const SYS_EVENTFD = 284
-const SYS_FALLOCATE = 285
-const SYS_TIMERFD_SETTIME = 286
-const SYS_TIMERFD_GETTIME = 287
-const SYS_ACCEPT4 = 288
-const SYS_SIGNALFD4 = 289
-const SYS_EVENTFD2 = 290
-const SYS_EPOLL_CREATE1 = 291
-const SYS_DUP3 = 292
-const SYS_PIPE2 = 293
-const SYS_INOTIFY_INIT1 = 294
-const SYS_PREADV = 295
-const SYS_PWRITEV = 296
-const SYS_RT_TGSIGQUEUEINFO = 297
-const SYS_PERF_EVENT_OPEN = 298
-const SYS_RECVMMSG = 299
-const SYS_FANOTIFY_INIT = 300
-const SYS_FANOTIFY_MARK = 301
-const SYS_PRLIMIT64 = 302
+pub const SYS_READ = 0
+pub const SYS_WRITE = 1
+pub const SYS_OPEN = 2
+pub const SYS_CLOSE = 3
+pub const SYS_STAT = 4
+pub const SYS_FSTAT = 5
+pub const SYS_LSTAT = 6
+pub const SYS_POLL = 7
+pub const SYS_LSEEK = 8
+pub const SYS_MMAP = 9
+pub const SYS_MPROTECT = 10
+pub const SYS_MUNMAP = 11
+pub const SYS_BRK = 12
+pub const SYS_RT_SIGACTION = 13
+pub const SYS_RT_SIGPROCMASK = 14
+pub const SYS_RT_SIGRETURN = 15
+pub const SYS_IOCTL = 16
+pub const SYS_PREAD64 = 17
+pub const SYS_PWRITE64 = 18
+pub const SYS_READV = 19
+pub const SYS_WRITEV = 20
+pub const SYS_ACCESS = 21
+pub const SYS_PIPE = 22
+pub const SYS_SELECT = 23
+pub const SYS_SCHED_YIELD = 24
+pub const SYS_MREMAP = 25
+pub const SYS_MSYNC = 26
+pub const SYS_MINCORE = 27
+pub const SYS_MADVISE = 28
+pub const SYS_SHMGET = 29
+pub const SYS_SHMAT = 30
+pub const SYS_SHMCTL = 31
+pub const SYS_DUP = 32
+pub const SYS_DUP2 = 33
+pub const SYS_PAUSE = 34
+pub const SYS_NANOSLEEP = 35
+pub const SYS_GETITIMER = 36
+pub const SYS_ALARM = 37
+pub const SYS_SETITIMER = 38
+pub const SYS_GETPID = 39
+pub const SYS_SENDFILE = 40
+pub const SYS_SOCKET = 41
+pub const SYS_CONNECT = 42
+pub const SYS_ACCEPT = 43
+pub const SYS_SENDTO = 44
+pub const SYS_RECVFROM = 45
+pub const SYS_SENDMSG = 46
+pub const SYS_RECVMSG = 47
+pub const SYS_SHUTDOWN = 48
+pub const SYS_BIND = 49
+pub const SYS_LISTEN = 50
+pub const SYS_GETSOCKNAME = 51
+pub const SYS_GETPEERNAME = 52
+pub const SYS_SOCKETPAIR = 53
+pub const SYS_SETSOCKOPT = 54
+pub const SYS_GETSOCKOPT = 55
+pub const SYS_CLONE = 56
+pub const SYS_FORK = 57
+pub const SYS_VFORK = 58
+pub const SYS_EXECVE = 59
+pub const SYS_EXIT = 60
+pub const SYS_WAIT4 = 61
+pub const SYS_KILL = 62
+pub const SYS_UNAME = 63
+pub const SYS_SEMGET = 64
+pub const SYS_SEMOP = 65
+pub const SYS_SEMCTL = 66
+pub const SYS_SHMDT = 67
+pub const SYS_MSGGET = 68
+pub const SYS_MSGSND = 69
+pub const SYS_MSGRCV = 70
+pub const SYS_MSGCTL = 71
+pub const SYS_FCNTL = 72
+pub const SYS_FLOCK = 73
+pub const SYS_FSYNC = 74
+pub const SYS_FDATASYNC = 75
+pub const SYS_TRUNCATE = 76
+pub const SYS_FTRUNCATE = 77
+pub const SYS_GETDENTS = 78
+pub const SYS_GETCWD = 79
+pub const SYS_CHDIR = 80
+pub const SYS_FCHDIR = 81
+pub const SYS_RENAME = 82
+pub const SYS_MKDIR = 83
+pub const SYS_RMDIR = 84
+pub const SYS_CREAT = 85
+pub const SYS_LINK = 86
+pub const SYS_UNLINK = 87
+pub const SYS_SYMLINK = 88
+pub const SYS_READLINK = 89
+pub const SYS_CHMOD = 90
+pub const SYS_FCHMOD = 91
+pub const SYS_CHOWN = 92
+pub const SYS_FCHOWN = 93
+pub const SYS_LCHOWN = 94
+pub const SYS_UMASK = 95
+pub const SYS_GETTIMEOFDAY = 96
+pub const SYS_GETRLIMIT = 97
+pub const SYS_GETRUSAGE = 98
+pub const SYS_SYSINFO = 99
+pub const SYS_TIMES = 100
+pub const SYS_PTRACE = 101
+pub const SYS_GETUID = 102
+pub const SYS_SYSLOG = 103
+pub const SYS_GETGID = 104
+pub const SYS_SETUID = 105
+pub const SYS_SETGID = 106
+pub const SYS_GETEUID = 107
+pub const SYS_GETEGID = 108
+pub const SYS_SETPGID = 109
+pub const SYS_GETPPID = 110
+pub const SYS_GETPGRP = 111
+pub const SYS_SETSID = 112
+pub const SYS_SETREUID = 113
+pub const SYS_SETREGID = 114
+pub const SYS_GETGROUPS = 115
+pub const SYS_SETGROUPS = 116
+pub const SYS_SETRESUID = 117
+pub const SYS_GETRESUID = 118
+pub const SYS_SETRESGID = 119
+pub const SYS_GETRESGID = 120
+pub const SYS_GETPGID = 121
+pub const SYS_SETFSUID = 122
+pub const SYS_SETFSGID = 123
+pub const SYS_GETSID = 124
+pub const SYS_CAPGET = 125
+pub const SYS_CAPSET = 126
+pub const SYS_RT_SIGPENDING = 127
+pub const SYS_RT_SIGTIMEDWAIT = 128
+pub const SYS_RT_SIGQUEUEINFO = 129
+pub const SYS_RT_SIGSUSPEND = 130
+pub const SYS_SIGALTSTACK = 131
+pub const SYS_UTIME = 132
+pub const SYS_MKNOD = 133
+pub const SYS_USELIB = 134
+pub const SYS_PERSONALITY = 135
+pub const SYS_USTAT = 136
+pub const SYS_STATFS = 137
+pub const SYS_FSTATFS = 138
+pub const SYS_SYSFS = 139
+pub const SYS_GETPRIORITY = 140
+pub const SYS_SETPRIORITY = 141
+pub const SYS_SCHED_SETPARAM = 142
+pub const SYS_SCHED_GETPARAM = 143
+pub const SYS_SCHED_SETSCHEDULER = 144
+pub const SYS_SCHED_GETSCHEDULER = 145
+pub const SYS_SCHED_GET_PRIORITY_MAX = 146
+pub const SYS_SCHED_GET_PRIORITY_MIN = 147
+pub const SYS_SCHED_RR_GET_INTERVAL = 148
+pub const SYS_MLOCK = 149
+pub const SYS_MUNLOCK = 150
+pub const SYS_MLOCKALL = 151
+pub const SYS_MUNLOCKALL = 152
+pub const SYS_VHANGUP = 153
+pub const SYS_MODIFY_LDT = 154
+pub const SYS_PIVOT_ROOT = 155
+pub const SYS__SYSCTL = 156
+pub const SYS_PRCTL = 157
+pub const SYS_ARCH_PRCTL = 158
+pub const SYS_ADJTIMEX = 159
+pub const SYS_SETRLIMIT = 160
+pub const SYS_CHROOT = 161
+pub const SYS_SYNC = 162
+pub const SYS_ACCT = 163
+pub const SYS_SETTIMEOFDAY = 164
+pub const SYS_MOUNT = 165
+pub const SYS_UMOUNT2 = 166
+pub const SYS_SWAPON = 167
+pub const SYS_SWAPOFF = 168
+pub const SYS_REBOOT = 169
+pub const SYS_SETHOSTNAME = 170
+pub const SYS_SETDOMAINNAME = 171
+pub const SYS_IOPL = 172
+pub const SYS_IOPERM = 173
+pub const SYS_CREATE_MODULE = 174
+pub const SYS_INIT_MODULE = 175
+pub const SYS_DELETE_MODULE = 176
+pub const SYS_GET_KERNEL_SYMS = 177
+pub const SYS_QUERY_MODULE = 178
+pub const SYS_QUOTACTL = 179
+pub const SYS_NFSSERVCTL = 180
+pub const SYS_GETPMSG = 181
+pub const SYS_PUTPMSG = 182
+pub const SYS_AFS_SYSCALL = 183
+pub const SYS_TUXCALL = 184
+pub const SYS_SECURITY = 185
+pub const SYS_GETTID = 186
+pub const SYS_READAHEAD = 187
+pub const SYS_SETXATTR = 188
+pub const SYS_LSETXATTR = 189
+pub const SYS_FSETXATTR = 190
+pub const SYS_GETXATTR = 191
+pub const SYS_LGETXATTR = 192
+pub const SYS_FGETXATTR = 193
+pub const SYS_LISTXATTR = 194
+pub const SYS_LLISTXATTR = 195
+pub const SYS_FLISTXATTR = 196
+pub const SYS_REMOVEXATTR = 197
+pub const SYS_LREMOVEXATTR = 198
+pub const SYS_FREMOVEXATTR = 199
+pub const SYS_TKILL = 200
+pub const SYS_TIME = 201
+pub const SYS_FUTEX = 202
+pub const SYS_SCHED_SETAFFINITY = 203
+pub const SYS_SCHED_GETAFFINITY = 204
+pub const SYS_SET_THREAD_AREA = 205
+pub const SYS_IO_SETUP = 206
+pub const SYS_IO_DESTROY = 207
+pub const SYS_IO_GETEVENTS = 208
+pub const SYS_IO_SUBMIT = 209
+pub const SYS_IO_CANCEL = 210
+pub const SYS_GET_THREAD_AREA = 211
+pub const SYS_LOOKUP_DCOOKIE = 212
+pub const SYS_EPOLL_CREATE = 213
+pub const SYS_EPOLL_CTL_OLD = 214
+pub const SYS_EPOLL_WAIT_OLD = 215
+pub const SYS_REMAP_FILE_PAGES = 216
+pub const SYS_GETDENTS64 = 217
+pub const SYS_SET_TID_ADDRESS = 218
+pub const SYS_RESTART_SYSCALL = 219
+pub const SYS_SEMTIMEDOP = 220
+pub const SYS_FADVISE64 = 221
+pub const SYS_TIMER_CREATE = 222
+pub const SYS_TIMER_SETTIME = 223
+pub const SYS_TIMER_GETTIME = 224
+pub const SYS_TIMER_GETOVERRUN = 225
+pub const SYS_TIMER_DELETE = 226
+pub const SYS_CLOCK_SETTIME = 227
+pub const SYS_CLOCK_GETTIME = 228
+pub const SYS_CLOCK_GETRES = 229
+pub const SYS_CLOCK_NANOSLEEP = 230
+pub const SYS_EXIT_GROUP = 231
+pub const SYS_EPOLL_WAIT = 232
+pub const SYS_EPOLL_CTL = 233
+pub const SYS_TGKILL = 234
+pub const SYS_UTIMES = 235
+pub const SYS_VSERVER = 236
+pub const SYS_MBIND = 237
+pub const SYS_SET_MEMPOLICY = 238
+pub const SYS_GET_MEMPOLICY = 239
+pub const SYS_MQ_OPEN = 240
+pub const SYS_MQ_UNLINK = 241
+pub const SYS_MQ_TIMEDSEND = 242
+pub const SYS_MQ_TIMEDRECEIVE = 243
+pub const SYS_MQ_NOTIFY = 244
+pub const SYS_MQ_GETSETATTR = 245
+pub const SYS_KEXEC_LOAD = 246
+pub const SYS_WAITID = 247
+pub const SYS_ADD_KEY = 248
+pub const SYS_REQUEST_KEY = 249
+pub const SYS_KEYCTL = 250
+pub const SYS_IOPRIO_SET = 251
+pub const SYS_IOPRIO_GET = 252
+pub const SYS_INOTIFY_INIT = 253
+pub const SYS_INOTIFY_ADD_WATCH = 254
+pub const SYS_INOTIFY_RM_WATCH = 255
+pub const SYS_MIGRATE_PAGES = 256
+pub const SYS_OPENAT = 257
+pub const SYS_MKDIRAT = 258
+pub const SYS_MKNODAT = 259
+pub const SYS_FCHOWNAT = 260
+pub const SYS_FUTIMESAT = 261
+pub const SYS_NEWFSTATAT = 262
+pub const SYS_UNLINKAT = 263
+pub const SYS_RENAMEAT = 264
+pub const SYS_LINKAT = 265
+pub const SYS_SYMLINKAT = 266
+pub const SYS_READLINKAT = 267
+pub const SYS_FCHMODAT = 268
+pub const SYS_FACCESSAT = 269
+pub const SYS_PSELECT6 = 270
+pub const SYS_PPOLL = 271
+pub const SYS_UNSHARE = 272
+pub const SYS_SET_ROBUST_LIST = 273
+pub const SYS_GET_ROBUST_LIST = 274
+pub const SYS_SPLICE = 275
+pub const SYS_TEE = 276
+pub const SYS_SYNC_FILE_RANGE = 277
+pub const SYS_VMSPLICE = 278
+pub const SYS_MOVE_PAGES = 279
+pub const SYS_UTIMENSAT = 280
+pub const SYS_EPOLL_PWAIT = 281
+pub const SYS_SIGNALFD = 282
+pub const SYS_TIMERFD_CREATE = 283
+pub const SYS_EVENTFD = 284
+pub const SYS_FALLOCATE = 285
+pub const SYS_TIMERFD_SETTIME = 286
+pub const SYS_TIMERFD_GETTIME = 287
+pub const SYS_ACCEPT4 = 288
+pub const SYS_SIGNALFD4 = 289
+pub const SYS_EVENTFD2 = 290
+pub const SYS_EPOLL_CREATE1 = 291
+pub const SYS_DUP3 = 292
+pub const SYS_PIPE2 = 293
+pub const SYS_INOTIFY_INIT1 = 294
+pub const SYS_PREADV = 295
+pub const SYS_PWRITEV = 296
+pub const SYS_RT_TGSIGQUEUEINFO = 297
+pub const SYS_PERF_EVENT_OPEN = 298
+pub const SYS_RECVMMSG = 299
+pub const SYS_FANOTIFY_INIT = 300
+pub const SYS_FANOTIFY_MARK = 301
+pub const SYS_PRLIMIT64 = 302
 
 // sigkill 相关信号
 int SIGABRT = 0x6
@@ -410,10 +410,10 @@ int SIGCONT = 0x12
 int SIGFPE = 0x8
 int SIGHUP = 0x1
 int SIGILL = 0x4
-int SIGINT = 0x2
+pub int SIGINT = 0x2
 int SIGIO = 0x1d
 int SIGIOT = 0x6
-int SIGKILL = 0x9
+pub int SIGKILL = 0x9
 int SIGPIPE = 0xd
 int SIGPOLL = 0x1d
 int SIGPROF = 0x1b
@@ -423,15 +423,15 @@ int SIGSEGV = 0xb
 int SIGSTKFLT = 0x10
 int SIGSTOP = 0x13
 int SIGSYS = 0x1f
-int SIGTERM = 0xf
+pub int SIGTERM = 0xf
 int SIGTRAP = 0x5
 int SIGTSTP = 0x14
 int SIGTTIN = 0x15
 int SIGTTOU = 0x16
 int SIGUNUSED = 0x1f
 int SIGURG = 0x17
-int SIGUSR1 = 0xa
-int SIGUSR2 = 0xc
+pub int SIGUSR1 = 0xa
+pub int SIGUSR2 = 0xc
 int SIGVTALRM = 0x1a
 int SIGWINCH = 0x1c
 int SIGXCPU = 0x18
@@ -452,8 +452,8 @@ int AF_DECnet = 0xc
 int AF_ECONET = 0x13
 int AF_FILE = 0x1
 int AF_IEEE802154 = 0x24
-int AF_INET = 0x2
-int AF_INET6 = 0xa
+pub int AF_INET = 0x2
+pub int AF_INET6 = 0xa
 int AF_IPX = 0x4
 int AF_IRDA = 0x17
 int AF_ISDN = 0x22
@@ -546,10 +546,10 @@ int SOCK_PACKET = 0xa
 int SOCK_RAW = 0x3
 int SOCK_RDM = 0x4
 int SOCK_SEQPACKET = 0x5
-int SOCK_STREAM = 0x1
+pub int SOCK_STREAM = 0x1
 
 
-#linkid syscall_call6
+pub #linkid syscall_call6
 fn call6(int number, anyptr a1, anyptr a2, anyptr a3, anyptr a4, anyptr a5, anyptr a6):int!
 
 #linkid syscall_getcwd
@@ -561,41 +561,41 @@ fn getenv(anyptr key):anyptr
 #linkid setenv
 fn setenv(anyptr key, anyptr value, i32 overwrite):i32
 
-fn open(string filename, int flags, u32 perm):int! {
+pub fn open(string filename, int flags, u32 perm):int! {
     return call6(SYS_OPEN, filename.ref(), flags as anyptr, perm as anyptr, 0, 0, 0)
 }
 
-fn read(int fd, anyptr buf, int len):int! {
+pub fn read(int fd, anyptr buf, int len):int! {
     return call6(SYS_READ, fd as anyptr, buf, len as anyptr, 0, 0, 0)
 }
 
-fn readlink(string file, [u8] buf):int! {
+pub fn readlink(string file, [u8] buf):int! {
     return call6(SYS_READLINK, file.ref(), buf.ref(), buf.len() as anyptr, 0, 0, 0)
 }
 
-fn write(int fd, anyptr buf, int len):int! {
+pub fn write(int fd, anyptr buf, int len):int! {
     return call6(SYS_WRITE, fd as anyptr, buf, len as anyptr, 0, 0, 0)
 }
 
-fn close(int fd):void! {
+pub fn close(int fd):void! {
     call6(SYS_CLOSE, fd as anyptr, 0, 0, 0, 0, 0)
 }
 
-fn unlink(string path):void! {
+pub fn unlink(string path):void! {
     call6(SYS_UNLINK, path.ref(), 0, 0, 0, 0, 0)
 }
 
-fn seek(int fd, int offset, int whence):int! {
+pub fn seek(int fd, int offset, int whence):int! {
     return call6(SYS_LSEEK, fd as anyptr, offset as anyptr, whence as anyptr, 0, 0, 0)
 }
 
-fn fork():int! {
+pub fn fork():int! {
     return call6(SYS_FORK, 0, 0, 0, 0, 0, 0)
 }
 
 // path is full path
 // argv[0] = /proc/:pid/comm
-#linkid syscall_exec
+pub #linkid syscall_exec
 fn exec(string path, [string] argv, [string] envp):void!
 
 type timespec_t = struct {
@@ -603,7 +603,7 @@ type timespec_t = struct {
     i64 nsec
 }
 
-type stat_t = struct {
+pub type stat_t = struct {
     u64 dev
     u64 ino
     u64 nlink
@@ -636,7 +636,7 @@ fn stat_is_blk(u32 mode):bool {
 fn stat_is_chr(u32 mode):bool {
     return (mode & S_IFMT) == S_IFCHR
 }
-fn stat_is_dir(u32 mode):bool {
+pub fn stat_is_dir(u32 mode):bool {
     return (mode & S_IFMT) == S_IFDIR
 }
 
@@ -644,7 +644,7 @@ fn stat_is_fifo(u32 mode):bool {
     return (mode & S_IFMT) == S_IFIFO
 }
 
-fn stat_is_reg(u32 mode):bool {
+pub fn stat_is_reg(u32 mode):bool {
     return (mode & S_IFMT) == S_IFREG
 }
 fn stat_is_lnk(u32 mode):bool {
@@ -653,7 +653,7 @@ fn stat_is_lnk(u32 mode):bool {
 fn stat_is_sock(u32 mode):bool {
     return (mode & S_IFMT) == S_IFSOCK
 }
-fn stat(string filename):stat_t! {
+pub fn stat(string filename):stat_t! {
     var st = stat_t{
         dev: 56,
         ino: 24,
@@ -665,7 +665,7 @@ fn stat(string filename):stat_t! {
     return st
 }
 
-fn fstat(int fd):stat_t! {
+pub fn fstat(int fd):stat_t! {
     var st = stat_t{}
 
     // call6 的错误处理在 runtime 中已经做过了k
@@ -674,15 +674,15 @@ fn fstat(int fd):stat_t! {
     return st
 }
 
-fn mkdir(string path, u32 mode):void! {
+pub fn mkdir(string path, u32 mode):void! {
     call6(SYS_MKDIR, path.ref(), mode as anyptr, 0, 0, 0, 0)
 }
 
-fn rmdir(string path):void! {
+pub fn rmdir(string path):void! {
     call6(SYS_RMDIR, path.ref(), 0, 0, 0, 0, 0)
 }
 
-fn rename(string oldpath, string newpath):void! {
+pub fn rename(string oldpath, string newpath):void! {
     call6(SYS_RENAME, oldpath.ref(), newpath.ref(), 0, 0, 0, 0)
 }
 
@@ -690,15 +690,15 @@ fn exit(int status):void! {
     call6(SYS_EXIT_GROUP, status as anyptr, 0, 0, 0, 0, 0)
 }
 
-fn getpid():int! {
+pub fn getpid():int! {
     return call6(SYS_GETPID, 0, 0, 0, 0, 0, 0)
 }
 
-fn getppid():int! {
+pub fn getppid():int! {
     return call6(SYS_GETPPID, 0, 0, 0, 0, 0, 0)
 }
 
-fn getcwd():string! {
+pub fn getcwd():string! {
     var buf = vec<u8>.new(0, 1024) // 1024 是 path max
     var len = call6(SYS_GETCWD, buf.ref(), buf.len() as anyptr, 0, 0, 0, 0)
 
@@ -707,11 +707,11 @@ fn getcwd():string! {
     return buf as string
 }
 
-fn kill(int pid, int sig):void! {
+pub fn kill(int pid, int sig):void! {
     call6(SYS_KILL, pid as anyptr, sig as anyptr, 0, 0, 0, 0)
 }
 
-fn wait(int pid, int option):(int, int)! {
+pub fn wait(int pid, int option):(int, int)! {
     var status = 0
     int result = libc.waitpid(pid, &status, option)
     if result == -1 {
@@ -733,11 +733,11 @@ fn chown(string path, u32 uid, u32 gid):void! {
     call6(SYS_CHOWN, path.ref(), uid as anyptr, gid as anyptr, 0, 0, 0)
 }
 
-fn chmod(string path, u32 mode):void! {
+pub fn chmod(string path, u32 mode):void! {
     call6(SYS_CHMOD, path.ref(), mode as anyptr, 0, 0, 0, 0)
 }
 
-fn gettime():timespec_t! {
+pub fn gettime():timespec_t! {
     int clock_id = CLOCK_REALTIME
     var result = timespec_t{}
 
@@ -747,7 +747,7 @@ fn gettime():timespec_t! {
 }
 
 // net --------------
-type sockaddr_in = struct {
+pub type sockaddr_in = struct {
     u16 sin_family
     u16 sin_port
     u32 sin_addr
@@ -771,12 +771,12 @@ type sockaddr_un = struct {
     [u8;108] sun_path
 }
 
-fn socket(int domain, int t, int protocol):int! {
+pub fn socket(int domain, int t, int protocol):int! {
     return call6(SYS_SOCKET, domain as anyptr, t as anyptr, protocol as anyptr, 0, 0, 0)
 }
 
 // TODO limit <T:sockaddr_in|sockaddr_un>
-fn bind<T>(int sockfd, T addr):void! {
+pub fn bind<T>(int sockfd, T addr):void! {
     //  nature struct to c
      var len = 16 as anyptr // in 和 unix 长度为 16byte
      call6(SYS_BIND, sockfd as anyptr, addr as anyptr, len, 0, 0, 0)
@@ -788,12 +788,12 @@ fn bind6(int sockfd, sockaddr_in6 addr):void! {
 }
 
 // backlog 表示最大的监听长度
-fn listen(int sockfd, int backlog):void! {
+pub fn listen(int sockfd, int backlog):void! {
     call6(SYS_LISTEN, sockfd as anyptr, backlog as anyptr, 0, 0, 0, 0)
 }
 
 // 相应 client sockfd 和 client sockaddr
-fn accept<T>(int sockfd, ref<T> addr):int! {
+pub fn accept<T>(int sockfd, ref<T> addr):int! {
     var len = 16
     ptr<int> len_ptr = &len
     int fd = call6(SYS_ACCEPT, sockfd as anyptr, addr as anyptr, len_ptr as anyptr, 0, 0, 0)
@@ -801,19 +801,19 @@ fn accept<T>(int sockfd, ref<T> addr):int! {
     return fd
 }
 
-fn recvfrom(int sockfd, [u8] buf, int flags):int! {
+pub fn recvfrom(int sockfd, [u8] buf, int flags):int! {
     return call6(SYS_RECVFROM, sockfd as anyptr, buf.ref(), buf.len() as anyptr, flags as anyptr, 0, 0)
 }
 
-fn sendto(int sockfd, [u8] buf, int flags):int! {
+pub fn sendto(int sockfd, [u8] buf, int flags):int! {
     return call6(SYS_SENDTO, sockfd as anyptr, buf.ref(), buf.len() as anyptr, flags as anyptr, 0, 0)
 }
 
-fn get_envs():[string] {
+pub fn get_envs():[string] {
     return libc.get_envs()
 }
 
-fn get_env(string key):string {
+pub fn get_env(string key):string {
     anyptr ref = getenv(key.ref())
     if ref == 0 {
         return ''
@@ -822,7 +822,7 @@ fn get_env(string key):string {
     return runtime.string_new(ref)
 }
 
-fn set_env(string key, string value):void! {
+pub fn set_env(string key, string value):void! {
     var result = setenv(key.ref(), value.ref(), 1)
     if result != 0 {
         throw errorf('setenv error')

--- a/std/syscall/syscall.linux_amd64.n
+++ b/std/syscall/syscall.linux_amd64.n
@@ -549,8 +549,8 @@ int SOCK_SEQPACKET = 0x5
 pub int SOCK_STREAM = 0x1
 
 
-pub #linkid syscall_call6
-fn call6(int number, anyptr a1, anyptr a2, anyptr a3, anyptr a4, anyptr a5, anyptr a6):int!
+#linkid syscall_call6
+pub fn call6(int number, anyptr a1, anyptr a2, anyptr a3, anyptr a4, anyptr a5, anyptr a6):int!
 
 #linkid syscall_getcwd
 fn syscall_getcwd():string
@@ -595,8 +595,8 @@ pub fn fork():int! {
 
 // path is full path
 // argv[0] = /proc/:pid/comm
-pub #linkid syscall_exec
-fn exec(string path, [string] argv, [string] envp):void!
+#linkid syscall_exec
+pub fn exec(string path, [string] argv, [string] envp):void!
 
 type timespec_t = struct {
     i64 sec

--- a/std/syscall/syscall.linux_arm64.n
+++ b/std/syscall/syscall.linux_arm64.n
@@ -577,8 +577,8 @@ int AT_STATX_DONT_SYNC = 0x4000
 int AT_RECURSIVE = 0x8000
 int AT_EACCESS = 0x200
 
-pub #linkid syscall_call6
-fn call6(int number, anyptr a1, anyptr a2, anyptr a3, anyptr a4, anyptr a5, anyptr a6):int!
+#linkid syscall_call6
+pub fn call6(int number, anyptr a1, anyptr a2, anyptr a3, anyptr a4, anyptr a5, anyptr a6):int!
 
 #linkid syscall_getcwd
 fn syscall_getcwd():string
@@ -623,8 +623,8 @@ pub fn fork():int! {
 
 // path is full path
 // argv[0] = /proc/:pid/comm
-pub #linkid syscall_exec
-fn exec(string path, [string] argv, [string] envp):void!
+#linkid syscall_exec
+pub fn exec(string path, [string] argv, [string] envp):void!
 
 type timespec_t = struct {
     i64 sec

--- a/std/syscall/syscall.linux_arm64.n
+++ b/std/syscall/syscall.linux_arm64.n
@@ -3,7 +3,7 @@ mod syscall
 import runtime
 import libc
 
-u32 MS_ACTIVE = 0x40000000
+pub u32 MS_ACTIVE = 0x40000000
 u32 MS_ASYNC = 0x1
 u32 MS_BIND = 0x1000
 u32 MS_DIRSYNC = 0x80
@@ -62,28 +62,28 @@ int CLONE_NEWPID = 0x20000000
 int CLONE_NEWNET = 0x40000000
 int CLONE_IO = 0x80000000
 
-int O_RDONLY = 0x0  // 只读模式
-int O_WRONLY = 0x1  // 只写模式
-int O_RDWR   = 0x2  // 读写模式
+pub int O_RDONLY = 0x0  // 只读模式
+pub int O_WRONLY = 0x1  // 只写模式
+pub int O_RDWR   = 0x2  // 读写模式
 
-int O_APPEND = 0x8  // 追加写入
-int O_CREAT = 0x40 // 如果文件不存在则创建文件
-int O_EXCL   = 0x80 // 与 O_CREAT 一起使用，文件必须不存在
-int O_TRUNC  = 0x200 // 打开文件时清空文件内容
+pub int O_APPEND = 0x8  // 追加写入
+pub int O_CREAT = 0x40 // 如果文件不存在则创建文件
+pub int O_EXCL   = 0x80 // 与 O_CREAT 一起使用，文件必须不存在
+pub int O_TRUNC  = 0x200 // 打开文件时清空文件内容
 
-int SEEK_SET = 0  // 移动到文件开头
-int SEEK_CUR = 1 // 保持不变
-int SEEK_END = 2 // 移动到文件末尾
+pub int SEEK_SET = 0  // 移动到文件开头
+pub int SEEK_CUR = 1 // 保持不变
+pub int SEEK_END = 2 // 移动到文件末尾
 
-int STDIN = 0
-int STDOUT = 1
-int STDERR = 2
+pub int STDIN = 0
+pub int STDOUT = 1
+pub int STDERR = 2
 
-fn null_device():string {
+pub fn null_device():string {
     return '/dev/null'
 }
 
-int CLOCK_REALTIME = 0
+pub int CLOCK_REALTIME = 0
 int CLOCK_MONOTONIC = 1
 int CLOCK_PROCESS_CPUTIME_ID = 2
 int CLOCK_THREAD_CPUTIME_ID = 3
@@ -96,324 +96,324 @@ int CLOCK_BOOTTIME_ALARM = 9
 int CLOCK_TAI = 11
 
 // 系统调用编码
-const SYS_IO_SETUP = 0
-const SYS_IO_DESTROY = 1
-const SYS_IO_SUBMIT = 2
-const SYS_IO_CANCEL = 3
-const SYS_IO_GETEVENTS = 4
-const SYS_SETXATTR = 5
-const SYS_LSETXATTR = 6
-const SYS_FSETXATTR = 7
-const SYS_GETXATTR = 8
-const SYS_LGETXATTR = 9
-const SYS_FGETXATTR = 10
-const SYS_LISTXATTR = 11
-const SYS_LLISTXATTR = 12
-const SYS_FLISTXATTR = 13
-const SYS_REMOVEXATTR = 14
-const SYS_LREMOVEXATTR = 15
-const SYS_FREMOVEXATTR = 16
-const SYS_GETCWD = 17
-const SYS_LOOKUP_DCOOKIE = 18
-const SYS_EVENTFD2 = 19
-const SYS_EPOLL_CREATE1 = 20
-const SYS_EPOLL_CTL = 21
-const SYS_EPOLL_PWAIT = 22
-const SYS_DUP = 23
-const SYS_DUP3 = 24
-const SYS_FCNTL = 25
-const SYS_INOTIFY_INIT1 = 26
-const SYS_INOTIFY_ADD_WATCH = 27
-const SYS_INOTIFY_RM_WATCH = 28
-const SYS_IOCTL = 29
-const SYS_IOPRIO_SET = 30
-const SYS_IOPRIO_GET = 31
-const SYS_FLOCK = 32
-const SYS_MKNODAT = 33
-const SYS_MKDIRAT = 34
-const SYS_UNLINKAT = 35
-const SYS_SYMLINKAT = 36
-const SYS_LINKAT = 37
-const SYS_RENAMEAT = 38
-const SYS_UMOUNT2 = 39
-const SYS_MOUNT = 40
-const SYS_PIVOT_ROOT = 41
-const SYS_NFSSERVCTL = 42
-const SYS_STATFS = 43
-const SYS_FSTATFS = 44
-const SYS_TRUNCATE = 45
-const SYS_FTRUNCATE = 46
-const SYS_FALLOCATE = 47
-const SYS_FACCESSAT = 48
-const SYS_CHDIR = 49
-const SYS_FCHDIR = 50
-const SYS_CHROOT = 51
-const SYS_FCHMOD = 52
-const SYS_FCHMODAT = 53
-const SYS_FCHOWNAT = 54
-const SYS_FCHOWN = 55
-const SYS_OPENAT = 56
-const SYS_CLOSE = 57
-const SYS_VHANGUP = 58
-const SYS_PIPE2 = 59
-const SYS_QUOTACTL = 60
-const SYS_GETDENTS64 = 61
-const SYS_LSEEK = 62
-const SYS_READ = 63
-const SYS_WRITE = 64
-const SYS_READV = 65
-const SYS_WRITEV = 66
-const SYS_PREAD64 = 67
-const SYS_PWRITE64 = 68
-const SYS_PREADV = 69
-const SYS_PWRITEV = 70
-const SYS_SENDFILE = 71
-const SYS_PSELECT6 = 72
-const SYS_PPOLL = 73
-const SYS_SIGNALFD4 = 74
-const SYS_VMSPLICE = 75
-const SYS_SPLICE = 76
-const SYS_TEE = 77
-const SYS_READLINKAT = 78
-const SYS_NEWFSTATAT = 79
-const SYS_FSTAT = 80
-const SYS_SYNC = 81
-const SYS_FSYNC = 82
-const SYS_FDATASYNC = 83
-const SYS_SYNC_FILE_RANGE = 84
-const SYS_TIMERFD_CREATE = 85
-const SYS_TIMERFD_SETTIME = 86
-const SYS_TIMERFD_GETTIME = 87
-const SYS_UTIMENSAT = 88
-const SYS_ACCT = 89
-const SYS_CAPGET = 90
-const SYS_CAPSET = 91
-const SYS_PERSONALITY = 92
-const SYS_EXIT = 93
-const SYS_EXIT_GROUP = 94
-const SYS_WAITID = 95
-const SYS_SET_TID_ADDRESS = 96
-const SYS_UNSHARE = 97
-const SYS_FUTEX = 98
-const SYS_SET_ROBUST_LIST = 99
-const SYS_GET_ROBUST_LIST = 100
-const SYS_NANOSLEEP = 101
-const SYS_GETITIMER = 102
-const SYS_SETITIMER = 103
-const SYS_KEXEC_LOAD = 104
-const SYS_INIT_MODULE = 105
-const SYS_DELETE_MODULE = 106
-const SYS_TIMER_CREATE = 107
-const SYS_TIMER_GETTIME = 108
-const SYS_TIMER_GETOVERRUN = 109
-const SYS_TIMER_SETTIME = 110
-const SYS_TIMER_DELETE = 111
-const SYS_CLOCK_SETTIME = 112
-const SYS_CLOCK_GETTIME = 113
-const SYS_CLOCK_GETRES = 114
-const SYS_CLOCK_NANOSLEEP = 115
-const SYS_SYSLOG = 116
-const SYS_PTRACE = 117
-const SYS_SCHED_SETPARAM = 118
-const SYS_SCHED_SETSCHEDULER = 119
-const SYS_SCHED_GETSCHEDULER = 120
-const SYS_SCHED_GETPARAM = 121
-const SYS_SCHED_SETAFFINITY = 122
-const SYS_SCHED_GETAFFINITY = 123
-const SYS_SCHED_YIELD = 124
-const SYS_SCHED_GET_PRIORITY_MAX = 125
-const SYS_SCHED_GET_PRIORITY_MIN = 126
-const SYS_SCHED_RR_GET_INTERVAL = 127
-const SYS_RESTART_SYSCALL = 128
-const SYS_KILL = 129
-const SYS_TKILL = 130
-const SYS_TGKILL = 131
-const SYS_SIGALTSTACK = 132
-const SYS_RT_SIGSUSPEND = 133
-const SYS_RT_SIGACTION = 134
-const SYS_RT_SIGPROCMASK = 135
-const SYS_RT_SIGPENDING = 136
-const SYS_RT_SIGTIMEDWAIT = 137
-const SYS_RT_SIGQUEUEINFO = 138
-const SYS_RT_SIGRETURN = 139
-const SYS_SETPRIORITY = 140
-const SYS_GETPRIORITY = 141
-const SYS_REBOOT = 142
-const SYS_SETREGID = 143
-const SYS_SETGID = 144
-const SYS_SETREUID = 145
-const SYS_SETUID = 146
-const SYS_SETRESUID = 147
-const SYS_GETRESUID = 148
-const SYS_SETRESGID = 149
-const SYS_GETRESGID = 150
-const SYS_SETFSUID = 151
-const SYS_SETFSGID = 152
-const SYS_TIMES = 153
-const SYS_SETPGID = 154
-const SYS_GETPGID = 155
-const SYS_GETSID = 156
-const SYS_SETSID = 157
-const SYS_GETGROUPS = 158
-const SYS_SETGROUPS = 159
-const SYS_UNAME = 160
-const SYS_SETHOSTNAME = 161
-const SYS_SETDOMAINNAME = 162
-const SYS_GETRLIMIT = 163
-const SYS_SETRLIMIT = 164
-const SYS_GETRUSAGE = 165
-const SYS_UMASK = 166
-const SYS_PRCTL = 167
-const SYS_GETCPU = 168
-const SYS_GETTIMEOFDAY = 169
-const SYS_SETTIMEOFDAY = 170
-const SYS_ADJTIMEX = 171
-const SYS_GETPID = 172
-const SYS_GETPPID = 173
-const SYS_GETUID = 174
-const SYS_GETEUID = 175
-const SYS_GETGID = 176
-const SYS_GETEGID = 177
-const SYS_GETTID = 178
-const SYS_SYSINFO = 179
-const SYS_MQ_OPEN = 180
-const SYS_MQ_UNLINK = 181
-const SYS_MQ_TIMEDSEND = 182
-const SYS_MQ_TIMEDRECEIVE = 183
-const SYS_MQ_NOTIFY = 184
-const SYS_MQ_GETSETATTR = 185
-const SYS_MSGGET = 186
-const SYS_MSGCTL = 187
-const SYS_MSGRCV = 188
-const SYS_MSGSND = 189
-const SYS_SEMGET = 190
-const SYS_SEMCTL = 191
-const SYS_SEMTIMEDOP = 192
-const SYS_SEMOP = 193
-const SYS_SHMGET = 194
-const SYS_SHMCTL = 195
-const SYS_SHMAT = 196
-const SYS_SHMDT = 197
-const SYS_SOCKET = 198
-const SYS_SOCKETPAIR = 199
-const SYS_BIND = 200
-const SYS_LISTEN = 201
-const SYS_ACCEPT = 202
-const SYS_CONNECT = 203
-const SYS_GETSOCKNAME = 204
-const SYS_GETPEERNAME = 205
-const SYS_SENDTO = 206
-const SYS_RECVFROM = 207
-const SYS_SETSOCKOPT = 208
-const SYS_GETSOCKOPT = 209
-const SYS_SHUTDOWN = 210
-const SYS_SENDMSG = 211
-const SYS_RECVMSG = 212
-const SYS_READAHEAD = 213
-const SYS_BRK = 214
-const SYS_MUNMAP = 215
-const SYS_MREMAP = 216
-const SYS_ADD_KEY = 217
-const SYS_REQUEST_KEY = 218
-const SYS_KEYCTL = 219
-const SYS_CLONE = 220
-const SYS_EXECVE = 221
-const SYS_MMAP = 222
-const SYS_FADVISE64 = 223
-const SYS_SWAPON = 224
-const SYS_SWAPOFF = 225
-const SYS_MPROTECT = 226
-const SYS_MSYNC = 227
-const SYS_MLOCK = 228
-const SYS_MUNLOCK = 229
-const SYS_MLOCKALL = 230
-const SYS_MUNLOCKALL = 231
-const SYS_MINCORE = 232
-const SYS_MADVISE = 233
-const SYS_REMAP_FILE_PAGES = 234
-const SYS_MBIND = 235
-const SYS_GET_MEMPOLICY = 236
-const SYS_SET_MEMPOLICY = 237
-const SYS_MIGRATE_PAGES = 238
-const SYS_MOVE_PAGES = 239
-const SYS_RT_TGSIGQUEUEINFO = 240
-const SYS_PERF_EVENT_OPEN = 241
-const SYS_ACCEPT4 = 242
-const SYS_RECVMMSG = 243
-const SYS_WAIT4 = 260
-const SYS_PRLIMIT64 = 261
-const SYS_FANOTIFY_INIT = 262
-const SYS_FANOTIFY_MARK = 263
-const SYS_NAME_TO_HANDLE_AT = 264
-const SYS_OPEN_BY_HANDLE_AT = 265
-const SYS_CLOCK_ADJTIME = 266
-const SYS_SYNCFS = 267
-const SYS_SETNS = 268
-const SYS_SENDMMSG = 269
-const SYS_PROCESS_VM_READV = 270
-const SYS_PROCESS_VM_WRITEV = 271
-const SYS_KCMP = 272
-const SYS_FINIT_MODULE = 273
-const SYS_SCHED_SETATTR = 274
-const SYS_SCHED_GETATTR = 275
-const SYS_RENAMEAT2 = 276
-const SYS_SECCOMP = 277
-const SYS_GETRANDOM = 278
-const SYS_MEMFD_CREATE = 279
-const SYS_BPF = 280
-const SYS_EXECVEAT = 281
-const SYS_USERFAULTFD = 282
-const SYS_MEMBARRIER = 283
-const SYS_MLOCK2 = 284
-const SYS_COPY_FILE_RANGE = 285
-const SYS_PREADV2 = 286
-const SYS_PWRITEV2 = 287
-const SYS_PKEY_MPROTECT = 288
-const SYS_PKEY_ALLOC = 289
-const SYS_PKEY_FREE = 290
-const SYS_STATX = 291
-const SYS_IO_PGETEVENTS = 292
-const SYS_RSEQ = 293
-const SYS_KEXEC_FILE_LOAD = 294
-const SYS_PIDFD_SEND_SIGNAL = 424
-const SYS_IO_URING_SETUP = 425
-const SYS_IO_URING_ENTER = 426
-const SYS_IO_URING_REGISTER = 427
-const SYS_OPEN_TREE = 428
-const SYS_MOVE_MOUNT = 429
-const SYS_FSOPEN = 430
-const SYS_FSCONFIG = 431
-const SYS_FSMOUNT = 432
-const SYS_FSPICK = 433
-const SYS_PIDFD_OPEN = 434
-const SYS_CLONE3 = 435
-const SYS_CLOSE_RANGE = 436
-const SYS_OPENAT2 = 437
-const SYS_PIDFD_GETFD = 438
-const SYS_FACCESSAT2 = 439
-const SYS_PROCESS_MADVISE = 440
-const SYS_EPOLL_PWAIT2 = 441
-const SYS_MOUNT_SETATTR = 442
-const SYS_QUOTACTL_FD = 443
-const SYS_LANDLOCK_CREATE_RULESET = 444
-const SYS_LANDLOCK_ADD_RULE = 445
-const SYS_LANDLOCK_RESTRICT_SELF = 446
-const SYS_MEMFD_SECRET = 447
-const SYS_PROCESS_MRELEASE = 448
-const SYS_FUTEX_WAITV = 449
-const SYS_SET_MEMPOLICY_HOME_NODE = 450
-const SYS_CACHESTAT = 451
-const SYS_FCHMODAT2 = 452
-const SYS_MAP_SHADOW_STACK = 453
-const SYS_FUTEX_WAKE = 454
-const SYS_FUTEX_WAIT = 455
-const SYS_FUTEX_REQUEUE = 456
-const SYS_STATMOUNT = 457
-const SYS_LISTMOUNT = 458
-const SYS_LSM_GET_SELF_ATTR = 459
-const SYS_LSM_SET_SELF_ATTR = 460
-const SYS_LSM_LIST_MODULES = 461
-const SYS_MSEAL = 462
+pub const SYS_IO_SETUP = 0
+pub const SYS_IO_DESTROY = 1
+pub const SYS_IO_SUBMIT = 2
+pub const SYS_IO_CANCEL = 3
+pub const SYS_IO_GETEVENTS = 4
+pub const SYS_SETXATTR = 5
+pub const SYS_LSETXATTR = 6
+pub const SYS_FSETXATTR = 7
+pub const SYS_GETXATTR = 8
+pub const SYS_LGETXATTR = 9
+pub const SYS_FGETXATTR = 10
+pub const SYS_LISTXATTR = 11
+pub const SYS_LLISTXATTR = 12
+pub const SYS_FLISTXATTR = 13
+pub const SYS_REMOVEXATTR = 14
+pub const SYS_LREMOVEXATTR = 15
+pub const SYS_FREMOVEXATTR = 16
+pub const SYS_GETCWD = 17
+pub const SYS_LOOKUP_DCOOKIE = 18
+pub const SYS_EVENTFD2 = 19
+pub const SYS_EPOLL_CREATE1 = 20
+pub const SYS_EPOLL_CTL = 21
+pub const SYS_EPOLL_PWAIT = 22
+pub const SYS_DUP = 23
+pub const SYS_DUP3 = 24
+pub const SYS_FCNTL = 25
+pub const SYS_INOTIFY_INIT1 = 26
+pub const SYS_INOTIFY_ADD_WATCH = 27
+pub const SYS_INOTIFY_RM_WATCH = 28
+pub const SYS_IOCTL = 29
+pub const SYS_IOPRIO_SET = 30
+pub const SYS_IOPRIO_GET = 31
+pub const SYS_FLOCK = 32
+pub const SYS_MKNODAT = 33
+pub const SYS_MKDIRAT = 34
+pub const SYS_UNLINKAT = 35
+pub const SYS_SYMLINKAT = 36
+pub const SYS_LINKAT = 37
+pub const SYS_RENAMEAT = 38
+pub const SYS_UMOUNT2 = 39
+pub const SYS_MOUNT = 40
+pub const SYS_PIVOT_ROOT = 41
+pub const SYS_NFSSERVCTL = 42
+pub const SYS_STATFS = 43
+pub const SYS_FSTATFS = 44
+pub const SYS_TRUNCATE = 45
+pub const SYS_FTRUNCATE = 46
+pub const SYS_FALLOCATE = 47
+pub const SYS_FACCESSAT = 48
+pub const SYS_CHDIR = 49
+pub const SYS_FCHDIR = 50
+pub const SYS_CHROOT = 51
+pub const SYS_FCHMOD = 52
+pub const SYS_FCHMODAT = 53
+pub const SYS_FCHOWNAT = 54
+pub const SYS_FCHOWN = 55
+pub const SYS_OPENAT = 56
+pub const SYS_CLOSE = 57
+pub const SYS_VHANGUP = 58
+pub const SYS_PIPE2 = 59
+pub const SYS_QUOTACTL = 60
+pub const SYS_GETDENTS64 = 61
+pub const SYS_LSEEK = 62
+pub const SYS_READ = 63
+pub const SYS_WRITE = 64
+pub const SYS_READV = 65
+pub const SYS_WRITEV = 66
+pub const SYS_PREAD64 = 67
+pub const SYS_PWRITE64 = 68
+pub const SYS_PREADV = 69
+pub const SYS_PWRITEV = 70
+pub const SYS_SENDFILE = 71
+pub const SYS_PSELECT6 = 72
+pub const SYS_PPOLL = 73
+pub const SYS_SIGNALFD4 = 74
+pub const SYS_VMSPLICE = 75
+pub const SYS_SPLICE = 76
+pub const SYS_TEE = 77
+pub const SYS_READLINKAT = 78
+pub const SYS_NEWFSTATAT = 79
+pub const SYS_FSTAT = 80
+pub const SYS_SYNC = 81
+pub const SYS_FSYNC = 82
+pub const SYS_FDATASYNC = 83
+pub const SYS_SYNC_FILE_RANGE = 84
+pub const SYS_TIMERFD_CREATE = 85
+pub const SYS_TIMERFD_SETTIME = 86
+pub const SYS_TIMERFD_GETTIME = 87
+pub const SYS_UTIMENSAT = 88
+pub const SYS_ACCT = 89
+pub const SYS_CAPGET = 90
+pub const SYS_CAPSET = 91
+pub const SYS_PERSONALITY = 92
+pub const SYS_EXIT = 93
+pub const SYS_EXIT_GROUP = 94
+pub const SYS_WAITID = 95
+pub const SYS_SET_TID_ADDRESS = 96
+pub const SYS_UNSHARE = 97
+pub const SYS_FUTEX = 98
+pub const SYS_SET_ROBUST_LIST = 99
+pub const SYS_GET_ROBUST_LIST = 100
+pub const SYS_NANOSLEEP = 101
+pub const SYS_GETITIMER = 102
+pub const SYS_SETITIMER = 103
+pub const SYS_KEXEC_LOAD = 104
+pub const SYS_INIT_MODULE = 105
+pub const SYS_DELETE_MODULE = 106
+pub const SYS_TIMER_CREATE = 107
+pub const SYS_TIMER_GETTIME = 108
+pub const SYS_TIMER_GETOVERRUN = 109
+pub const SYS_TIMER_SETTIME = 110
+pub const SYS_TIMER_DELETE = 111
+pub const SYS_CLOCK_SETTIME = 112
+pub const SYS_CLOCK_GETTIME = 113
+pub const SYS_CLOCK_GETRES = 114
+pub const SYS_CLOCK_NANOSLEEP = 115
+pub const SYS_SYSLOG = 116
+pub const SYS_PTRACE = 117
+pub const SYS_SCHED_SETPARAM = 118
+pub const SYS_SCHED_SETSCHEDULER = 119
+pub const SYS_SCHED_GETSCHEDULER = 120
+pub const SYS_SCHED_GETPARAM = 121
+pub const SYS_SCHED_SETAFFINITY = 122
+pub const SYS_SCHED_GETAFFINITY = 123
+pub const SYS_SCHED_YIELD = 124
+pub const SYS_SCHED_GET_PRIORITY_MAX = 125
+pub const SYS_SCHED_GET_PRIORITY_MIN = 126
+pub const SYS_SCHED_RR_GET_INTERVAL = 127
+pub const SYS_RESTART_SYSCALL = 128
+pub const SYS_KILL = 129
+pub const SYS_TKILL = 130
+pub const SYS_TGKILL = 131
+pub const SYS_SIGALTSTACK = 132
+pub const SYS_RT_SIGSUSPEND = 133
+pub const SYS_RT_SIGACTION = 134
+pub const SYS_RT_SIGPROCMASK = 135
+pub const SYS_RT_SIGPENDING = 136
+pub const SYS_RT_SIGTIMEDWAIT = 137
+pub const SYS_RT_SIGQUEUEINFO = 138
+pub const SYS_RT_SIGRETURN = 139
+pub const SYS_SETPRIORITY = 140
+pub const SYS_GETPRIORITY = 141
+pub const SYS_REBOOT = 142
+pub const SYS_SETREGID = 143
+pub const SYS_SETGID = 144
+pub const SYS_SETREUID = 145
+pub const SYS_SETUID = 146
+pub const SYS_SETRESUID = 147
+pub const SYS_GETRESUID = 148
+pub const SYS_SETRESGID = 149
+pub const SYS_GETRESGID = 150
+pub const SYS_SETFSUID = 151
+pub const SYS_SETFSGID = 152
+pub const SYS_TIMES = 153
+pub const SYS_SETPGID = 154
+pub const SYS_GETPGID = 155
+pub const SYS_GETSID = 156
+pub const SYS_SETSID = 157
+pub const SYS_GETGROUPS = 158
+pub const SYS_SETGROUPS = 159
+pub const SYS_UNAME = 160
+pub const SYS_SETHOSTNAME = 161
+pub const SYS_SETDOMAINNAME = 162
+pub const SYS_GETRLIMIT = 163
+pub const SYS_SETRLIMIT = 164
+pub const SYS_GETRUSAGE = 165
+pub const SYS_UMASK = 166
+pub const SYS_PRCTL = 167
+pub const SYS_GETCPU = 168
+pub const SYS_GETTIMEOFDAY = 169
+pub const SYS_SETTIMEOFDAY = 170
+pub const SYS_ADJTIMEX = 171
+pub const SYS_GETPID = 172
+pub const SYS_GETPPID = 173
+pub const SYS_GETUID = 174
+pub const SYS_GETEUID = 175
+pub const SYS_GETGID = 176
+pub const SYS_GETEGID = 177
+pub const SYS_GETTID = 178
+pub const SYS_SYSINFO = 179
+pub const SYS_MQ_OPEN = 180
+pub const SYS_MQ_UNLINK = 181
+pub const SYS_MQ_TIMEDSEND = 182
+pub const SYS_MQ_TIMEDRECEIVE = 183
+pub const SYS_MQ_NOTIFY = 184
+pub const SYS_MQ_GETSETATTR = 185
+pub const SYS_MSGGET = 186
+pub const SYS_MSGCTL = 187
+pub const SYS_MSGRCV = 188
+pub const SYS_MSGSND = 189
+pub const SYS_SEMGET = 190
+pub const SYS_SEMCTL = 191
+pub const SYS_SEMTIMEDOP = 192
+pub const SYS_SEMOP = 193
+pub const SYS_SHMGET = 194
+pub const SYS_SHMCTL = 195
+pub const SYS_SHMAT = 196
+pub const SYS_SHMDT = 197
+pub const SYS_SOCKET = 198
+pub const SYS_SOCKETPAIR = 199
+pub const SYS_BIND = 200
+pub const SYS_LISTEN = 201
+pub const SYS_ACCEPT = 202
+pub const SYS_CONNECT = 203
+pub const SYS_GETSOCKNAME = 204
+pub const SYS_GETPEERNAME = 205
+pub const SYS_SENDTO = 206
+pub const SYS_RECVFROM = 207
+pub const SYS_SETSOCKOPT = 208
+pub const SYS_GETSOCKOPT = 209
+pub const SYS_SHUTDOWN = 210
+pub const SYS_SENDMSG = 211
+pub const SYS_RECVMSG = 212
+pub const SYS_READAHEAD = 213
+pub const SYS_BRK = 214
+pub const SYS_MUNMAP = 215
+pub const SYS_MREMAP = 216
+pub const SYS_ADD_KEY = 217
+pub const SYS_REQUEST_KEY = 218
+pub const SYS_KEYCTL = 219
+pub const SYS_CLONE = 220
+pub const SYS_EXECVE = 221
+pub const SYS_MMAP = 222
+pub const SYS_FADVISE64 = 223
+pub const SYS_SWAPON = 224
+pub const SYS_SWAPOFF = 225
+pub const SYS_MPROTECT = 226
+pub const SYS_MSYNC = 227
+pub const SYS_MLOCK = 228
+pub const SYS_MUNLOCK = 229
+pub const SYS_MLOCKALL = 230
+pub const SYS_MUNLOCKALL = 231
+pub const SYS_MINCORE = 232
+pub const SYS_MADVISE = 233
+pub const SYS_REMAP_FILE_PAGES = 234
+pub const SYS_MBIND = 235
+pub const SYS_GET_MEMPOLICY = 236
+pub const SYS_SET_MEMPOLICY = 237
+pub const SYS_MIGRATE_PAGES = 238
+pub const SYS_MOVE_PAGES = 239
+pub const SYS_RT_TGSIGQUEUEINFO = 240
+pub const SYS_PERF_EVENT_OPEN = 241
+pub const SYS_ACCEPT4 = 242
+pub const SYS_RECVMMSG = 243
+pub const SYS_WAIT4 = 260
+pub const SYS_PRLIMIT64 = 261
+pub const SYS_FANOTIFY_INIT = 262
+pub const SYS_FANOTIFY_MARK = 263
+pub const SYS_NAME_TO_HANDLE_AT = 264
+pub const SYS_OPEN_BY_HANDLE_AT = 265
+pub const SYS_CLOCK_ADJTIME = 266
+pub const SYS_SYNCFS = 267
+pub const SYS_SETNS = 268
+pub const SYS_SENDMMSG = 269
+pub const SYS_PROCESS_VM_READV = 270
+pub const SYS_PROCESS_VM_WRITEV = 271
+pub const SYS_KCMP = 272
+pub const SYS_FINIT_MODULE = 273
+pub const SYS_SCHED_SETATTR = 274
+pub const SYS_SCHED_GETATTR = 275
+pub const SYS_RENAMEAT2 = 276
+pub const SYS_SECCOMP = 277
+pub const SYS_GETRANDOM = 278
+pub const SYS_MEMFD_CREATE = 279
+pub const SYS_BPF = 280
+pub const SYS_EXECVEAT = 281
+pub const SYS_USERFAULTFD = 282
+pub const SYS_MEMBARRIER = 283
+pub const SYS_MLOCK2 = 284
+pub const SYS_COPY_FILE_RANGE = 285
+pub const SYS_PREADV2 = 286
+pub const SYS_PWRITEV2 = 287
+pub const SYS_PKEY_MPROTECT = 288
+pub const SYS_PKEY_ALLOC = 289
+pub const SYS_PKEY_FREE = 290
+pub const SYS_STATX = 291
+pub const SYS_IO_PGETEVENTS = 292
+pub const SYS_RSEQ = 293
+pub const SYS_KEXEC_FILE_LOAD = 294
+pub const SYS_PIDFD_SEND_SIGNAL = 424
+pub const SYS_IO_URING_SETUP = 425
+pub const SYS_IO_URING_ENTER = 426
+pub const SYS_IO_URING_REGISTER = 427
+pub const SYS_OPEN_TREE = 428
+pub const SYS_MOVE_MOUNT = 429
+pub const SYS_FSOPEN = 430
+pub const SYS_FSCONFIG = 431
+pub const SYS_FSMOUNT = 432
+pub const SYS_FSPICK = 433
+pub const SYS_PIDFD_OPEN = 434
+pub const SYS_CLONE3 = 435
+pub const SYS_CLOSE_RANGE = 436
+pub const SYS_OPENAT2 = 437
+pub const SYS_PIDFD_GETFD = 438
+pub const SYS_FACCESSAT2 = 439
+pub const SYS_PROCESS_MADVISE = 440
+pub const SYS_EPOLL_PWAIT2 = 441
+pub const SYS_MOUNT_SETATTR = 442
+pub const SYS_QUOTACTL_FD = 443
+pub const SYS_LANDLOCK_CREATE_RULESET = 444
+pub const SYS_LANDLOCK_ADD_RULE = 445
+pub const SYS_LANDLOCK_RESTRICT_SELF = 446
+pub const SYS_MEMFD_SECRET = 447
+pub const SYS_PROCESS_MRELEASE = 448
+pub const SYS_FUTEX_WAITV = 449
+pub const SYS_SET_MEMPOLICY_HOME_NODE = 450
+pub const SYS_CACHESTAT = 451
+pub const SYS_FCHMODAT2 = 452
+pub const SYS_MAP_SHADOW_STACK = 453
+pub const SYS_FUTEX_WAKE = 454
+pub const SYS_FUTEX_WAIT = 455
+pub const SYS_FUTEX_REQUEUE = 456
+pub const SYS_STATMOUNT = 457
+pub const SYS_LISTMOUNT = 458
+pub const SYS_LSM_GET_SELF_ATTR = 459
+pub const SYS_LSM_SET_SELF_ATTR = 460
+pub const SYS_LSM_LIST_MODULES = 461
+pub const SYS_MSEAL = 462
 
 // sigkill 相关信号
 int SIGABRT = 0x6
@@ -425,10 +425,10 @@ int SIGCONT = 0x12
 int SIGFPE = 0x8
 int SIGHUP = 0x1
 int SIGILL = 0x4
-int SIGINT = 0x2
+pub int SIGINT = 0x2
 int SIGIO = 0x1d
 int SIGIOT = 0x6
-int SIGKILL = 0x9
+pub int SIGKILL = 0x9
 int SIGPIPE = 0xd
 int SIGPOLL = 0x1d
 int SIGPROF = 0x1b
@@ -438,15 +438,15 @@ int SIGSEGV = 0xb
 int SIGSTKFLT = 0x10
 int SIGSTOP = 0x13
 int SIGSYS = 0x1f
-int SIGTERM = 0xf
+pub int SIGTERM = 0xf
 int SIGTRAP = 0x5
 int SIGTSTP = 0x14
 int SIGTTIN = 0x15
 int SIGTTOU = 0x16
 int SIGUNUSED = 0x1f
 int SIGURG = 0x17
-int SIGUSR1 = 0xa
-int SIGUSR2 = 0xc
+pub int SIGUSR1 = 0xa
+pub int SIGUSR2 = 0xc
 int SIGVTALRM = 0x1a
 int SIGWINCH = 0x1c
 int SIGXCPU = 0x18
@@ -467,8 +467,8 @@ int AF_DECnet = 0xc
 int AF_ECONET = 0x13
 int AF_FILE = 0x1
 int AF_IEEE802154 = 0x24
-int AF_INET = 0x2
-int AF_INET6 = 0xa
+pub int AF_INET = 0x2
+pub int AF_INET6 = 0xa
 int AF_IPX = 0x4
 int AF_IRDA = 0x17
 int AF_ISDN = 0x22
@@ -561,7 +561,7 @@ int SOCK_PACKET = 0xa
 int SOCK_RAW = 0x3
 int SOCK_RDM = 0x4
 int SOCK_SEQPACKET = 0x5
-int SOCK_STREAM = 0x1
+pub int SOCK_STREAM = 0x1
 
 // AT_* 常量定义
 int AT_FDCWD = -100
@@ -577,7 +577,7 @@ int AT_STATX_DONT_SYNC = 0x4000
 int AT_RECURSIVE = 0x8000
 int AT_EACCESS = 0x200
 
-#linkid syscall_call6
+pub #linkid syscall_call6
 fn call6(int number, anyptr a1, anyptr a2, anyptr a3, anyptr a4, anyptr a5, anyptr a6):int!
 
 #linkid syscall_getcwd
@@ -589,41 +589,41 @@ fn getenv(anyptr key):anyptr
 #linkid setenv
 fn setenv(anyptr key, anyptr value, i32 overwrite):i32
 
-fn open(string filename, int flags, u32 perm):int! {
+pub fn open(string filename, int flags, u32 perm):int! {
     return call6(SYS_OPENAT, AT_FDCWD as anyptr, filename.ref(), flags as anyptr, perm as anyptr, 0, 0)
 }
 
-fn read(int fd, anyptr buf, int len):int! {
+pub fn read(int fd, anyptr buf, int len):int! {
     return call6(SYS_READ, fd as anyptr, buf, len as anyptr, 0, 0, 0)
 }
 
-fn readlink(string file, [u8] buf):int! {
+pub fn readlink(string file, [u8] buf):int! {
     return call6(SYS_READLINKAT, AT_FDCWD as anyptr, file.ref(), buf.ref(), buf.len() as anyptr, 0, 0)
 }
 
-fn write(int fd, anyptr buf, int len):int! {
+pub fn write(int fd, anyptr buf, int len):int! {
     return call6(SYS_WRITE, fd as anyptr, buf, len as anyptr, 0, 0, 0)
 }
 
-fn close(int fd):void! {
+pub fn close(int fd):void! {
     call6(SYS_CLOSE, fd as anyptr, 0, 0, 0, 0, 0)
 }
 
-fn unlink(string path):void! {
+pub fn unlink(string path):void! {
     call6(SYS_UNLINKAT, AT_FDCWD as anyptr, path.ref(), 0, 0, 0, 0)
 }
 
-fn seek(int fd, int offset, int whence):int! {
+pub fn seek(int fd, int offset, int whence):int! {
     return call6(SYS_LSEEK, fd as anyptr, offset as anyptr, whence as anyptr, 0, 0, 0)
 }
 
-fn fork():int! {
+pub fn fork():int! {
     return call6(SYS_CLONE, 17 as anyptr /* SIGCHLD */, 0, 0, 0, 0, 0)
 }
 
 // path is full path
 // argv[0] = /proc/:pid/comm
-#linkid syscall_exec
+pub #linkid syscall_exec
 fn exec(string path, [string] argv, [string] envp):void!
 
 type timespec_t = struct {
@@ -631,7 +631,7 @@ type timespec_t = struct {
     i64 nsec
 }
 
-type stat_t = struct {
+pub type stat_t = struct {
     u64 dev         // __dev_t st_dev
     u64 ino         // __ino64_t st_ino
     u32 mode        // __mode_t st_mode
@@ -665,7 +665,7 @@ fn stat_is_blk(u32 mode):bool {
 fn stat_is_chr(u32 mode):bool {
     return (mode & S_IFMT) == S_IFCHR
 }
-fn stat_is_dir(u32 mode):bool {
+pub fn stat_is_dir(u32 mode):bool {
     return (mode & S_IFMT) == S_IFDIR
 }
 
@@ -673,7 +673,7 @@ fn stat_is_fifo(u32 mode):bool {
     return (mode & S_IFMT) == S_IFIFO
 }
 
-fn stat_is_reg(u32 mode):bool {
+pub fn stat_is_reg(u32 mode):bool {
     return (mode & S_IFMT) == S_IFREG
 }
 fn stat_is_lnk(u32 mode):bool {
@@ -682,13 +682,13 @@ fn stat_is_lnk(u32 mode):bool {
 fn stat_is_sock(u32 mode):bool {
     return (mode & S_IFMT) == S_IFSOCK
 }
-fn stat(string filename):stat_t! {
+pub fn stat(string filename):stat_t! {
     var st = stat_t{}
     call6(SYS_NEWFSTATAT, AT_FDCWD as anyptr, filename.ref(), st as anyptr, 0, 0, 0)
     return st
 }
 
-fn fstat(int fd):stat_t! {
+pub fn fstat(int fd):stat_t! {
     var st = stat_t{}
 
     call6(SYS_FSTAT, fd as anyptr, st as anyptr, 0, 0, 0, 0)
@@ -696,15 +696,15 @@ fn fstat(int fd):stat_t! {
     return st
 }
 
-fn mkdir(string path, u32 mode):void! {
+pub fn mkdir(string path, u32 mode):void! {
     call6(SYS_MKDIRAT, AT_FDCWD as anyptr, path.ref(), mode as anyptr, 0, 0, 0)
 }
 
-fn rmdir(string path):void! {
+pub fn rmdir(string path):void! {
     call6(SYS_UNLINKAT, AT_FDCWD as anyptr, path.ref(), AT_REMOVEDIR as anyptr, 0, 0, 0)
 }
 
-fn rename(string oldpath, string newpath):void! {
+pub fn rename(string oldpath, string newpath):void! {
     call6(SYS_RENAMEAT, AT_FDCWD as anyptr, oldpath.ref(), AT_FDCWD as anyptr, newpath.ref(), 0, 0)
 }
 
@@ -712,15 +712,15 @@ fn exit(int status):void! {
     call6(SYS_EXIT_GROUP, status as anyptr, 0, 0, 0, 0, 0)
 }
 
-fn getpid():int! {
+pub fn getpid():int! {
     return call6(SYS_GETPID, 0, 0, 0, 0, 0, 0)
 }
 
-fn getppid():int! {
+pub fn getppid():int! {
     return call6(SYS_GETPPID, 0, 0, 0, 0, 0, 0)
 }
 
-fn getcwd():string! {
+pub fn getcwd():string! {
     var buf = vec<u8>.new(0, 1024) // 1024 是 path max
     var len = call6(SYS_GETCWD, buf.ref(), buf.len() as anyptr, 0, 0, 0, 0)
 
@@ -729,11 +729,11 @@ fn getcwd():string! {
     return buf as string
 }
 
-fn kill(int pid, int sig):void! {
+pub fn kill(int pid, int sig):void! {
     call6(SYS_KILL, pid as anyptr, sig as anyptr, 0, 0, 0, 0)
 }
 
-fn wait(int pid, int option):(int, int)! {
+pub fn wait(int pid, int option):(int, int)! {
     var status = 0
     int result = libc.waitpid(pid, &status, option)
     if result == -1 {
@@ -755,11 +755,11 @@ fn chown(string path, u32 uid, u32 gid):void! {
     call6(SYS_FCHOWNAT, AT_FDCWD as anyptr, path.ref(), uid as anyptr, gid as anyptr, 0, 0)
 }
 
-fn chmod(string path, u32 mode):void! {
+pub fn chmod(string path, u32 mode):void! {
     call6(SYS_FCHMODAT, AT_FDCWD as anyptr, path.ref(), mode as anyptr, 0, 0, 0)
 }
 
-fn gettime():timespec_t! {
+pub fn gettime():timespec_t! {
     int clock_id = CLOCK_REALTIME
     var result = timespec_t{}
 
@@ -769,7 +769,7 @@ fn gettime():timespec_t! {
 }
 
 // net --------------
-type sockaddr_in = struct {
+pub type sockaddr_in = struct {
     u16 sin_family
     u16 sin_port
     u32 sin_addr
@@ -791,12 +791,12 @@ type sockaddr_un = struct {
     [u8;108] sun_path
 }
 
-fn socket(int domain, int t, int protocol):int! {
+pub fn socket(int domain, int t, int protocol):int! {
     return call6(SYS_SOCKET, domain as anyptr, t as anyptr, protocol as anyptr, 0, 0, 0)
 }
 
 // TODO limit <T:sockaddr_in|sockaddr_un>
-fn bind<T>(int sockfd, T addr):void! {
+pub fn bind<T>(int sockfd, T addr):void! {
     //  nature struct to c
      var len = 16 as anyptr // in 和 unix 长度为 16byte
      call6(SYS_BIND, sockfd as anyptr, addr as anyptr, len, 0, 0, 0)
@@ -808,12 +808,12 @@ fn bind6(int sockfd, sockaddr_in6 addr):void! {
 }
 
 // backlog 表示最大的监听长度
-fn listen(int sockfd, int backlog):void! {
+pub fn listen(int sockfd, int backlog):void! {
     call6(SYS_LISTEN, sockfd as anyptr, backlog as anyptr, 0, 0, 0, 0)
 }
 
 // 相应 client sockfd 和 client sockaddr
-fn accept<T>(int sockfd, ref<T> addr):int! {
+pub fn accept<T>(int sockfd, ref<T> addr):int! {
     var len = 16
     ptr<int> len_ptr = &len
     int fd = call6(SYS_ACCEPT, sockfd as anyptr, addr as anyptr, len_ptr as anyptr, 0, 0, 0)
@@ -821,19 +821,19 @@ fn accept<T>(int sockfd, ref<T> addr):int! {
     return fd
 }
 
-fn recvfrom(int sockfd, [u8] buf, int flags):int! {
+pub fn recvfrom(int sockfd, [u8] buf, int flags):int! {
     return call6(SYS_RECVFROM, sockfd as anyptr, buf.ref(), buf.len() as anyptr, flags as anyptr, 0, 0)
 }
 
-fn sendto(int sockfd, [u8] buf, int flags):int! {
+pub fn sendto(int sockfd, [u8] buf, int flags):int! {
     return call6(SYS_SENDTO, sockfd as anyptr, buf.ref(), buf.len() as anyptr, flags as anyptr, 0, 0)
 }
 
-fn get_envs():[string] {
+pub fn get_envs():[string] {
     return libc.get_envs()
 }
 
-fn get_env(string key):string {
+pub fn get_env(string key):string {
     anyptr ref = getenv(key.ref())
     if ref == 0 {
         return ''
@@ -842,7 +842,7 @@ fn get_env(string key):string {
     return runtime.string_new(ref)
 }
 
-fn set_env(string key, string value):void! {
+pub fn set_env(string key, string value):void! {
     var result = setenv(key.ref(), value.ref(), 1)
     if result != 0 {
         throw errorf('setenv error')

--- a/std/syscall/syscall.linux_riscv64.n
+++ b/std/syscall/syscall.linux_riscv64.n
@@ -577,8 +577,8 @@ int AT_STATX_DONT_SYNC = 0x4000
 int AT_RECURSIVE = 0x8000
 int AT_EACCESS = 0x200
 
-pub #linkid syscall_call6
-fn call6(int number, anyptr a1, anyptr a2, anyptr a3, anyptr a4, anyptr a5, anyptr a6):int!
+#linkid syscall_call6
+pub fn call6(int number, anyptr a1, anyptr a2, anyptr a3, anyptr a4, anyptr a5, anyptr a6):int!
 
 #linkid syscall_getcwd
 fn syscall_getcwd():string
@@ -623,8 +623,8 @@ pub fn fork():int! {
 
 // path is full path
 // argv[0] = /proc/:pid/comm
-pub #linkid syscall_exec
-fn exec(string path, [string] argv, [string] envp):void!
+#linkid syscall_exec
+pub fn exec(string path, [string] argv, [string] envp):void!
 
 type timespec_t = struct {
     i64 sec

--- a/std/syscall/syscall.linux_riscv64.n
+++ b/std/syscall/syscall.linux_riscv64.n
@@ -3,7 +3,7 @@ mod syscall
 import runtime
 import libc
 
-u32 MS_ACTIVE = 0x40000000
+pub u32 MS_ACTIVE = 0x40000000
 u32 MS_ASYNC = 0x1
 u32 MS_BIND = 0x1000
 u32 MS_DIRSYNC = 0x80
@@ -62,28 +62,28 @@ int CLONE_NEWPID = 0x20000000
 int CLONE_NEWNET = 0x40000000
 int CLONE_IO = 0x80000000
 
-int O_RDONLY = 0x0  // 只读模式
-int O_WRONLY = 0x1  // 只写模式
-int O_RDWR   = 0x2  // 读写模式
+pub int O_RDONLY = 0x0  // 只读模式
+pub int O_WRONLY = 0x1  // 只写模式
+pub int O_RDWR   = 0x2  // 读写模式
 
-int O_APPEND = 0x8  // 追加写入
-int O_CREAT = 0x40 // 如果文件不存在则创建文件
-int O_EXCL   = 0x80 // 与 O_CREAT 一起使用，文件必须不存在
-int O_TRUNC  = 0x200 // 打开文件时清空文件内容
+pub int O_APPEND = 0x8  // 追加写入
+pub int O_CREAT = 0x40 // 如果文件不存在则创建文件
+pub int O_EXCL   = 0x80 // 与 O_CREAT 一起使用，文件必须不存在
+pub int O_TRUNC  = 0x200 // 打开文件时清空文件内容
 
-int SEEK_SET = 0  // 移动到文件开头
-int SEEK_CUR = 1 // 保持不变
-int SEEK_END = 2 // 移动到文件末尾
+pub int SEEK_SET = 0  // 移动到文件开头
+pub int SEEK_CUR = 1 // 保持不变
+pub int SEEK_END = 2 // 移动到文件末尾
 
-int STDIN = 0
-int STDOUT = 1
-int STDERR = 2
+pub int STDIN = 0
+pub int STDOUT = 1
+pub int STDERR = 2
 
-fn null_device():string {
+pub fn null_device():string {
     return '/dev/null'
 }
 
-int CLOCK_REALTIME = 0
+pub int CLOCK_REALTIME = 0
 int CLOCK_MONOTONIC = 1
 int CLOCK_PROCESS_CPUTIME_ID = 2
 int CLOCK_THREAD_CPUTIME_ID = 3
@@ -96,324 +96,324 @@ int CLOCK_BOOTTIME_ALARM = 9
 int CLOCK_TAI = 11
 
 // 系统调用编码
-const SYS_IO_SETUP = 0
-const SYS_IO_DESTROY = 1
-const SYS_IO_SUBMIT = 2
-const SYS_IO_CANCEL = 3
-const SYS_IO_GETEVENTS = 4
-const SYS_SETXATTR = 5
-const SYS_LSETXATTR = 6
-const SYS_FSETXATTR = 7
-const SYS_GETXATTR = 8
-const SYS_LGETXATTR = 9
-const SYS_FGETXATTR = 10
-const SYS_LISTXATTR = 11
-const SYS_LLISTXATTR = 12
-const SYS_FLISTXATTR = 13
-const SYS_REMOVEXATTR = 14
-const SYS_LREMOVEXATTR = 15
-const SYS_FREMOVEXATTR = 16
-const SYS_GETCWD = 17
-const SYS_LOOKUP_DCOOKIE = 18
-const SYS_EVENTFD2 = 19
-const SYS_EPOLL_CREATE1 = 20
-const SYS_EPOLL_CTL = 21
-const SYS_EPOLL_PWAIT = 22
-const SYS_DUP = 23
-const SYS_DUP3 = 24
-const SYS_FCNTL = 25
-const SYS_INOTIFY_INIT1 = 26
-const SYS_INOTIFY_ADD_WATCH = 27
-const SYS_INOTIFY_RM_WATCH = 28
-const SYS_IOCTL = 29
-const SYS_IOPRIO_SET = 30
-const SYS_IOPRIO_GET = 31
-const SYS_FLOCK = 32
-const SYS_MKNODAT = 33
-const SYS_MKDIRAT = 34
-const SYS_UNLINKAT = 35
-const SYS_SYMLINKAT = 36
-const SYS_LINKAT = 37
-const SYS_RENAMEAT = 38
-const SYS_UMOUNT2 = 39
-const SYS_MOUNT = 40
-const SYS_PIVOT_ROOT = 41
-const SYS_NFSSERVCTL = 42
-const SYS_STATFS = 43
-const SYS_FSTATFS = 44
-const SYS_TRUNCATE = 45
-const SYS_FTRUNCATE = 46
-const SYS_FALLOCATE = 47
-const SYS_FACCESSAT = 48
-const SYS_CHDIR = 49
-const SYS_FCHDIR = 50
-const SYS_CHROOT = 51
-const SYS_FCHMOD = 52
-const SYS_FCHMODAT = 53
-const SYS_FCHOWNAT = 54
-const SYS_FCHOWN = 55
-const SYS_OPENAT = 56
-const SYS_CLOSE = 57
-const SYS_VHANGUP = 58
-const SYS_PIPE2 = 59
-const SYS_QUOTACTL = 60
-const SYS_GETDENTS64 = 61
-const SYS_LSEEK = 62
-const SYS_READ = 63
-const SYS_WRITE = 64
-const SYS_READV = 65
-const SYS_WRITEV = 66
-const SYS_PREAD64 = 67
-const SYS_PWRITE64 = 68
-const SYS_PREADV = 69
-const SYS_PWRITEV = 70
-const SYS_SENDFILE = 71
-const SYS_PSELECT6 = 72
-const SYS_PPOLL = 73
-const SYS_SIGNALFD4 = 74
-const SYS_VMSPLICE = 75
-const SYS_SPLICE = 76
-const SYS_TEE = 77
-const SYS_READLINKAT = 78
-const SYS_NEWFSTATAT = 79
-const SYS_FSTAT = 80
-const SYS_SYNC = 81
-const SYS_FSYNC = 82
-const SYS_FDATASYNC = 83
-const SYS_SYNC_FILE_RANGE = 84
-const SYS_TIMERFD_CREATE = 85
-const SYS_TIMERFD_SETTIME = 86
-const SYS_TIMERFD_GETTIME = 87
-const SYS_UTIMENSAT = 88
-const SYS_ACCT = 89
-const SYS_CAPGET = 90
-const SYS_CAPSET = 91
-const SYS_PERSONALITY = 92
-const SYS_EXIT = 93
-const SYS_EXIT_GROUP = 94
-const SYS_WAITID = 95
-const SYS_SET_TID_ADDRESS = 96
-const SYS_UNSHARE = 97
-const SYS_FUTEX = 98
-const SYS_SET_ROBUST_LIST = 99
-const SYS_GET_ROBUST_LIST = 100
-const SYS_NANOSLEEP = 101
-const SYS_GETITIMER = 102
-const SYS_SETITIMER = 103
-const SYS_KEXEC_LOAD = 104
-const SYS_INIT_MODULE = 105
-const SYS_DELETE_MODULE = 106
-const SYS_TIMER_CREATE = 107
-const SYS_TIMER_GETTIME = 108
-const SYS_TIMER_GETOVERRUN = 109
-const SYS_TIMER_SETTIME = 110
-const SYS_TIMER_DELETE = 111
-const SYS_CLOCK_SETTIME = 112
-const SYS_CLOCK_GETTIME = 113
-const SYS_CLOCK_GETRES = 114
-const SYS_CLOCK_NANOSLEEP = 115
-const SYS_SYSLOG = 116
-const SYS_PTRACE = 117
-const SYS_SCHED_SETPARAM = 118
-const SYS_SCHED_SETSCHEDULER = 119
-const SYS_SCHED_GETSCHEDULER = 120
-const SYS_SCHED_GETPARAM = 121
-const SYS_SCHED_SETAFFINITY = 122
-const SYS_SCHED_GETAFFINITY = 123
-const SYS_SCHED_YIELD = 124
-const SYS_SCHED_GET_PRIORITY_MAX = 125
-const SYS_SCHED_GET_PRIORITY_MIN = 126
-const SYS_SCHED_RR_GET_INTERVAL = 127
-const SYS_RESTART_SYSCALL = 128
-const SYS_KILL = 129
-const SYS_TKILL = 130
-const SYS_TGKILL = 131
-const SYS_SIGALTSTACK = 132
-const SYS_RT_SIGSUSPEND = 133
-const SYS_RT_SIGACTION = 134
-const SYS_RT_SIGPROCMASK = 135
-const SYS_RT_SIGPENDING = 136
-const SYS_RT_SIGTIMEDWAIT = 137
-const SYS_RT_SIGQUEUEINFO = 138
-const SYS_RT_SIGRETURN = 139
-const SYS_SETPRIORITY = 140
-const SYS_GETPRIORITY = 141
-const SYS_REBOOT = 142
-const SYS_SETREGID = 143
-const SYS_SETGID = 144
-const SYS_SETREUID = 145
-const SYS_SETUID = 146
-const SYS_SETRESUID = 147
-const SYS_GETRESUID = 148
-const SYS_SETRESGID = 149
-const SYS_GETRESGID = 150
-const SYS_SETFSUID = 151
-const SYS_SETFSGID = 152
-const SYS_TIMES = 153
-const SYS_SETPGID = 154
-const SYS_GETPGID = 155
-const SYS_GETSID = 156
-const SYS_SETSID = 157
-const SYS_GETGROUPS = 158
-const SYS_SETGROUPS = 159
-const SYS_UNAME = 160
-const SYS_SETHOSTNAME = 161
-const SYS_SETDOMAINNAME = 162
-const SYS_GETRLIMIT = 163
-const SYS_SETRLIMIT = 164
-const SYS_GETRUSAGE = 165
-const SYS_UMASK = 166
-const SYS_PRCTL = 167
-const SYS_GETCPU = 168
-const SYS_GETTIMEOFDAY = 169
-const SYS_SETTIMEOFDAY = 170
-const SYS_ADJTIMEX = 171
-const SYS_GETPID = 172
-const SYS_GETPPID = 173
-const SYS_GETUID = 174
-const SYS_GETEUID = 175
-const SYS_GETGID = 176
-const SYS_GETEGID = 177
-const SYS_GETTID = 178
-const SYS_SYSINFO = 179
-const SYS_MQ_OPEN = 180
-const SYS_MQ_UNLINK = 181
-const SYS_MQ_TIMEDSEND = 182
-const SYS_MQ_TIMEDRECEIVE = 183
-const SYS_MQ_NOTIFY = 184
-const SYS_MQ_GETSETATTR = 185
-const SYS_MSGGET = 186
-const SYS_MSGCTL = 187
-const SYS_MSGRCV = 188
-const SYS_MSGSND = 189
-const SYS_SEMGET = 190
-const SYS_SEMCTL = 191
-const SYS_SEMTIMEDOP = 192
-const SYS_SEMOP = 193
-const SYS_SHMGET = 194
-const SYS_SHMCTL = 195
-const SYS_SHMAT = 196
-const SYS_SHMDT = 197
-const SYS_SOCKET = 198
-const SYS_SOCKETPAIR = 199
-const SYS_BIND = 200
-const SYS_LISTEN = 201
-const SYS_ACCEPT = 202
-const SYS_CONNECT = 203
-const SYS_GETSOCKNAME = 204
-const SYS_GETPEERNAME = 205
-const SYS_SENDTO = 206
-const SYS_RECVFROM = 207
-const SYS_SETSOCKOPT = 208
-const SYS_GETSOCKOPT = 209
-const SYS_SHUTDOWN = 210
-const SYS_SENDMSG = 211
-const SYS_RECVMSG = 212
-const SYS_READAHEAD = 213
-const SYS_BRK = 214
-const SYS_MUNMAP = 215
-const SYS_MREMAP = 216
-const SYS_ADD_KEY = 217
-const SYS_REQUEST_KEY = 218
-const SYS_KEYCTL = 219
-const SYS_CLONE = 220
-const SYS_EXECVE = 221
-const SYS_MMAP = 222
-const SYS_FADVISE64 = 223
-const SYS_SWAPON = 224
-const SYS_SWAPOFF = 225
-const SYS_MPROTECT = 226
-const SYS_MSYNC = 227
-const SYS_MLOCK = 228
-const SYS_MUNLOCK = 229
-const SYS_MLOCKALL = 230
-const SYS_MUNLOCKALL = 231
-const SYS_MINCORE = 232
-const SYS_MADVISE = 233
-const SYS_REMAP_FILE_PAGES = 234
-const SYS_MBIND = 235
-const SYS_GET_MEMPOLICY = 236
-const SYS_SET_MEMPOLICY = 237
-const SYS_MIGRATE_PAGES = 238
-const SYS_MOVE_PAGES = 239
-const SYS_RT_TGSIGQUEUEINFO = 240
-const SYS_PERF_EVENT_OPEN = 241
-const SYS_ACCEPT4 = 242
-const SYS_RECVMMSG = 243
-const SYS_WAIT4 = 260
-const SYS_PRLIMIT64 = 261
-const SYS_FANOTIFY_INIT = 262
-const SYS_FANOTIFY_MARK = 263
-const SYS_NAME_TO_HANDLE_AT = 264
-const SYS_OPEN_BY_HANDLE_AT = 265
-const SYS_CLOCK_ADJTIME = 266
-const SYS_SYNCFS = 267
-const SYS_SETNS = 268
-const SYS_SENDMMSG = 269
-const SYS_PROCESS_VM_READV = 270
-const SYS_PROCESS_VM_WRITEV = 271
-const SYS_KCMP = 272
-const SYS_FINIT_MODULE = 273
-const SYS_SCHED_SETATTR = 274
-const SYS_SCHED_GETATTR = 275
-const SYS_RENAMEAT2 = 276
-const SYS_SECCOMP = 277
-const SYS_GETRANDOM = 278
-const SYS_MEMFD_CREATE = 279
-const SYS_BPF = 280
-const SYS_EXECVEAT = 281
-const SYS_USERFAULTFD = 282
-const SYS_MEMBARRIER = 283
-const SYS_MLOCK2 = 284
-const SYS_COPY_FILE_RANGE = 285
-const SYS_PREADV2 = 286
-const SYS_PWRITEV2 = 287
-const SYS_PKEY_MPROTECT = 288
-const SYS_PKEY_ALLOC = 289
-const SYS_PKEY_FREE = 290
-const SYS_STATX = 291
-const SYS_IO_PGETEVENTS = 292
-const SYS_RSEQ = 293
-const SYS_KEXEC_FILE_LOAD = 294
-const SYS_PIDFD_SEND_SIGNAL = 424
-const SYS_IO_URING_SETUP = 425
-const SYS_IO_URING_ENTER = 426
-const SYS_IO_URING_REGISTER = 427
-const SYS_OPEN_TREE = 428
-const SYS_MOVE_MOUNT = 429
-const SYS_FSOPEN = 430
-const SYS_FSCONFIG = 431
-const SYS_FSMOUNT = 432
-const SYS_FSPICK = 433
-const SYS_PIDFD_OPEN = 434
-const SYS_CLONE3 = 435
-const SYS_CLOSE_RANGE = 436
-const SYS_OPENAT2 = 437
-const SYS_PIDFD_GETFD = 438
-const SYS_FACCESSAT2 = 439
-const SYS_PROCESS_MADVISE = 440
-const SYS_EPOLL_PWAIT2 = 441
-const SYS_MOUNT_SETATTR = 442
-const SYS_QUOTACTL_FD = 443
-const SYS_LANDLOCK_CREATE_RULESET = 444
-const SYS_LANDLOCK_ADD_RULE = 445
-const SYS_LANDLOCK_RESTRICT_SELF = 446
-const SYS_MEMFD_SECRET = 447
-const SYS_PROCESS_MRELEASE = 448
-const SYS_FUTEX_WAITV = 449
-const SYS_SET_MEMPOLICY_HOME_NODE = 450
-const SYS_CACHESTAT = 451
-const SYS_FCHMODAT2 = 452
-const SYS_MAP_SHADOW_STACK = 453
-const SYS_FUTEX_WAKE = 454
-const SYS_FUTEX_WAIT = 455
-const SYS_FUTEX_REQUEUE = 456
-const SYS_STATMOUNT = 457
-const SYS_LISTMOUNT = 458
-const SYS_LSM_GET_SELF_ATTR = 459
-const SYS_LSM_SET_SELF_ATTR = 460
-const SYS_LSM_LIST_MODULES = 461
-const SYS_MSEAL = 462
+pub const SYS_IO_SETUP = 0
+pub const SYS_IO_DESTROY = 1
+pub const SYS_IO_SUBMIT = 2
+pub const SYS_IO_CANCEL = 3
+pub const SYS_IO_GETEVENTS = 4
+pub const SYS_SETXATTR = 5
+pub const SYS_LSETXATTR = 6
+pub const SYS_FSETXATTR = 7
+pub const SYS_GETXATTR = 8
+pub const SYS_LGETXATTR = 9
+pub const SYS_FGETXATTR = 10
+pub const SYS_LISTXATTR = 11
+pub const SYS_LLISTXATTR = 12
+pub const SYS_FLISTXATTR = 13
+pub const SYS_REMOVEXATTR = 14
+pub const SYS_LREMOVEXATTR = 15
+pub const SYS_FREMOVEXATTR = 16
+pub const SYS_GETCWD = 17
+pub const SYS_LOOKUP_DCOOKIE = 18
+pub const SYS_EVENTFD2 = 19
+pub const SYS_EPOLL_CREATE1 = 20
+pub const SYS_EPOLL_CTL = 21
+pub const SYS_EPOLL_PWAIT = 22
+pub const SYS_DUP = 23
+pub const SYS_DUP3 = 24
+pub const SYS_FCNTL = 25
+pub const SYS_INOTIFY_INIT1 = 26
+pub const SYS_INOTIFY_ADD_WATCH = 27
+pub const SYS_INOTIFY_RM_WATCH = 28
+pub const SYS_IOCTL = 29
+pub const SYS_IOPRIO_SET = 30
+pub const SYS_IOPRIO_GET = 31
+pub const SYS_FLOCK = 32
+pub const SYS_MKNODAT = 33
+pub const SYS_MKDIRAT = 34
+pub const SYS_UNLINKAT = 35
+pub const SYS_SYMLINKAT = 36
+pub const SYS_LINKAT = 37
+pub const SYS_RENAMEAT = 38
+pub const SYS_UMOUNT2 = 39
+pub const SYS_MOUNT = 40
+pub const SYS_PIVOT_ROOT = 41
+pub const SYS_NFSSERVCTL = 42
+pub const SYS_STATFS = 43
+pub const SYS_FSTATFS = 44
+pub const SYS_TRUNCATE = 45
+pub const SYS_FTRUNCATE = 46
+pub const SYS_FALLOCATE = 47
+pub const SYS_FACCESSAT = 48
+pub const SYS_CHDIR = 49
+pub const SYS_FCHDIR = 50
+pub const SYS_CHROOT = 51
+pub const SYS_FCHMOD = 52
+pub const SYS_FCHMODAT = 53
+pub const SYS_FCHOWNAT = 54
+pub const SYS_FCHOWN = 55
+pub const SYS_OPENAT = 56
+pub const SYS_CLOSE = 57
+pub const SYS_VHANGUP = 58
+pub const SYS_PIPE2 = 59
+pub const SYS_QUOTACTL = 60
+pub const SYS_GETDENTS64 = 61
+pub const SYS_LSEEK = 62
+pub const SYS_READ = 63
+pub const SYS_WRITE = 64
+pub const SYS_READV = 65
+pub const SYS_WRITEV = 66
+pub const SYS_PREAD64 = 67
+pub const SYS_PWRITE64 = 68
+pub const SYS_PREADV = 69
+pub const SYS_PWRITEV = 70
+pub const SYS_SENDFILE = 71
+pub const SYS_PSELECT6 = 72
+pub const SYS_PPOLL = 73
+pub const SYS_SIGNALFD4 = 74
+pub const SYS_VMSPLICE = 75
+pub const SYS_SPLICE = 76
+pub const SYS_TEE = 77
+pub const SYS_READLINKAT = 78
+pub const SYS_NEWFSTATAT = 79
+pub const SYS_FSTAT = 80
+pub const SYS_SYNC = 81
+pub const SYS_FSYNC = 82
+pub const SYS_FDATASYNC = 83
+pub const SYS_SYNC_FILE_RANGE = 84
+pub const SYS_TIMERFD_CREATE = 85
+pub const SYS_TIMERFD_SETTIME = 86
+pub const SYS_TIMERFD_GETTIME = 87
+pub const SYS_UTIMENSAT = 88
+pub const SYS_ACCT = 89
+pub const SYS_CAPGET = 90
+pub const SYS_CAPSET = 91
+pub const SYS_PERSONALITY = 92
+pub const SYS_EXIT = 93
+pub const SYS_EXIT_GROUP = 94
+pub const SYS_WAITID = 95
+pub const SYS_SET_TID_ADDRESS = 96
+pub const SYS_UNSHARE = 97
+pub const SYS_FUTEX = 98
+pub const SYS_SET_ROBUST_LIST = 99
+pub const SYS_GET_ROBUST_LIST = 100
+pub const SYS_NANOSLEEP = 101
+pub const SYS_GETITIMER = 102
+pub const SYS_SETITIMER = 103
+pub const SYS_KEXEC_LOAD = 104
+pub const SYS_INIT_MODULE = 105
+pub const SYS_DELETE_MODULE = 106
+pub const SYS_TIMER_CREATE = 107
+pub const SYS_TIMER_GETTIME = 108
+pub const SYS_TIMER_GETOVERRUN = 109
+pub const SYS_TIMER_SETTIME = 110
+pub const SYS_TIMER_DELETE = 111
+pub const SYS_CLOCK_SETTIME = 112
+pub const SYS_CLOCK_GETTIME = 113
+pub const SYS_CLOCK_GETRES = 114
+pub const SYS_CLOCK_NANOSLEEP = 115
+pub const SYS_SYSLOG = 116
+pub const SYS_PTRACE = 117
+pub const SYS_SCHED_SETPARAM = 118
+pub const SYS_SCHED_SETSCHEDULER = 119
+pub const SYS_SCHED_GETSCHEDULER = 120
+pub const SYS_SCHED_GETPARAM = 121
+pub const SYS_SCHED_SETAFFINITY = 122
+pub const SYS_SCHED_GETAFFINITY = 123
+pub const SYS_SCHED_YIELD = 124
+pub const SYS_SCHED_GET_PRIORITY_MAX = 125
+pub const SYS_SCHED_GET_PRIORITY_MIN = 126
+pub const SYS_SCHED_RR_GET_INTERVAL = 127
+pub const SYS_RESTART_SYSCALL = 128
+pub const SYS_KILL = 129
+pub const SYS_TKILL = 130
+pub const SYS_TGKILL = 131
+pub const SYS_SIGALTSTACK = 132
+pub const SYS_RT_SIGSUSPEND = 133
+pub const SYS_RT_SIGACTION = 134
+pub const SYS_RT_SIGPROCMASK = 135
+pub const SYS_RT_SIGPENDING = 136
+pub const SYS_RT_SIGTIMEDWAIT = 137
+pub const SYS_RT_SIGQUEUEINFO = 138
+pub const SYS_RT_SIGRETURN = 139
+pub const SYS_SETPRIORITY = 140
+pub const SYS_GETPRIORITY = 141
+pub const SYS_REBOOT = 142
+pub const SYS_SETREGID = 143
+pub const SYS_SETGID = 144
+pub const SYS_SETREUID = 145
+pub const SYS_SETUID = 146
+pub const SYS_SETRESUID = 147
+pub const SYS_GETRESUID = 148
+pub const SYS_SETRESGID = 149
+pub const SYS_GETRESGID = 150
+pub const SYS_SETFSUID = 151
+pub const SYS_SETFSGID = 152
+pub const SYS_TIMES = 153
+pub const SYS_SETPGID = 154
+pub const SYS_GETPGID = 155
+pub const SYS_GETSID = 156
+pub const SYS_SETSID = 157
+pub const SYS_GETGROUPS = 158
+pub const SYS_SETGROUPS = 159
+pub const SYS_UNAME = 160
+pub const SYS_SETHOSTNAME = 161
+pub const SYS_SETDOMAINNAME = 162
+pub const SYS_GETRLIMIT = 163
+pub const SYS_SETRLIMIT = 164
+pub const SYS_GETRUSAGE = 165
+pub const SYS_UMASK = 166
+pub const SYS_PRCTL = 167
+pub const SYS_GETCPU = 168
+pub const SYS_GETTIMEOFDAY = 169
+pub const SYS_SETTIMEOFDAY = 170
+pub const SYS_ADJTIMEX = 171
+pub const SYS_GETPID = 172
+pub const SYS_GETPPID = 173
+pub const SYS_GETUID = 174
+pub const SYS_GETEUID = 175
+pub const SYS_GETGID = 176
+pub const SYS_GETEGID = 177
+pub const SYS_GETTID = 178
+pub const SYS_SYSINFO = 179
+pub const SYS_MQ_OPEN = 180
+pub const SYS_MQ_UNLINK = 181
+pub const SYS_MQ_TIMEDSEND = 182
+pub const SYS_MQ_TIMEDRECEIVE = 183
+pub const SYS_MQ_NOTIFY = 184
+pub const SYS_MQ_GETSETATTR = 185
+pub const SYS_MSGGET = 186
+pub const SYS_MSGCTL = 187
+pub const SYS_MSGRCV = 188
+pub const SYS_MSGSND = 189
+pub const SYS_SEMGET = 190
+pub const SYS_SEMCTL = 191
+pub const SYS_SEMTIMEDOP = 192
+pub const SYS_SEMOP = 193
+pub const SYS_SHMGET = 194
+pub const SYS_SHMCTL = 195
+pub const SYS_SHMAT = 196
+pub const SYS_SHMDT = 197
+pub const SYS_SOCKET = 198
+pub const SYS_SOCKETPAIR = 199
+pub const SYS_BIND = 200
+pub const SYS_LISTEN = 201
+pub const SYS_ACCEPT = 202
+pub const SYS_CONNECT = 203
+pub const SYS_GETSOCKNAME = 204
+pub const SYS_GETPEERNAME = 205
+pub const SYS_SENDTO = 206
+pub const SYS_RECVFROM = 207
+pub const SYS_SETSOCKOPT = 208
+pub const SYS_GETSOCKOPT = 209
+pub const SYS_SHUTDOWN = 210
+pub const SYS_SENDMSG = 211
+pub const SYS_RECVMSG = 212
+pub const SYS_READAHEAD = 213
+pub const SYS_BRK = 214
+pub const SYS_MUNMAP = 215
+pub const SYS_MREMAP = 216
+pub const SYS_ADD_KEY = 217
+pub const SYS_REQUEST_KEY = 218
+pub const SYS_KEYCTL = 219
+pub const SYS_CLONE = 220
+pub const SYS_EXECVE = 221
+pub const SYS_MMAP = 222
+pub const SYS_FADVISE64 = 223
+pub const SYS_SWAPON = 224
+pub const SYS_SWAPOFF = 225
+pub const SYS_MPROTECT = 226
+pub const SYS_MSYNC = 227
+pub const SYS_MLOCK = 228
+pub const SYS_MUNLOCK = 229
+pub const SYS_MLOCKALL = 230
+pub const SYS_MUNLOCKALL = 231
+pub const SYS_MINCORE = 232
+pub const SYS_MADVISE = 233
+pub const SYS_REMAP_FILE_PAGES = 234
+pub const SYS_MBIND = 235
+pub const SYS_GET_MEMPOLICY = 236
+pub const SYS_SET_MEMPOLICY = 237
+pub const SYS_MIGRATE_PAGES = 238
+pub const SYS_MOVE_PAGES = 239
+pub const SYS_RT_TGSIGQUEUEINFO = 240
+pub const SYS_PERF_EVENT_OPEN = 241
+pub const SYS_ACCEPT4 = 242
+pub const SYS_RECVMMSG = 243
+pub const SYS_WAIT4 = 260
+pub const SYS_PRLIMIT64 = 261
+pub const SYS_FANOTIFY_INIT = 262
+pub const SYS_FANOTIFY_MARK = 263
+pub const SYS_NAME_TO_HANDLE_AT = 264
+pub const SYS_OPEN_BY_HANDLE_AT = 265
+pub const SYS_CLOCK_ADJTIME = 266
+pub const SYS_SYNCFS = 267
+pub const SYS_SETNS = 268
+pub const SYS_SENDMMSG = 269
+pub const SYS_PROCESS_VM_READV = 270
+pub const SYS_PROCESS_VM_WRITEV = 271
+pub const SYS_KCMP = 272
+pub const SYS_FINIT_MODULE = 273
+pub const SYS_SCHED_SETATTR = 274
+pub const SYS_SCHED_GETATTR = 275
+pub const SYS_RENAMEAT2 = 276
+pub const SYS_SECCOMP = 277
+pub const SYS_GETRANDOM = 278
+pub const SYS_MEMFD_CREATE = 279
+pub const SYS_BPF = 280
+pub const SYS_EXECVEAT = 281
+pub const SYS_USERFAULTFD = 282
+pub const SYS_MEMBARRIER = 283
+pub const SYS_MLOCK2 = 284
+pub const SYS_COPY_FILE_RANGE = 285
+pub const SYS_PREADV2 = 286
+pub const SYS_PWRITEV2 = 287
+pub const SYS_PKEY_MPROTECT = 288
+pub const SYS_PKEY_ALLOC = 289
+pub const SYS_PKEY_FREE = 290
+pub const SYS_STATX = 291
+pub const SYS_IO_PGETEVENTS = 292
+pub const SYS_RSEQ = 293
+pub const SYS_KEXEC_FILE_LOAD = 294
+pub const SYS_PIDFD_SEND_SIGNAL = 424
+pub const SYS_IO_URING_SETUP = 425
+pub const SYS_IO_URING_ENTER = 426
+pub const SYS_IO_URING_REGISTER = 427
+pub const SYS_OPEN_TREE = 428
+pub const SYS_MOVE_MOUNT = 429
+pub const SYS_FSOPEN = 430
+pub const SYS_FSCONFIG = 431
+pub const SYS_FSMOUNT = 432
+pub const SYS_FSPICK = 433
+pub const SYS_PIDFD_OPEN = 434
+pub const SYS_CLONE3 = 435
+pub const SYS_CLOSE_RANGE = 436
+pub const SYS_OPENAT2 = 437
+pub const SYS_PIDFD_GETFD = 438
+pub const SYS_FACCESSAT2 = 439
+pub const SYS_PROCESS_MADVISE = 440
+pub const SYS_EPOLL_PWAIT2 = 441
+pub const SYS_MOUNT_SETATTR = 442
+pub const SYS_QUOTACTL_FD = 443
+pub const SYS_LANDLOCK_CREATE_RULESET = 444
+pub const SYS_LANDLOCK_ADD_RULE = 445
+pub const SYS_LANDLOCK_RESTRICT_SELF = 446
+pub const SYS_MEMFD_SECRET = 447
+pub const SYS_PROCESS_MRELEASE = 448
+pub const SYS_FUTEX_WAITV = 449
+pub const SYS_SET_MEMPOLICY_HOME_NODE = 450
+pub const SYS_CACHESTAT = 451
+pub const SYS_FCHMODAT2 = 452
+pub const SYS_MAP_SHADOW_STACK = 453
+pub const SYS_FUTEX_WAKE = 454
+pub const SYS_FUTEX_WAIT = 455
+pub const SYS_FUTEX_REQUEUE = 456
+pub const SYS_STATMOUNT = 457
+pub const SYS_LISTMOUNT = 458
+pub const SYS_LSM_GET_SELF_ATTR = 459
+pub const SYS_LSM_SET_SELF_ATTR = 460
+pub const SYS_LSM_LIST_MODULES = 461
+pub const SYS_MSEAL = 462
 
 // sigkill 相关信号
 int SIGABRT = 0x6
@@ -425,10 +425,10 @@ int SIGCONT = 0x12
 int SIGFPE = 0x8
 int SIGHUP = 0x1
 int SIGILL = 0x4
-int SIGINT = 0x2
+pub int SIGINT = 0x2
 int SIGIO = 0x1d
 int SIGIOT = 0x6
-int SIGKILL = 0x9
+pub int SIGKILL = 0x9
 int SIGPIPE = 0xd
 int SIGPOLL = 0x1d
 int SIGPROF = 0x1b
@@ -438,15 +438,15 @@ int SIGSEGV = 0xb
 int SIGSTKFLT = 0x10
 int SIGSTOP = 0x13
 int SIGSYS = 0x1f
-int SIGTERM = 0xf
+pub int SIGTERM = 0xf
 int SIGTRAP = 0x5
 int SIGTSTP = 0x14
 int SIGTTIN = 0x15
 int SIGTTOU = 0x16
 int SIGUNUSED = 0x1f
 int SIGURG = 0x17
-int SIGUSR1 = 0xa
-int SIGUSR2 = 0xc
+pub int SIGUSR1 = 0xa
+pub int SIGUSR2 = 0xc
 int SIGVTALRM = 0x1a
 int SIGWINCH = 0x1c
 int SIGXCPU = 0x18
@@ -467,8 +467,8 @@ int AF_DECnet = 0xc
 int AF_ECONET = 0x13
 int AF_FILE = 0x1
 int AF_IEEE802154 = 0x24
-int AF_INET = 0x2
-int AF_INET6 = 0xa
+pub int AF_INET = 0x2
+pub int AF_INET6 = 0xa
 int AF_IPX = 0x4
 int AF_IRDA = 0x17
 int AF_ISDN = 0x22
@@ -561,7 +561,7 @@ int SOCK_PACKET = 0xa
 int SOCK_RAW = 0x3
 int SOCK_RDM = 0x4
 int SOCK_SEQPACKET = 0x5
-int SOCK_STREAM = 0x1
+pub int SOCK_STREAM = 0x1
 
 // AT_* 常量定义
 int AT_FDCWD = -100
@@ -577,7 +577,7 @@ int AT_STATX_DONT_SYNC = 0x4000
 int AT_RECURSIVE = 0x8000
 int AT_EACCESS = 0x200
 
-#linkid syscall_call6
+pub #linkid syscall_call6
 fn call6(int number, anyptr a1, anyptr a2, anyptr a3, anyptr a4, anyptr a5, anyptr a6):int!
 
 #linkid syscall_getcwd
@@ -589,41 +589,41 @@ fn getenv(anyptr key):anyptr
 #linkid setenv
 fn setenv(anyptr key, anyptr value, i32 overwrite):i32
 
-fn open(string filename, int flags, u32 perm):int! {
+pub fn open(string filename, int flags, u32 perm):int! {
     return call6(SYS_OPENAT, AT_FDCWD as anyptr, filename.ref(), flags as anyptr, perm as anyptr, 0, 0)
 }
 
-fn read(int fd, anyptr buf, int len):int! {
+pub fn read(int fd, anyptr buf, int len):int! {
     return call6(SYS_READ, fd as anyptr, buf, len as anyptr, 0, 0, 0)
 }
 
-fn readlink(string file, [u8] buf):int! {
+pub fn readlink(string file, [u8] buf):int! {
     return call6(SYS_READLINKAT, AT_FDCWD as anyptr, file.ref(), buf.ref(), buf.len() as anyptr, 0, 0)
 }
 
-fn write(int fd, anyptr buf, int len):int! {
+pub fn write(int fd, anyptr buf, int len):int! {
     return call6(SYS_WRITE, fd as anyptr, buf, len as anyptr, 0, 0, 0)
 }
 
-fn close(int fd):void! {
+pub fn close(int fd):void! {
     call6(SYS_CLOSE, fd as anyptr, 0, 0, 0, 0, 0)
 }
 
-fn unlink(string path):void! {
+pub fn unlink(string path):void! {
     call6(SYS_UNLINKAT, AT_FDCWD as anyptr, path.ref(), 0, 0, 0, 0)
 }
 
-fn seek(int fd, int offset, int whence):int! {
+pub fn seek(int fd, int offset, int whence):int! {
     return call6(SYS_LSEEK, fd as anyptr, offset as anyptr, whence as anyptr, 0, 0, 0)
 }
 
-fn fork():int! {
+pub fn fork():int! {
     return call6(SYS_CLONE, 17 as anyptr /* SIGCHLD */, 0, 0, 0, 0, 0)
 }
 
 // path is full path
 // argv[0] = /proc/:pid/comm
-#linkid syscall_exec
+pub #linkid syscall_exec
 fn exec(string path, [string] argv, [string] envp):void!
 
 type timespec_t = struct {
@@ -631,7 +631,7 @@ type timespec_t = struct {
     i64 nsec
 }
 
-type stat_t = struct {
+pub type stat_t = struct {
     u64 dev         // __dev_t st_dev
     u64 ino         // __ino64_t st_ino
     u32 mode        // __mode_t st_mode
@@ -665,7 +665,7 @@ fn stat_is_blk(u32 mode):bool {
 fn stat_is_chr(u32 mode):bool {
     return (mode & S_IFMT) == S_IFCHR
 }
-fn stat_is_dir(u32 mode):bool {
+pub fn stat_is_dir(u32 mode):bool {
     return (mode & S_IFMT) == S_IFDIR
 }
 
@@ -673,7 +673,7 @@ fn stat_is_fifo(u32 mode):bool {
     return (mode & S_IFMT) == S_IFIFO
 }
 
-fn stat_is_reg(u32 mode):bool {
+pub fn stat_is_reg(u32 mode):bool {
     return (mode & S_IFMT) == S_IFREG
 }
 fn stat_is_lnk(u32 mode):bool {
@@ -682,13 +682,13 @@ fn stat_is_lnk(u32 mode):bool {
 fn stat_is_sock(u32 mode):bool {
     return (mode & S_IFMT) == S_IFSOCK
 }
-fn stat(string filename):stat_t! {
+pub fn stat(string filename):stat_t! {
     var st = stat_t{}
     call6(SYS_NEWFSTATAT, AT_FDCWD as anyptr, filename.ref(), st as anyptr, 0, 0, 0)
     return st
 }
 
-fn fstat(int fd):stat_t! {
+pub fn fstat(int fd):stat_t! {
     var st = stat_t{}
 
     call6(SYS_FSTAT, fd as anyptr, st as anyptr, 0, 0, 0, 0)
@@ -696,15 +696,15 @@ fn fstat(int fd):stat_t! {
     return st
 }
 
-fn mkdir(string path, u32 mode):void! {
+pub fn mkdir(string path, u32 mode):void! {
     call6(SYS_MKDIRAT, AT_FDCWD as anyptr, path.ref(), mode as anyptr, 0, 0, 0)
 }
 
-fn rmdir(string path):void! {
+pub fn rmdir(string path):void! {
     call6(SYS_UNLINKAT, AT_FDCWD as anyptr, path.ref(), AT_REMOVEDIR as anyptr, 0, 0, 0)
 }
 
-fn rename(string oldpath, string newpath):void! {
+pub fn rename(string oldpath, string newpath):void! {
     call6(SYS_RENAMEAT2, AT_FDCWD as anyptr, oldpath.ref(), AT_FDCWD as anyptr, newpath.ref(), 0, 0)
 }
 
@@ -712,15 +712,15 @@ fn exit(int status):void! {
     call6(SYS_EXIT_GROUP, status as anyptr, 0, 0, 0, 0, 0)
 }
 
-fn getpid():int! {
+pub fn getpid():int! {
     return call6(SYS_GETPID, 0, 0, 0, 0, 0, 0)
 }
 
-fn getppid():int! {
+pub fn getppid():int! {
     return call6(SYS_GETPPID, 0, 0, 0, 0, 0, 0)
 }
 
-fn getcwd():string! {
+pub fn getcwd():string! {
     var buf = vec<u8>.new(0, 1024) // 1024 是 path max
     var len = call6(SYS_GETCWD, buf.ref(), buf.len() as anyptr, 0, 0, 0, 0)
 
@@ -729,11 +729,11 @@ fn getcwd():string! {
     return buf as string
 }
 
-fn kill(int pid, int sig):void! {
+pub fn kill(int pid, int sig):void! {
     call6(SYS_KILL, pid as anyptr, sig as anyptr, 0, 0, 0, 0)
 }
 
-fn wait(int pid, int option):(int, int)! {
+pub fn wait(int pid, int option):(int, int)! {
     var status = 0
     int result = libc.waitpid(pid, &status, option)
     if result == -1 {
@@ -755,11 +755,11 @@ fn chown(string path, u32 uid, u32 gid):void! {
     call6(SYS_FCHOWNAT, AT_FDCWD as anyptr, path.ref(), uid as anyptr, gid as anyptr, 0, 0)
 }
 
-fn chmod(string path, u32 mode):void! {
+pub fn chmod(string path, u32 mode):void! {
     call6(SYS_FCHMODAT, AT_FDCWD as anyptr, path.ref(), mode as anyptr, 0, 0, 0)
 }
 
-fn gettime():timespec_t! {
+pub fn gettime():timespec_t! {
     int clock_id = CLOCK_REALTIME
     var result = timespec_t{}
 
@@ -769,7 +769,7 @@ fn gettime():timespec_t! {
 }
 
 // net --------------
-type sockaddr_in = struct {
+pub type sockaddr_in = struct {
     u16 sin_family
     u16 sin_port
     u32 sin_addr
@@ -791,12 +791,12 @@ type sockaddr_un = struct {
     [u8;108] sun_path
 }
 
-fn socket(int domain, int t, int protocol):int! {
+pub fn socket(int domain, int t, int protocol):int! {
     return call6(SYS_SOCKET, domain as anyptr, t as anyptr, protocol as anyptr, 0, 0, 0)
 }
 
 // TODO limit <T:sockaddr_in|sockaddr_un>
-fn bind<T>(int sockfd, T addr):void! {
+pub fn bind<T>(int sockfd, T addr):void! {
     //  nature struct to c
      var len = 16 as anyptr // in 和 unix 长度为 16byte
      call6(SYS_BIND, sockfd as anyptr, addr as anyptr, len, 0, 0, 0)
@@ -808,12 +808,12 @@ fn bind6(int sockfd, sockaddr_in6 addr):void! {
 }
 
 // backlog 表示最大的监听长度
-fn listen(int sockfd, int backlog):void! {
+pub fn listen(int sockfd, int backlog):void! {
     call6(SYS_LISTEN, sockfd as anyptr, backlog as anyptr, 0, 0, 0, 0)
 }
 
 // 相应 client sockfd 和 client sockaddr
-fn accept<T>(int sockfd, ref<T> addr):int! {
+pub fn accept<T>(int sockfd, ref<T> addr):int! {
     var len = 16
     ptr<int> len_ptr = &len
     int fd = call6(SYS_ACCEPT, sockfd as anyptr, addr as anyptr, len_ptr as anyptr, 0, 0, 0)
@@ -821,19 +821,19 @@ fn accept<T>(int sockfd, ref<T> addr):int! {
     return fd
 }
 
-fn recvfrom(int sockfd, [u8] buf, int flags):int! {
+pub fn recvfrom(int sockfd, [u8] buf, int flags):int! {
     return call6(SYS_RECVFROM, sockfd as anyptr, buf.ref(), buf.len() as anyptr, flags as anyptr, 0, 0)
 }
 
-fn sendto(int sockfd, [u8] buf, int flags):int! {
+pub fn sendto(int sockfd, [u8] buf, int flags):int! {
     return call6(SYS_SENDTO, sockfd as anyptr, buf.ref(), buf.len() as anyptr, flags as anyptr, 0, 0)
 }
 
-fn get_envs():[string] {
+pub fn get_envs():[string] {
     return libc.get_envs()
 }
 
-fn get_env(string key):string {
+pub fn get_env(string key):string {
     anyptr ref = getenv(key.ref())
     if ref == 0 {
         return ''
@@ -842,7 +842,7 @@ fn get_env(string key):string {
     return runtime.string_new(ref)
 }
 
-fn set_env(string key, string value):void! {
+pub fn set_env(string key, string value):void! {
     var result = setenv(key.ref(), value.ref(), 1)
     if result != 0 {
         throw errorf('setenv error')

--- a/std/syscall/syscall.windows_amd64.n
+++ b/std/syscall/syscall.windows_amd64.n
@@ -4,27 +4,27 @@ import libc
 import runtime
 // UCRT open flags. Files opened through this package default to binary mode so
 // that the descriptor behaves like the descriptors returned on Unix targets.
-int O_RDONLY = 0x0000
-int O_WRONLY = 0x0001
-int O_RDWR = 0x0002
-int O_APPEND = 0x0008
-int O_CREAT = 0x0100
-int O_TRUNC = 0x0200
-int O_EXCL = 0x0400
+pub int O_RDONLY = 0x0000
+pub int O_WRONLY = 0x0001
+pub int O_RDWR = 0x0002
+pub int O_APPEND = 0x0008
+pub int O_CREAT = 0x0100
+pub int O_TRUNC = 0x0200
+pub int O_EXCL = 0x0400
 int O_TEXT = 0x4000
 int O_BINARY = 0x8000
-int SEEK_SET = 0
-int SEEK_CUR = 1
-int SEEK_END = 2
+pub int SEEK_SET = 0
+pub int SEEK_CUR = 1
+pub int SEEK_END = 2
 // UCRT reserves descriptors 0, 1, and 2 for the standard streams.
-int STDIN = 0
-int STDOUT = 1
-int STDERR = 2
+pub int STDIN = 0
+pub int STDOUT = 1
+pub int STDERR = 2
 
-fn null_device():string {
+pub fn null_device():string {
     return 'NUL'
 }
-int CLOCK_REALTIME = 0
+pub int CLOCK_REALTIME = 0
 u32 S_IFMT = 0xf000
 u32 S_IFBLK = 0x6000
 u32 S_IFCHR = 0x2000
@@ -43,7 +43,7 @@ type timespec_t = struct {
     i64 nsec
 }
 // Keep the common Nature stat surface independent from the UCRT wire layout.
-type stat_t = struct {
+pub type stat_t = struct {
     u64 dev
     u64 ino
     u64 nlink
@@ -128,7 +128,7 @@ fn windows_exit(i32 status): void
 fn windows_getpid(): i32
 #local #linkid getppid
 fn windows_getppid(): i32
-fn open(string filename, int flags, u32 perm): int! {
+pub fn open(string filename, int flags, u32 perm): int! {
     int native_flags = flags
     if (native_flags & (O_TEXT | O_BINARY)) == 0 {
         native_flags |= O_BINARY
@@ -139,7 +139,7 @@ fn open(string filename, int flags, u32 perm): int! {
     }
     return fd
 }
-fn read(int fd, anyptr buf, int len): int! {
+pub fn read(int fd, anyptr buf, int len): int! {
     if len < 0 || len > 0xffffffff {
         throw errorf('read length is outside the UCRT range')
     }
@@ -149,7 +149,7 @@ fn read(int fd, anyptr buf, int len): int! {
     }
     return result
 }
-fn write(int fd, anyptr buf, int len): int! {
+pub fn write(int fd, anyptr buf, int len): int! {
     if len < 0 || len > 0xffffffff {
         throw errorf('write length is outside the UCRT range')
     }
@@ -159,12 +159,12 @@ fn write(int fd, anyptr buf, int len): int! {
     }
     return result
 }
-fn close(int fd): void! {
+pub fn close(int fd): void! {
     if windows_close(fd as i32) == -1 {
         throw errorf(libc.error_string())
     }
 }
-fn seek(int fd, int offset, int whence): int! {
+pub fn seek(int fd, int offset, int whence): int! {
     i64 result = windows_seek(fd as i32, offset as i64, whence as i32)
     if result == -1 {
         throw errorf(libc.error_string())
@@ -173,7 +173,7 @@ fn seek(int fd, int offset, int whence): int! {
 }
 // Windows has no POSIX readlink. Preserve the existing std/os executable-path
 // request and otherwise return the normalized target reached through a handle.
-fn readlink(string file, [u8] buf): int! {
+pub fn readlink(string file, [u8] buf): int! {
     if buf.len() == 0 || buf.len() > 0xffffffff {
         throw errorf('readlink buffer has an invalid size')
     }
@@ -183,7 +183,7 @@ fn readlink(string file, [u8] buf): int! {
     }
     return len as int
 }
-fn unlink(string path): void! {
+pub fn unlink(string path): void! {
     if windows_unlink(path.ref()) == -1 {
         throw errorf(libc.error_string())
     }
@@ -194,13 +194,13 @@ fn stat_is_blk(u32 mode): bool {
 fn stat_is_chr(u32 mode): bool {
     return (mode & S_IFMT) == S_IFCHR
 }
-fn stat_is_dir(u32 mode): bool {
+pub fn stat_is_dir(u32 mode): bool {
     return (mode & S_IFMT) == S_IFDIR
 }
 fn stat_is_fifo(u32 mode): bool {
     return (mode & S_IFMT) == S_IFIFO
 }
-fn stat_is_reg(u32 mode): bool {
+pub fn stat_is_reg(u32 mode): bool {
     return (mode & S_IFMT) == S_IFREG
 }
 fn stat_is_lnk(u32 mode): bool {
@@ -209,7 +209,7 @@ fn stat_is_lnk(u32 mode): bool {
 fn stat_is_sock(u32 mode): bool {
     return (mode & S_IFMT) == S_IFSOCK
 }
-fn stat(string filename): stat_t! {
+pub fn stat(string filename): stat_t! {
     var raw = windows_stat64_t {}
     if windows_stat(filename.ref(), &raw) == -1 {
         throw errorf(libc.error_string())
@@ -228,7 +228,7 @@ fn stat(string filename): stat_t! {
         dev: raw.dev as u64, ino: raw.ino as u64, nlink: raw.nlink as u64, mode: raw.mode as u32, uid: raw.uid as u32, gid: raw.gid as u32, rdev: raw.rdev as u64, size: raw.size, blksize: 0, blocks: blocks, atim: atim, mtim: mtim, ctim: ctim,
     }
 }
-fn fstat(int fd): stat_t! {
+pub fn fstat(int fd): stat_t! {
     var raw = windows_stat64_t {}
     if windows_fstat(fd as i32, &raw) == -1 {
         throw errorf(libc.error_string())
@@ -247,22 +247,22 @@ fn fstat(int fd): stat_t! {
         dev: raw.dev as u64, ino: raw.ino as u64, nlink: raw.nlink as u64, mode: raw.mode as u32, uid: raw.uid as u32, gid: raw.gid as u32, rdev: raw.rdev as u64, size: raw.size, blksize: 0, blocks: blocks, atim: atim, mtim: mtim, ctim: ctim,
     }
 }
-fn mkdir(string path, u32 mode): void! {
+pub fn mkdir(string path, u32 mode): void! {
     if windows_mkdir(path.ref()) == -1 {
         throw errorf(libc.error_string())
     }
 }
-fn rmdir(string path): void! {
+pub fn rmdir(string path): void! {
     if windows_rmdir(path.ref()) == -1 {
         throw errorf(libc.error_string())
     }
 }
-fn rename(string oldpath, string newpath): void! {
+pub fn rename(string oldpath, string newpath): void! {
     if windows_rename(oldpath.ref(), newpath.ref()) == -1 {
         throw errorf(libc.error_string())
     }
 }
-fn chmod(string path, u32 mode): void! {
+pub fn chmod(string path, u32 mode): void! {
     if windows_chmod(path.ref(), mode as i32) == -1 {
         throw errorf(libc.error_string())
     }
@@ -270,17 +270,17 @@ fn chmod(string path, u32 mode): void! {
 fn exit(int status): void! {
     windows_exit(status as i32)
 }
-fn getpid(): int! {
+pub fn getpid(): int! {
     return windows_getpid() as int
 }
-fn getppid(): int! {
+pub fn getppid(): int! {
     i32 pid = windows_getppid()
     if pid <= 0 {
         throw errorf(libc.error_string())
     }
     return pid as int
 }
-fn getcwd(): string! {
+pub fn getcwd(): string! {
     var buf = vec<u8>.new(0, 32768)
     i64 len = windows_getcwd(buf.ref(), buf.len() as u64)
     if len < 0 {
@@ -293,7 +293,7 @@ fn chdir(string path): void! {
         throw errorf(libc.error_string())
     }
 }
-fn gettime(): timespec_t! {
+pub fn gettime(): timespec_t! {
     var filetime = windows_filetime_t {}
     windows_system_time(&filetime)
     u64 ticks = (filetime.high as u64) << 32 | filetime.low as u64
@@ -305,7 +305,7 @@ fn gettime(): timespec_t! {
         sec: (ticks / WINDOWS_TICKS_PER_SECOND) as i64, nsec: ((ticks % WINDOWS_TICKS_PER_SECOND) * 100) as i64,
     }
 }
-fn get_envs(): [string]{
+pub fn get_envs(): [string]{
     [string] result = []
     var entry_buf = vec<u8>.new(0, 131072)
     anyptr iterator = windows_env_first(entry_buf.ref(), entry_buf.len() as u64)
@@ -323,7 +323,7 @@ fn get_envs(): [string]{
     windows_env_close(iterator)
     return result
 }
-fn get_env(string key): string {
+pub fn get_env(string key): string {
     var value_buf = vec<u8>.new(0, 131072)
     i64 len = windows_get_env(key.ref(), value_buf.ref(), value_buf.len() as u64)
     if len <= 0 {
@@ -331,7 +331,7 @@ fn get_env(string key): string {
     }
     return value_buf.slice(0, len as int) as string
 }
-fn set_env(string key, string value): void! {
+pub fn set_env(string key, string value): void! {
     if windows_set_env(key.ref(), value.ref()) == 0 {
         throw errorf('SetEnvironmentVariableW failed with Windows error %d', windows_last_error())
     }

--- a/std/testing/testing.n
+++ b/std/testing/testing.n
@@ -1,6 +1,6 @@
 mod testing
 
-fn assert(bool cond):void! {
+pub fn assert(bool cond):void! {
     if !cond {
         throw errorf("assertion failed")
     }

--- a/std/time/time.n
+++ b/std/time/time.n
@@ -4,17 +4,17 @@ import syscall
 import strings
 import libc
 
-type time_t = struct {
+pub type time_t = struct {
     i64 sec
     i64 nsec
     ptr<libc.tm> tm
 }
 
-fn time_t.timestamp(self):i64 {
+pub fn time_t.timestamp(self):i64 {
     return self.sec
 }
 
-fn time_t.ms_timestamp(self):i64 {
+pub fn time_t.ms_timestamp(self):i64 {
     return self.sec * 1000 + self.nsec / 1000000
 }
 
@@ -22,7 +22,7 @@ fn time_t.ns_timestamp(self):i64 {
     return self.sec * 1000000000 + self.nsec
 }
 
-fn time_t.datetime(self):string {
+pub fn time_t.datetime(self):string {
     var buf = vec<u8>.new(0, 100)// 必须预留足够大的空间,才能正常引用
 
    var len = libc.strftime(buf.ref() as libc.cstr, buf.len() as u64, '%Y-%m-%d %H:%M:%S'.to_cstr(), self.tm)
@@ -32,7 +32,7 @@ fn time_t.datetime(self):string {
 }
 
 // 将 time_t 使用当前时间进行初始化
-fn now():time_t {
+pub fn now():time_t {
     var sys_time = syscall.gettime() catch err {
         return time_t{}
     }
@@ -46,6 +46,6 @@ fn now():time_t {
     return t
 }
 
-fn unix():i64 {
+pub fn unix():i64 {
     return now().timestamp()
 }

--- a/std/unsafe/unsafe.n
+++ b/std/unsafe/unsafe.n
@@ -13,8 +13,8 @@ pub fn vec_new<T>(ptr<T> p, int len):vec<T>! {
     return unsafe_vec_new<T>(hash, ele_hash, len, p as anyptr)
 }
 
-pub #local #linkid unsafe_vec_new
-fn unsafe_vec_new<T>(int hash, int ele_hash, int len, anyptr p):vec<T>!
+#local #linkid unsafe_vec_new
+pub fn unsafe_vec_new<T>(int hash, int ele_hash, int len, anyptr p):vec<T>!
 
 pub fn ptr_to<T>(anyptr p):T {
     return *(p as ptr<T>)

--- a/std/unsafe/unsafe.n
+++ b/std/unsafe/unsafe.n
@@ -2,7 +2,7 @@ mod unsafe
 
 import libc
 
-fn vec_new<T>(ptr<T> p, int len):vec<T>! {
+pub fn vec_new<T>(ptr<T> p, int len):vec<T>! {
     if len < 0 {
         throw errorf("invalid vec index '%d' (must be non-negative)", len)
     }
@@ -13,14 +13,14 @@ fn vec_new<T>(ptr<T> p, int len):vec<T>! {
     return unsafe_vec_new<T>(hash, ele_hash, len, p as anyptr)
 }
 
-#local #linkid unsafe_vec_new
+pub #local #linkid unsafe_vec_new
 fn unsafe_vec_new<T>(int hash, int ele_hash, int len, anyptr p):vec<T>!
 
-fn ptr_to<T>(anyptr p):T {
+pub fn ptr_to<T>(anyptr p):T {
     return *(p as ptr<T>)
 }
 
-fn ptr_copy<T>(anyptr dst, ptr<T> src) {
+pub fn ptr_copy<T>(anyptr dst, ptr<T> src) {
     var dst2 = dst as ptr<T>
 
     var size = @sizeof(T)

--- a/tests/features/20260807_00_pub_acl.c
+++ b/tests/features/20260807_00_pub_acl.c
@@ -80,8 +80,7 @@ int main(void) {
 
     // 函数体内 pub 报错
     assert_entry_error("err_local_pub.n", "acl_err_local_pub",
-                       "20260807_00_pub_acl/err_local_pub.n:2:7: pub can only be applied to module-level "
-                       "declarations\n");
+                       "20260807_00_pub_acl/err_local_pub.n:2:7: cannot parser ident 'pub'\n");
 
     return 0;
 }

--- a/tests/features/20260807_00_pub_acl.c
+++ b/tests/features/20260807_00_pub_acl.c
@@ -1,0 +1,92 @@
+#include "tests/test.h"
+#include "utils/assertf.h"
+#include "utils/exec.h"
+#include <stdio.h>
+
+/**
+ * pub 访问控制测试:
+ * - pub fn/const/var/type + impl 方法跨 module 访问成功
+ * - 私有符号在 module.member / star import / selective import / 类型引用 / 方法调用 各路径报错
+ * - 函数体内 pub 报错
+ */
+static void set_build_output(char *output_name) {
+    strcpy(BUILD_OUTPUT_DIR, getenv("BUILD_OUTPUT_DIR"));
+#ifdef __WINDOWS
+    snprintf(BUILD_OUTPUT_NAME, sizeof(BUILD_OUTPUT_NAME), "%s.exe", output_name);
+#else
+    strcpy(BUILD_OUTPUT_NAME, output_name);
+#endif
+}
+
+static void build_entry(char *entry, char *output_name) {
+    set_build_output(output_name);
+
+    COMPILER_TRY {
+        build(entry, false);
+    }
+    else {
+        assertf(false, "build entry '%s' failed: %s", entry, (char *) test_error_msg);
+    }
+}
+
+static void assert_entry_output(char *entry, char *output_name, char *expect) {
+    build_entry(entry, output_name);
+
+    char *output = exec_output();
+    assertf(str_equal(output, expect), "entry '%s' output mismatch\nexpect: %s\nactual: %s", entry, expect,
+            output);
+}
+
+static void assert_entry_error(char *entry, char *output_name, char *expect) {
+    set_build_output(output_name);
+
+    COMPILER_TRY {
+        build(entry, false);
+        assertf(false, "entry '%s' should not build successfully", entry);
+    }
+    else {
+        assertf(str_equal(test_error_msg, expect), "entry '%s' error mismatch\nexpect: %s\nactual: %s", entry,
+                expect, (char *) test_error_msg);
+    }
+}
+
+int main(void) {
+    char *nature_root = getenv("NATURE_ROOT");
+    assert_true(nature_root != NULL);
+
+    // pub 导出的 fn/const/var/type/impl 方法跨 module 访问成功
+    assert_entry_output("main.n", "acl_ok", "3\n100\n7\n2\n");
+
+    // 私有符号跨 module 访问报错(module.member)
+    assert_entry_error("err_member.n", "acl_err_member",
+                       "20260807_00_pub_acl/err_member.n:4:17: cannot access private symbol 'private_fn', "
+                       "declare it with 'pub' to export it from its module\n");
+
+    // star import 本身合法, 使用其中的私有符号时报错
+    assert_entry_error("err_star.n", "acl_err_star",
+                       "20260807_00_pub_acl/err_star.n:4:13: cannot access private symbol 'private_fn', "
+                       "declare it with 'pub' to export it from its module\n");
+
+    // selective import 在符号实际解析时检查可见性
+    assert_entry_error("err_select.n", "acl_err_select",
+                       "20260807_00_pub_acl/err_select.n:4:13: cannot access private symbol 'private_fn', "
+                       "declare it with 'pub' to export it from its module\n");
+
+    // 私有类型引用报错
+    assert_entry_error("err_type.n", "acl_err_type",
+                       "20260807_00_pub_acl/err_type.n:4:16: cannot access private symbol 'private_t', "
+                       "declare it with 'pub' to export it from its module\n");
+
+    // 私有方法调用报错
+    assert_entry_error("err_method.n", "acl_err_method",
+                       "20260807_00_pub_acl/err_method.n:5:13: cannot access private method 'priv_mul' of type "
+                       "'20260807_00_pub_acl.mod.pub_pair_t', declare it with 'pub' to export it from its "
+                       "module\n");
+
+    // 函数体内 pub 报错
+    assert_entry_error("err_local_pub.n", "acl_err_local_pub",
+                       "20260807_00_pub_acl/err_local_pub.n:2:7: pub can only be applied to module-level "
+                       "declarations\n");
+
+    return 0;
+}

--- a/tests/features/20260807_00_pub_acl.c
+++ b/tests/features/20260807_00_pub_acl.c
@@ -59,29 +59,24 @@ int main(void) {
 
     // 私有符号跨 module 访问报错(module.member)
     assert_entry_error("err_member.n", "acl_err_member",
-                       "20260807_00_pub_acl/err_member.n:4:17: cannot access private symbol 'private_fn', "
-                       "declare it with 'pub' to export it from its module\n");
+                       "20260807_00_pub_acl/err_member.n:4:17: undefined: math.private_fn\n");
 
     // star import 本身合法, 使用其中的私有符号时报错
     assert_entry_error("err_star.n", "acl_err_star",
-                       "20260807_00_pub_acl/err_star.n:4:13: cannot access private symbol 'private_fn', "
-                       "declare it with 'pub' to export it from its module\n");
+                       "20260807_00_pub_acl/err_star.n:4:22: undefined: private_fn\n");
 
     // selective import 在符号实际解析时检查可见性
     assert_entry_error("err_select.n", "acl_err_select",
-                       "20260807_00_pub_acl/err_select.n:4:13: cannot access private symbol 'private_fn', "
-                       "declare it with 'pub' to export it from its module\n");
+                       "20260807_00_pub_acl/err_select.n:4:22: undefined: private_fn\n");
 
     // 私有类型引用报错
     assert_entry_error("err_type.n", "acl_err_type",
-                       "20260807_00_pub_acl/err_type.n:4:16: cannot access private symbol 'private_t', "
-                       "declare it with 'pub' to export it from its module\n");
+                       "20260807_00_pub_acl/err_type.n:4:16: undefined: math.private_t\n");
 
     // 私有方法调用报错
     assert_entry_error("err_method.n", "acl_err_method",
-                       "20260807_00_pub_acl/err_method.n:5:13: cannot access private method 'priv_mul' of type "
-                       "'20260807_00_pub_acl.mod.pub_pair_t', declare it with 'pub' to export it from its "
-                       "module\n");
+                       "20260807_00_pub_acl/err_method.n:5:13: p.priv_mul undefined (cannot refer to unexported "
+                       "method priv_mul)\n");
 
     // 函数体内 pub 报错
     assert_entry_error("err_local_pub.n", "acl_err_local_pub",

--- a/tests/features/20260807_01_label_pub.c
+++ b/tests/features/20260807_01_label_pub.c
@@ -1,0 +1,6 @@
+#include "tests/test.h"
+
+int main(void) {
+    feature_testar_test(NULL);
+    return 0;
+}

--- a/tests/features/cases/20221025_03_call.n
+++ b/tests/features/cases/20221025_03_call.n
@@ -1,4 +1,4 @@
-fn sum(int a, int b):int {
+pub fn sum(int a, int b):int {
     return a + b
 }
 

--- a/tests/features/cases/20221113_01_rest.n
+++ b/tests/features/cases/20221113_01_rest.n
@@ -1,4 +1,4 @@
-fn sum(int a, int b, ...[int] rest):int  {
+pub fn sum(int a, int b, ...[int] rest):int  {
     return a + b + rest[1] + rest[2]
 }
 

--- a/tests/features/cases/20230423_00_advance_struct/mod.n
+++ b/tests/features/cases/20230423_00_advance_struct/mod.n
@@ -1,8 +1,8 @@
-type square = struct {
+pub type square = struct {
     int length
     int width
 }
 
-fn square.area(self):int {
+pub fn square.area(self):int {
     return self.length * self.width
 }

--- a/tests/features/cases/20230430_03_sort.n
+++ b/tests/features/cases/20230430_03_sort.n
@@ -9,7 +9,7 @@ fn sort([int] list) {
     }
 }
 
-[int] list = []
+pub [int] list = []
 
 fn main() {
     list = [2, 8, 4, 2, 3]

--- a/tests/features/cases/20230430_04_module/src/config.n
+++ b/tests/features/cases/20230430_04_module/src/config.n
@@ -1,17 +1,17 @@
 import 'math.n'
 
-int max = 10000
-int count = 0
+pub int max = 10000
+pub int count = 0
 
-fn get_max(): int {
+pub fn get_max(): int {
     return max
 }
 
-fn set_count(int n) {
+pub fn set_count(int n) {
     count = n
 }
 
-fn test_math() {
+pub fn test_math() {
     var result = math.max(max, count)
     print('[test_math] max result=', result, '\n')
 }

--- a/tests/features/cases/20230430_04_module/src/math.n
+++ b/tests/features/cases/20230430_04_module/src/math.n
@@ -1,4 +1,4 @@
-fn max(int a, int b):int {
+pub fn max(int a, int b):int {
     if (a > b) {
         return a
     }

--- a/tests/features/cases/20230501_00_gc/helper.n
+++ b/tests/features/cases/20230501_00_gc/helper.n
@@ -1,10 +1,10 @@
-[u8] list = []
+pub [u8] list = []
 
-string haha = ''
+pub string haha = ''
 
 u8 test = 24
 
-fn init() {
+pub fn init() {
     list = [5, 4, 3, 2, 1]
     haha = 'hello world'
 }

--- a/tests/features/cases/20230505_01_for_rest.n
+++ b/tests/features/cases/20230505_01_for_rest.n
@@ -1,4 +1,4 @@
-fn sum(...[int] list):int {
+pub fn sum(...[int] list):int {
 	var result = 0 // 这里应该是进行了重新定值，所以不应该影响原来的 sum
 	for v in list { // 迭代语法
 		result += v

--- a/tests/features/cases/20230506_02_user/user.n
+++ b/tests/features/cases/20230506_02_user/user.n
@@ -7,11 +7,11 @@ type user = struct {
 
 // 全局变量(暂时不支持类型自动推导)
 int id = 1
-[user] list = []
+pub [user] list = []
 {string:user} userof = {}
 
 // 全局函数
-fn register(string username, string password):void! {
+pub fn register(string username, string password):void! {
 	var u = userof[username] catch err {}
     if u.id > 0 {
         throw errorf('The user ' + username +' has already registered')
@@ -28,7 +28,7 @@ fn register(string username, string password):void! {
 	id += 1
 }
 
-fn find(string username):user! {
+pub fn find(string username):user! {
     var u = userof[username] catch err {}
 	if u.id == 0 {
 		throw errorf('user ' + username + ' notfound')

--- a/tests/features/cases/20230614_00_union.n
+++ b/tests/features/cases/20230614_00_union.n
@@ -1,4 +1,4 @@
-type nullable<T> = T|null
+pub type nullable<T> = T|null
 type nullable2<T, E> = T|E|null
 
 fn main() {

--- a/tests/features/cases/20230615_01_type_param/mod.n
+++ b/tests/features/cases/20230615_01_type_param/mod.n
@@ -1,12 +1,12 @@
-type box<T, U> = struct {
+pub type box<T, U> = struct {
 	T width
 	U length
 }
 
 // nullable
-type nullable<T> = T|null
+pub type nullable<T> = T|null
 
-fn box<T, U>.area(&self):T {
+pub fn box<T, U>.area(&self):T {
     return self.width * self.length as T
 }
 

--- a/tests/features/cases/20230720_00_package/mock/left/shared.n
+++ b/tests/features/cases/20230720_00_package/mock/left/shared.n
@@ -1,5 +1,5 @@
 mod shared
 
-fn value():string {
+pub fn value():string {
     return 'left'
 }

--- a/tests/features/cases/20230720_00_package/mock/local/local.darwin.n
+++ b/tests/features/cases/20230720_00_package/mock/local/local.darwin.n
@@ -2,13 +2,13 @@ mod local
 
 import rand.other as rand_other
 
-int count = 333
+pub int count = 333
 
-fn get_count():int {
+pub fn get_count():int {
     return count
 }
 
-fn dump() {
+pub fn dump() {
     rand_other.dump()
     println("hello local in cross darwin")
 }

--- a/tests/features/cases/20230720_00_package/mock/local/local.linux.n
+++ b/tests/features/cases/20230720_00_package/mock/local/local.linux.n
@@ -2,13 +2,13 @@ mod local
 
 import rand.other as rand_other
 
-int count = 444
+pub int count = 444
 
-fn get_count():int {
+pub fn get_count():int {
     return count
 }
 
-fn dump() {
+pub fn dump() {
     rand_other.dump()
     println("hello local in cross linux")
 }

--- a/tests/features/cases/20230720_00_package/mock/local/local.linux_amd64.n
+++ b/tests/features/cases/20230720_00_package/mock/local/local.linux_amd64.n
@@ -2,13 +2,13 @@ mod local
 
 import rand.other as rand_other
 
-int count = 444
+pub int count = 444
 
-fn get_count():int {
+pub fn get_count():int {
     return count
 }
 
-fn dump() {
+pub fn dump() {
     rand_other.dump()
     println("hello local in cross linux amd64")
 }

--- a/tests/features/cases/20230720_00_package/mock/local/local.n
+++ b/tests/features/cases/20230720_00_package/mock/local/local.n
@@ -2,13 +2,13 @@ mod local
 
 import rand.other as rand_other
 
-int count = 555
+pub int count = 555
 
-fn get_count():int {
+pub fn get_count():int {
     return count
 }
 
-fn dump() {
+pub fn dump() {
     rand_other.dump()
     println("hello local")
 }

--- a/tests/features/cases/20230720_00_package/mock/os/os.n
+++ b/tests/features/cases/20230720_00_package/mock/os/os.n
@@ -5,13 +5,13 @@ import rand.other as rand_other
 import rand.utils.pool
 import rand.utils.seed
 
-int count = 233
+pub int count = 233
 
-fn get_count():int {
+pub fn get_count():int {
     return count
 }
 
-fn dump() {
+pub fn dump() {
     rand_other.dump()
     pool.dump()
     seed.dump()

--- a/tests/features/cases/20230720_00_package/mock/rand/other.n
+++ b/tests/features/cases/20230720_00_package/mock/rand/other.n
@@ -1,3 +1,3 @@
-fn dump() {
+pub fn dump() {
     println('this is other')
 }

--- a/tests/features/cases/20230720_00_package/mock/rand/rand.n
+++ b/tests/features/cases/20230720_00_package/mock/rand/rand.n
@@ -4,7 +4,7 @@ import 'other.n'
 import rand.utils.seed
 import rand.utils.pool
 
-fn dump():int {
+pub fn dump():int {
     other.dump()
     pool.dump()
     seed.dump()

--- a/tests/features/cases/20230720_00_package/mock/rand/utils/pool.n
+++ b/tests/features/cases/20230720_00_package/mock/rand/utils/pool.n
@@ -1,3 +1,3 @@
-fn dump() {
+pub fn dump() {
     println('this is pool')
 }

--- a/tests/features/cases/20230720_00_package/mock/rand/utils/seed.n
+++ b/tests/features/cases/20230720_00_package/mock/rand/utils/seed.n
@@ -1,3 +1,3 @@
-fn dump() {
+pub fn dump() {
     println('this is seed')
 }

--- a/tests/features/cases/20230720_00_package/mock/right/shared.n
+++ b/tests/features/cases/20230720_00_package/mock/right/shared.n
@@ -1,5 +1,5 @@
 mod shared
 
-fn value():string {
+pub fn value():string {
     return 'right'
 }

--- a/tests/features/cases/20230720_00_package/mock/syscall/syscall.n
+++ b/tests/features/cases/20230720_00_package/mock/syscall/syscall.n
@@ -3,7 +3,7 @@ mod syscall
 import myrand
 import myrand.utils.pool
 
-fn dump() {
+pub fn dump() {
     myrand.dump()
     pool.dump()
     println('hello world syscall')

--- a/tests/features/cases/20230720_00_package/src/user.n
+++ b/tests/features/cases/20230720_00_package/src/user.n
@@ -1,6 +1,6 @@
 import package.util
 
-fn dump() {
+pub fn dump() {
     var res = util.sum(1, 2)
     println('util.sum(1, 2) =', res)
 }

--- a/tests/features/cases/20230720_00_package/util.n
+++ b/tests/features/cases/20230720_00_package/util.n
@@ -1,3 +1,3 @@
-fn sum(int a, int b):int {
+pub fn sum(int a, int b):int {
     return a + b
 }

--- a/tests/features/cases/20230808_00_import_all/mod.n
+++ b/tests/features/cases/20230808_00_import_all/mod.n
@@ -1,11 +1,11 @@
-int foo = 1
-int bar = 2
+pub int foo = 1
+pub int bar = 2
 
-fn log() {
+pub fn log() {
     println('i am log')
 }
 
-fn assert(bool cond) {
+pub fn assert(bool cond) {
     if cond {
         println('cond is true')
     } else {

--- a/tests/features/cases/20230808_00_import_all/pool.n
+++ b/tests/features/cases/20230808_00_import_all/pool.n
@@ -1,6 +1,6 @@
-int foo = 1
-int bar = 2
+pub int foo = 1
+pub int bar = 2
 
-fn log() {
+pub fn log() {
     println('i am pool.log')
 }

--- a/tests/features/cases/20230809_00_fn_spread.n
+++ b/tests/features/cases/20230809_00_fn_spread.n
@@ -1,4 +1,4 @@
-fn sum(int a, ...[int] list):int {
+pub fn sum(int a, ...[int] list):int {
     int t = 0
     for v in list {
         t += v

--- a/tests/features/cases/20230811_00_template/zlib.n
+++ b/tests/features/cases/20230811_00_template/zlib.n
@@ -1,8 +1,8 @@
-pub #linkid gzopen
-fn gzopen(anyptr fname, anyptr mode):anyptr
+#linkid gzopen
+pub fn gzopen(anyptr fname, anyptr mode):anyptr
 
-pub #linkid gzwrite
-fn gzwrite(anyptr outfile, anyptr buf, int len):int
+#linkid gzwrite
+pub fn gzwrite(anyptr outfile, anyptr buf, int len):int
 
-pub #linkid gzclose
-fn gzclose(anyptr outfile):int
+#linkid gzclose
+pub fn gzclose(anyptr outfile):int

--- a/tests/features/cases/20230811_00_template/zlib.n
+++ b/tests/features/cases/20230811_00_template/zlib.n
@@ -1,8 +1,8 @@
-#linkid gzopen
+pub #linkid gzopen
 fn gzopen(anyptr fname, anyptr mode):anyptr
 
-#linkid gzwrite
+pub #linkid gzwrite
 fn gzwrite(anyptr outfile, anyptr buf, int len):int
 
-#linkid gzclose
+pub #linkid gzclose
 fn gzclose(anyptr outfile):int

--- a/tests/features/cases/20230824_00_struct_ptr/mod.n
+++ b/tests/features/cases/20230824_00_struct_ptr/mod.n
@@ -1,14 +1,14 @@
-type person_t = struct {
+pub type person_t = struct {
     string name
     int age
     string from
     u8 gender
 }
 
-fn person_t.set_age(&self, int now) {
+pub fn person_t.set_age(&self, int now) {
     self.age = now
 }
 
-fn person_t.get_name(&self):string {
+pub fn person_t.get_name(&self):string {
     return self.name
 }

--- a/tests/features/cases/20230825_00_array.n
+++ b/tests/features/cases/20230825_00_array.n
@@ -3,7 +3,7 @@ type sub_t = struct {
     i64 b
 }
 
-type person_t = struct {
+pub type person_t = struct {
     [i32;8] foo
     bool bar
     sub_t car

--- a/tests/features/cases/20230914_00_global_checking/mod.n
+++ b/tests/features/cases/20230914_00_global_checking/mod.n
@@ -1,19 +1,19 @@
-var a = 12
-var b = 12 as u8
+pub var a = 12
+pub var b = 12 as u8
 
-fn call() {
+pub fn call() {
     println('hello world')
 }
 
 int c = 24
-var d = 3.1415
-[int] e = []
+pub var d = 3.1415
+pub [int] e = []
 
-int e1 = 2.15 as int
+pub int e1 = 2.15 as int
 
 var f = false
-var t = true
+pub var t = true
 
-fn init() {
+pub fn init() {
     e = [1, 5, 7, 9]
 }

--- a/tests/features/cases/20231219_00_coroutine.n
+++ b/tests/features/cases/20231219_00_coroutine.n
@@ -28,7 +28,7 @@ fn car() {
     b = 'hello world nice'
 }
 
-fn foo(){
+pub fn foo(){
     int a = 1
     int b = 2
     bool c = true

--- a/tests/features/cases/20240316_00_coroutine_arg.n
+++ b/tests/features/cases/20240316_00_coroutine_arg.n
@@ -1,7 +1,7 @@
 import co
 import time
 
-fn sum(int a, int b):int {
+pub fn sum(int a, int b):int {
     co.sleep(1000)
     return a + b
 }

--- a/tests/features/cases/20240321_01_coroutine_power/mod.n
+++ b/tests/features/cases/20240321_01_coroutine_power/mod.n
@@ -1,1 +1,1 @@
-int count = 0
+pub int count = 0

--- a/tests/features/cases/20240327_01_linkid/mod.n
+++ b/tests/features/cases/20240327_01_linkid/mod.n
@@ -1,6 +1,6 @@
-fn bar()
+pub fn bar()
 
-#linkid custom_link_foo_id
+pub #linkid custom_link_foo_id
 fn foo(int a) {
     println('hello world', a)
 }
@@ -11,5 +11,5 @@ fn test2() {
     println("aa")
 }
 
-#linkid sleep
+pub #linkid sleep
 fn test3(int second)

--- a/tests/features/cases/20240327_01_linkid/mod.n
+++ b/tests/features/cases/20240327_01_linkid/mod.n
@@ -1,7 +1,7 @@
 pub fn bar()
 
-pub #linkid custom_link_foo_id
-fn foo(int a) {
+#linkid custom_link_foo_id
+pub fn foo(int a) {
     println('hello world', a)
 }
 
@@ -11,5 +11,5 @@ fn test2() {
     println("aa")
 }
 
-pub #linkid sleep
-fn test3(int second)
+#linkid sleep
+pub fn test3(int second)

--- a/tests/features/cases/20240329_00_struct_ptr/other.n
+++ b/tests/features/cases/20240329_00_struct_ptr/other.n
@@ -1,19 +1,19 @@
-type person_t = struct{
+pub type person_t = struct{
     string name
     int age
     bool sex
 }
 
 
-fn person_t.set_age(*self, int now) {
+pub fn person_t.set_age(*self, int now) {
     self.age = now
 }
 
-fn person_t.get_name(*self):string {
+pub fn person_t.get_name(*self):string {
     return self.name
 }
 
-fn person_t.test_self(self) {
+pub fn person_t.test_self(self) {
     person_t p = self
     println('in test_self', p.name, p.age, p.sex)
 }

--- a/tests/features/cases/20240409_00_generics_constraint/mod.n
+++ b/tests/features/cases/20240409_00_generics_constraint/mod.n
@@ -4,12 +4,12 @@ type foo_t<T:f32|bool|int, U:bool|string|f32|[i32]> = struct{
     float c
 }
 
-type bar_t<T,U> = struct{
+pub type bar_t<T,U> = struct{
     T a
     U b
 }
 
-fn bar_t<T, U>.dump(self):T {
+pub fn bar_t<T, U>.dump(self):T {
    println('bar_t any dump', self.a)
    return self.a
 }

--- a/tests/features/cases/20240519_00_struct_nest_call/other.n
+++ b/tests/features/cases/20240519_00_struct_nest_call/other.n
@@ -1,24 +1,24 @@
-type person_t = struct{
+pub type person_t = struct{
     string name
     int age
     bool sex
     fn() hello
 }
 
-type package_t = struct{
+pub type package_t = struct{
     bool t
     person_t p
 }
 
-fn person_t.set_age(&self, int now) {
+pub fn person_t.set_age(&self, int now) {
     self.age = now
 }
 
-fn person_t.get_name(&self):string {
+pub fn person_t.get_name(&self):string {
     return self.name
 }
 
-fn person_t.test_self(&self) {
+pub fn person_t.test_self(&self) {
     ref<person_t> p = self
     println('in test_self', p.name, p.age, p.sex)
 }

--- a/tests/features/cases/20240808_00_escape_analysis/mod.n
+++ b/tests/features/cases/20240808_00_escape_analysis/mod.n
@@ -1,11 +1,11 @@
-type bar_t = [int;5]
+pub type bar_t = [int;5]
 
-fn bar_t.len(self):int {
+pub fn bar_t.len(self):int {
     return 5
 }
 
-type car_t = i64
+pub type car_t = i64
 
-fn car_t.tostr(self) {
+pub fn car_t.tostr(self) {
     println('self is', self)
 }

--- a/tests/features/cases/20240908_00_struct_default/main.n
+++ b/tests/features/cases/20240908_00_struct_default/main.n
@@ -1,6 +1,6 @@
 import 'mod.n' as m
 
-type person_t = struct{
+pub type person_t = struct{
     string sex = 'male'
     int age = 1
     var limbs = true

--- a/tests/features/cases/20240908_00_struct_default/mod.n
+++ b/tests/features/cases/20240908_00_struct_default/mod.n
@@ -1,8 +1,8 @@
-type car_t<E> = [E]
+pub type car_t<E> = [E]
 
 int global_v = 12
 
-type bar_t<T> = struct{
+pub type bar_t<T> = struct{
     T a = global_v as T
     car_t<T> c
     int size = @sizeof(T)

--- a/tests/features/cases/20241228_00_match_assert.testar
+++ b/tests/features/cases/20241228_00_match_assert.testar
@@ -70,7 +70,7 @@ type HashTable = struct{
     [HashItem?] items
 }
 
-fn newHashTable(int size):ref<HashTable> {
+pub fn newHashTable(int size):ref<HashTable> {
     return new HashTable(
         size = size,
         count = 0,
@@ -78,7 +78,7 @@ fn newHashTable(int size):ref<HashTable> {
     )
 }
 
-fn HashTable.hash(&self, string s, int a, int m):int {
+pub fn HashTable.hash(&self, string s, int a, int m):int {
     var hash = 0
     for var i= 0; i < s.len(); i += 1 {
         hash += pow(a,s.len() - (i + 1)) * s[i] as int
@@ -87,13 +87,13 @@ fn HashTable.hash(&self, string s, int a, int m):int {
     return hash
 }
 
-fn HashTable.getHash(&self, string s, int num_bucket, int attempt): int {
+pub fn HashTable.getHash(&self, string s, int num_bucket, int attempt): int {
     var hash_a = self.hash(s, 99, num_bucket)
     var hash_b = self.hash(s, 66, num_bucket)
     return (hash_a + (attempt * (hash_b + 1))) % num_bucket
 }
 
-fn HashTable.insert(&self, string key, string value) {
+pub fn HashTable.insert(&self, string key, string value) {
     var item = newItem(key, value)
     var idx = self.getHash(key, self.size, 0)
     println("Inserting at index: ", idx)
@@ -117,7 +117,7 @@ fn HashTable.insert(&self, string key, string value) {
     self.count += 1
 }
 
-fn  HashTable.get(&self, string key): string? {
+pub fn  HashTable.get(&self, string key): string? {
     var idx = self.getHash(key, self.size, 0)
     HashItem? item = self.items[idx]
     var i = 1

--- a/tests/features/cases/20250315_00_error_interface.n
+++ b/tests/features/cases/20250315_00_error_interface.n
@@ -1,9 +1,9 @@
-fn bar():void! {
+pub fn bar():void! {
     var list = vec<i8>.new(0, 10)
     var foo = list[11]
 }
 
-fn foo():void! {
+pub fn foo():void! {
     bar()
 }
 

--- a/tests/features/cases/20250324_00_llama/main.n
+++ b/tests/features/cases/20250324_00_llama/main.n
@@ -464,7 +464,7 @@ fn transformer_new(string path):ref<transformer>! {
     return t
 }
 
-fn tokenizer_t.decode(&self, int prev_token, int token):string! {
+pub fn tokenizer_t.decode(&self, int prev_token, int token):string! {
     string piece = self.vocab[token]
     // following BOS (1) token, sentencepiece decoder strips any leading whitespace (see PR #89)
     if prev_token == 1 && piece[0] == ' '.char() {

--- a/tests/features/cases/20250404_00_tetris/raylib.n
+++ b/tests/features/cases/20250404_00_tetris/raylib.n
@@ -675,23 +675,23 @@ type automation_event_list_t = struct{
     anyptr events
 }
 
-pub #linkid WindowShouldClose
-fn window_should_close():bool
+#linkid WindowShouldClose
+pub fn window_should_close():bool
 
-pub #linkid BeginDrawing
-fn begin_drawing()
+#linkid BeginDrawing
+pub fn begin_drawing()
 
-pub #linkid ClearBackground
-fn clear_background(color_t color)
+#linkid ClearBackground
+pub fn clear_background(color_t color)
 
-pub #linkid EndDrawing
-fn end_drawing()
+#linkid EndDrawing
+pub fn end_drawing()
 
-pub #linkid InitWindow
-fn init_window(i32 width, i32 height, anyptr title)
+#linkid InitWindow
+pub fn init_window(i32 width, i32 height, anyptr title)
 
-pub #linkid CloseWindow
-fn close_window()
+#linkid CloseWindow
+pub fn close_window()
 
 
 #linkid IsWindowReady
@@ -769,11 +769,11 @@ fn set_window_focused()
 #linkid GetWindowHandle
 fn get_window_handle():anyptr
 
-pub #linkid GetScreenWidth
-fn get_screen_width():i32
+#linkid GetScreenWidth
+pub fn get_screen_width():i32
 
-pub #linkid GetScreenHeight
-fn get_screen_height():i32
+#linkid GetScreenHeight
+pub fn get_screen_height():i32
 
 #linkid GetRenderWidth
 fn get_render_width():i32
@@ -958,14 +958,14 @@ fn get_camera_matrix_2d(camera2d_t camera):matrix_t
 
 
 // Timing-related functions
-pub #linkid SetTargetFPS
-fn set_target_fps(i32 fps)
+#linkid SetTargetFPS
+pub fn set_target_fps(i32 fps)
 
-pub #linkid GetFrameTime
-fn get_frame_time():f32
+#linkid GetFrameTime
+pub fn get_frame_time():f32
 
-pub #linkid GetTime
-fn get_time():f64
+#linkid GetTime
+pub fn get_time():f64
 
 #linkid GetFPS
 fn get_fps():i32
@@ -984,8 +984,8 @@ fn wait_time(f64 seconds)
 #linkid SetRandomSeed
 fn set_random_seed(u32 seed)
 
-pub #linkid GetRandomValue
-fn get_random_value(i32 min, i32 max):i32
+#linkid GetRandomValue
+pub fn get_random_value(i32 min, i32 max):i32
 
 #linkid LoadRandomSequence
 fn load_random_sequence(u32 count, i32 min, i32 max):ptr<i32>
@@ -1174,14 +1174,14 @@ fn stop_automation_event_recording()
 fn play_automation_event(automation_event_t event)
 
 // Input-related functions: keyboard
-pub #linkid IsKeyPressed
-fn is_key_pressed(i32 key):bool
+#linkid IsKeyPressed
+pub fn is_key_pressed(i32 key):bool
 
 #linkid IsKeyPressedRepeat
 fn is_key_pressed_repeat(i32 key):bool
 
-pub #linkid IsKeyDown
-fn is_key_down(i32 key):bool
+#linkid IsKeyDown
+pub fn is_key_down(i32 key):bool
 
 #linkid IsKeyReleased
 fn is_key_released(i32 key):bool
@@ -1334,20 +1334,20 @@ fn get_shapes_texture():texture2d_t
 fn get_shapes_texture_rectangle():rectangle_t
 
 // Basic shapes drawing functions
-pub #linkid DrawPixel
-fn draw_pixel(i32 pos_x, i32 pos_y, color_t color)
+#linkid DrawPixel
+pub fn draw_pixel(i32 pos_x, i32 pos_y, color_t color)
 
 #linkid DrawPixelV
 fn draw_pixel_v(vector2_t position, color_t color)
 
-pub #linkid DrawLine
-fn draw_line(i32 start_pos_x, i32 start_pos_y, i32 end_pos_x, i32 end_pos_y, color_t color)
+#linkid DrawLine
+pub fn draw_line(i32 start_pos_x, i32 start_pos_y, i32 end_pos_x, i32 end_pos_y, color_t color)
 
 #linkid DrawLineV
 fn draw_line_v(vector2_t start_pos, vector2_t end_pos, color_t color)
 
-pub #linkid DrawLineEx
-fn draw_line_ex(vector2_t start_pos, vector2_t end_pos, f32 thick, color_t color)
+#linkid DrawLineEx
+pub fn draw_line_ex(vector2_t start_pos, vector2_t end_pos, f32 thick, color_t color)
 
 #linkid DrawLineStrip
 fn draw_line_strip(ptr<vector2_t> points, i32 point_count, color_t color)
@@ -1367,8 +1367,8 @@ fn draw_circle_sector_lines(vector2_t center, f32 radius, f32 start_angle, f32 e
 #linkid DrawCircleGradient
 fn draw_circle_gradient(i32 center_x, i32 center_y, f32 radius, color_t inner, color_t outer)
 
-pub #linkid DrawCircleV
-fn draw_circle_v(vector2_t center, f32 radius, color_t color)
+#linkid DrawCircleV
+pub fn draw_circle_v(vector2_t center, f32 radius, color_t color)
 
 #linkid DrawCircleLines
 fn draw_circle_lines(i32 center_x, i32 center_y, f32 radius, color_t color)
@@ -1388,8 +1388,8 @@ fn draw_ring(vector2_t center, f32 inner_radius, f32 outer_radius, f32 start_ang
 #linkid DrawRingLines
 fn draw_ring_lines(vector2_t center, f32 inner_radius, f32 outer_radius, f32 start_angle, f32 end_angle, i32 segments, color_t color)
 
-pub #linkid DrawRectangle
-fn draw_rectangle(i32 pos_x, i32 pos_y, i32 width, i32 height, color_t color)
+#linkid DrawRectangle
+pub fn draw_rectangle(i32 pos_x, i32 pos_y, i32 width, i32 height, color_t color)
 
 #linkid DrawRectangleV
 fn draw_rectangle_v(vector2_t position, vector2_t size, color_t color)
@@ -1409,8 +1409,8 @@ fn draw_rectangle_gradient_h(i32 pos_x, i32 pos_y, i32 width, i32 height, color_
 #linkid DrawRectangleGradientEx
 fn draw_rectangle_gradient_ex(rectangle_t rec, color_t top_left, color_t bottom_left, color_t top_right, color_t bottom_right)
 
-pub #linkid DrawRectangleLines
-fn draw_rectangle_lines(i32 pos_x, i32 pos_y, i32 width, i32 height, color_t color)
+#linkid DrawRectangleLines
+pub fn draw_rectangle_lines(i32 pos_x, i32 pos_y, i32 width, i32 height, color_t color)
 
 #linkid DrawRectangleLinesEx
 fn draw_rectangle_lines_ex(rectangle_t rec, f32 line_thick, color_t color)
@@ -1493,8 +1493,8 @@ fn get_spline_point_bezier_quad(vector2_t p1, vector2_t c2, vector2_t p3, f32 t)
 fn get_spline_point_bezier_cubic(vector2_t p1, vector2_t c2, vector2_t c3, vector2_t p4, f32 t):vector2_t
 
 // Basic shapes collision detection functions
-pub #linkid CheckCollisionRecs
-fn check_collision_recs(rectangle_t rec1, rectangle_t rec2):bool
+#linkid CheckCollisionRecs
+pub fn check_collision_recs(rectangle_t rec1, rectangle_t rec2):bool
 
 #linkid CheckCollisionCircles
 fn check_collision_circles(vector2_t center1, f32 radius1, vector2_t center2, f32 radius2):bool
@@ -1832,8 +1832,8 @@ fn draw_texture_n_patch(texture2d_t texture, npatch_info_t n_patch_info, rectang
 #linkid ColorIsEqual
 fn color_is_equal(color_t col1, color_t col2):bool
 
-pub #linkid Fade
-fn fade(color_t color, f32 alpha):color_t
+#linkid Fade
+pub fn fade(color_t color, f32 alpha):color_t
 
 #linkid ColorToInt
 fn color_to_int(color_t color):i32
@@ -1919,8 +1919,8 @@ fn export_font_as_code(font_t font, anyptr file_name):bool
 #linkid DrawFPS
 fn draw_fps(i32 pos_x, i32 pos_y)
 
-pub #linkid DrawText
-fn draw_text(anyptr text, i32 pos_x, i32 pos_y, i32 font_size, color_t color)
+#linkid DrawText
+pub fn draw_text(anyptr text, i32 pos_x, i32 pos_y, i32 font_size, color_t color)
 
 #linkid DrawTextEx
 fn draw_text_ex(font_t font, anyptr text, vector2_t position, f32 font_size, f32 spacing, color_t tint)
@@ -1938,8 +1938,8 @@ fn draw_text_codepoints(font_t font, ptr<i32> codepoints, i32 codepoint_count, v
 #linkid SetTextLineSpacing
 fn set_text_line_spacing(i32 spacing)
 
-pub #linkid MeasureText
-fn measure_text(anyptr text, i32 font_size):i32
+#linkid MeasureText
+pub fn measure_text(anyptr text, i32 font_size):i32
 
 #linkid MeasureTextEx
 fn measure_text_ex(font_t font, anyptr text, f32 font_size, f32 spacing):vector2_t

--- a/tests/features/cases/20250404_00_tetris/raylib.n
+++ b/tests/features/cases/20250404_00_tetris/raylib.n
@@ -47,10 +47,10 @@ i32 KEY_EIGHT = 56
 i32 KEY_NINE = 57
 i32 KEY_SEMICOLON = 59
 i32 KEY_EQUAL = 61
-i32 KEY_A = 65
+pub i32 KEY_A = 65
 i32 KEY_B = 66
 i32 KEY_C = 67
-i32 KEY_D = 68
+pub i32 KEY_D = 68
 i32 KEY_E = 69
 i32 KEY_F = 70
 i32 KEY_G = 71
@@ -62,14 +62,14 @@ i32 KEY_L = 76
 i32 KEY_M = 77
 i32 KEY_N = 78
 i32 KEY_O = 79
-i32 KEY_P = 80
+pub i32 KEY_P = 80
 i32 KEY_Q = 81
-i32 KEY_R = 82
-i32 KEY_S = 83
+pub i32 KEY_R = 82
+pub i32 KEY_S = 83
 i32 KEY_T = 84
 i32 KEY_U = 85
 i32 KEY_V = 86
-i32 KEY_W = 87
+pub i32 KEY_W = 87
 i32 KEY_X = 88
 i32 KEY_Y = 89
 i32 KEY_Z = 90
@@ -79,17 +79,17 @@ i32 KEY_RIGHT_BRACKET = 93
 i32 KEY_GRAVE = 96
 
 // Function keys
-i32 KEY_SPACE = 32
+pub i32 KEY_SPACE = 32
 i32 KEY_ESCAPE = 256
-i32 KEY_ENTER = 257
+pub i32 KEY_ENTER = 257
 i32 KEY_TAB = 258
 i32 KEY_BACKSPACE = 259
 i32 KEY_INSERT = 260
 i32 KEY_DELETE = 261
-i32 KEY_RIGHT = 262
-i32 KEY_LEFT = 263
-i32 KEY_DOWN = 264
-i32 KEY_UP = 265
+pub i32 KEY_RIGHT = 262
+pub i32 KEY_LEFT = 263
+pub i32 KEY_DOWN = 264
+pub i32 KEY_UP = 265
 i32 KEY_PAGE_UP = 266
 i32 KEY_PAGE_DOWN = 267
 i32 KEY_HOME = 268
@@ -314,7 +314,7 @@ i32 FONT_BITMAP = 1   // Bitmap font generation, no anti-aliasing
 i32 FONT_SDF = 2      // SDF font generation, requires external shader
 
 // Color blending modes (pre-defined)
-i32 BLEND_ALPHA = 0                // Blend textures considering alpha (default)
+pub i32 BLEND_ALPHA = 0                // Blend textures considering alpha (default)
 i32 BLEND_ADDITIVE = 1             // Blend textures adding colors
 i32 BLEND_MULTIPLIED = 2           // Blend textures multiplying colors
 i32 BLEND_ADD_COLORS = 3           // Blend textures adding colors (alternative)
@@ -353,18 +353,18 @@ i32 NPATCH_NINE_PATCH = 0                // Npatch layout: 3x3 tiles
 i32 NPATCH_THREE_PATCH_VERTICAL = 1      // Npatch layout: 1x3 tiles
 i32 NPATCH_THREE_PATCH_HORIZONTAL = 2    // Npatch layout: 3x1 tiles
 
-var LIGHTGRAY = color_t{r: 200, g: 200, b: 200, a: 255}
-var GRAY = color_t{r: 130, g: 130, b: 130, a: 255}
-var DARKGRAY = color_t{r: 80, g: 80, b: 80, a: 255}
-var YELLOW = color_t{r: 253, g: 249, b: 0, a: 255}
-var GOLD = color_t{r: 255, g: 203, b: 0, a: 255}
-var ORANGE = color_t{r: 255, g: 161, b: 0, a: 255}
+pub var LIGHTGRAY = color_t{r: 200, g: 200, b: 200, a: 255}
+pub var GRAY = color_t{r: 130, g: 130, b: 130, a: 255}
+pub var DARKGRAY = color_t{r: 80, g: 80, b: 80, a: 255}
+pub var YELLOW = color_t{r: 253, g: 249, b: 0, a: 255}
+pub var GOLD = color_t{r: 255, g: 203, b: 0, a: 255}
+pub var ORANGE = color_t{r: 255, g: 161, b: 0, a: 255}
 var PINK = color_t{r: 255, g: 109, b: 194, a: 255}
-var RED = color_t{r: 230, g: 41, b: 55, a: 255}
-var MAROON = color_t{r: 190, g: 33, b: 55, a: 255}
-var GREEN = color_t{r: 0, g: 228, b: 48, a: 255}
+pub var RED = color_t{r: 230, g: 41, b: 55, a: 255}
+pub var MAROON = color_t{r: 190, g: 33, b: 55, a: 255}
+pub var GREEN = color_t{r: 0, g: 228, b: 48, a: 255}
 var LIME = color_t{r: 0, g: 158, b: 47, a: 255}
-var DARKGREEN = color_t{r: 0, g: 117, b: 44, a: 255}
+pub var DARKGREEN = color_t{r: 0, g: 117, b: 44, a: 255}
 var SKYBLUE = color_t{r: 102, g: 191, b: 255, a: 255}
 var BLUE = color_t{r: 0, g: 121, b: 241, a: 255}
 var DARKBLUE = color_t{r: 0, g: 82, b: 172, a: 255}
@@ -374,13 +374,13 @@ var DARKPURPLE = color_t{r: 112, g: 31, b: 126, a: 255}
 var BEIGE = color_t{r: 211, g: 176, b: 131, a: 255}
 var BROWN = color_t{r: 127, g: 106, b: 79, a: 255}
 var DARKBROWN = color_t{r: 76, g: 63, b: 47, a: 255}
-var WHITE = color_t{r: 255, g: 255, b: 255, a: 255}
-var BLACK = color_t{r: 0, g: 0, b: 0, a: 255}
+pub var WHITE = color_t{r: 255, g: 255, b: 255, a: 255}
+pub var BLACK = color_t{r: 0, g: 0, b: 0, a: 255}
 var BLANK = color_t{r: 0, g: 0, b: 0, a: 0}
 var MAGENTA = color_t{r: 255, g: 0, b: 255, a: 255}
-var RAYWHITE = color_t{r: 245, g: 245, b: 245, a: 255}
+pub var RAYWHITE = color_t{r: 245, g: 245, b: 245, a: 255}
 
-type vector2_t = struct{
+pub type vector2_t = struct{
     f32 x     // Vector x component
     f32 y     // Vector y component
 }
@@ -420,14 +420,14 @@ type matrix_t = struct{
     f32 m15
 }
 
-type color_t = struct{
+pub type color_t = struct{
     u8 r
     u8 g
     u8 b
     u8 a
 }
 
-type rectangle_t = struct{
+pub type rectangle_t = struct{
     f32 x        // Rectangle top-left corner position x
     f32 y        // Rectangle top-left corner position y
     f32 width    // Rectangle width
@@ -675,22 +675,22 @@ type automation_event_list_t = struct{
     anyptr events
 }
 
-#linkid WindowShouldClose
+pub #linkid WindowShouldClose
 fn window_should_close():bool
 
-#linkid BeginDrawing
+pub #linkid BeginDrawing
 fn begin_drawing()
 
-#linkid ClearBackground
+pub #linkid ClearBackground
 fn clear_background(color_t color)
 
-#linkid EndDrawing
+pub #linkid EndDrawing
 fn end_drawing()
 
-#linkid InitWindow
+pub #linkid InitWindow
 fn init_window(i32 width, i32 height, anyptr title)
 
-#linkid CloseWindow
+pub #linkid CloseWindow
 fn close_window()
 
 
@@ -769,10 +769,10 @@ fn set_window_focused()
 #linkid GetWindowHandle
 fn get_window_handle():anyptr
 
-#linkid GetScreenWidth
+pub #linkid GetScreenWidth
 fn get_screen_width():i32
 
-#linkid GetScreenHeight
+pub #linkid GetScreenHeight
 fn get_screen_height():i32
 
 #linkid GetRenderWidth
@@ -958,13 +958,13 @@ fn get_camera_matrix_2d(camera2d_t camera):matrix_t
 
 
 // Timing-related functions
-#linkid SetTargetFPS
+pub #linkid SetTargetFPS
 fn set_target_fps(i32 fps)
 
-#linkid GetFrameTime
+pub #linkid GetFrameTime
 fn get_frame_time():f32
 
-#linkid GetTime
+pub #linkid GetTime
 fn get_time():f64
 
 #linkid GetFPS
@@ -984,7 +984,7 @@ fn wait_time(f64 seconds)
 #linkid SetRandomSeed
 fn set_random_seed(u32 seed)
 
-#linkid GetRandomValue
+pub #linkid GetRandomValue
 fn get_random_value(i32 min, i32 max):i32
 
 #linkid LoadRandomSequence
@@ -1174,13 +1174,13 @@ fn stop_automation_event_recording()
 fn play_automation_event(automation_event_t event)
 
 // Input-related functions: keyboard
-#linkid IsKeyPressed
+pub #linkid IsKeyPressed
 fn is_key_pressed(i32 key):bool
 
 #linkid IsKeyPressedRepeat
 fn is_key_pressed_repeat(i32 key):bool
 
-#linkid IsKeyDown
+pub #linkid IsKeyDown
 fn is_key_down(i32 key):bool
 
 #linkid IsKeyReleased
@@ -1334,19 +1334,19 @@ fn get_shapes_texture():texture2d_t
 fn get_shapes_texture_rectangle():rectangle_t
 
 // Basic shapes drawing functions
-#linkid DrawPixel
+pub #linkid DrawPixel
 fn draw_pixel(i32 pos_x, i32 pos_y, color_t color)
 
 #linkid DrawPixelV
 fn draw_pixel_v(vector2_t position, color_t color)
 
-#linkid DrawLine
+pub #linkid DrawLine
 fn draw_line(i32 start_pos_x, i32 start_pos_y, i32 end_pos_x, i32 end_pos_y, color_t color)
 
 #linkid DrawLineV
 fn draw_line_v(vector2_t start_pos, vector2_t end_pos, color_t color)
 
-#linkid DrawLineEx
+pub #linkid DrawLineEx
 fn draw_line_ex(vector2_t start_pos, vector2_t end_pos, f32 thick, color_t color)
 
 #linkid DrawLineStrip
@@ -1367,7 +1367,7 @@ fn draw_circle_sector_lines(vector2_t center, f32 radius, f32 start_angle, f32 e
 #linkid DrawCircleGradient
 fn draw_circle_gradient(i32 center_x, i32 center_y, f32 radius, color_t inner, color_t outer)
 
-#linkid DrawCircleV
+pub #linkid DrawCircleV
 fn draw_circle_v(vector2_t center, f32 radius, color_t color)
 
 #linkid DrawCircleLines
@@ -1388,7 +1388,7 @@ fn draw_ring(vector2_t center, f32 inner_radius, f32 outer_radius, f32 start_ang
 #linkid DrawRingLines
 fn draw_ring_lines(vector2_t center, f32 inner_radius, f32 outer_radius, f32 start_angle, f32 end_angle, i32 segments, color_t color)
 
-#linkid DrawRectangle
+pub #linkid DrawRectangle
 fn draw_rectangle(i32 pos_x, i32 pos_y, i32 width, i32 height, color_t color)
 
 #linkid DrawRectangleV
@@ -1409,7 +1409,7 @@ fn draw_rectangle_gradient_h(i32 pos_x, i32 pos_y, i32 width, i32 height, color_
 #linkid DrawRectangleGradientEx
 fn draw_rectangle_gradient_ex(rectangle_t rec, color_t top_left, color_t bottom_left, color_t top_right, color_t bottom_right)
 
-#linkid DrawRectangleLines
+pub #linkid DrawRectangleLines
 fn draw_rectangle_lines(i32 pos_x, i32 pos_y, i32 width, i32 height, color_t color)
 
 #linkid DrawRectangleLinesEx
@@ -1493,7 +1493,7 @@ fn get_spline_point_bezier_quad(vector2_t p1, vector2_t c2, vector2_t p3, f32 t)
 fn get_spline_point_bezier_cubic(vector2_t p1, vector2_t c2, vector2_t c3, vector2_t p4, f32 t):vector2_t
 
 // Basic shapes collision detection functions
-#linkid CheckCollisionRecs
+pub #linkid CheckCollisionRecs
 fn check_collision_recs(rectangle_t rec1, rectangle_t rec2):bool
 
 #linkid CheckCollisionCircles
@@ -1832,7 +1832,7 @@ fn draw_texture_n_patch(texture2d_t texture, npatch_info_t n_patch_info, rectang
 #linkid ColorIsEqual
 fn color_is_equal(color_t col1, color_t col2):bool
 
-#linkid Fade
+pub #linkid Fade
 fn fade(color_t color, f32 alpha):color_t
 
 #linkid ColorToInt
@@ -1919,7 +1919,7 @@ fn export_font_as_code(font_t font, anyptr file_name):bool
 #linkid DrawFPS
 fn draw_fps(i32 pos_x, i32 pos_y)
 
-#linkid DrawText
+pub #linkid DrawText
 fn draw_text(anyptr text, i32 pos_x, i32 pos_y, i32 font_size, color_t color)
 
 #linkid DrawTextEx
@@ -1938,7 +1938,7 @@ fn draw_text_codepoints(font_t font, ptr<i32> codepoints, i32 codepoint_count, v
 #linkid SetTextLineSpacing
 fn set_text_line_spacing(i32 spacing)
 
-#linkid MeasureText
+pub #linkid MeasureText
 fn measure_text(anyptr text, i32 font_size):i32
 
 #linkid MeasureTextEx

--- a/tests/features/cases/20250405_02_compress/archive.n
+++ b/tests/features/cases/20250405_02_compress/archive.n
@@ -1,26 +1,26 @@
 type archive_t = anyptr
 type archive_entry_t = anyptr
 
-pub #linkid archive_write_new
-fn write_new():archive_t
+#linkid archive_write_new
+pub fn write_new():archive_t
 
-pub #linkid archive_write_add_filter_gzip
-fn write_add_filter_gzip(archive_t a)
+#linkid archive_write_add_filter_gzip
+pub fn write_add_filter_gzip(archive_t a)
 
-pub #linkid archive_write_set_format_ustar
-fn write_set_format_ustar(archive_t a)
+#linkid archive_write_set_format_ustar
+pub fn write_set_format_ustar(archive_t a)
 
-pub #linkid archive_write_open_filename
-fn write_open_filename(archive_t a, anyptr filename)
+#linkid archive_write_open_filename
+pub fn write_open_filename(archive_t a, anyptr filename)
 
-pub #linkid archive_read_disk_new
-fn read_disk_new():archive_t
+#linkid archive_read_disk_new
+pub fn read_disk_new():archive_t
 
-pub #linkid archive_read_disk_open
-fn read_disk_open(archive_t a, anyptr filename):i32
+#linkid archive_read_disk_open
+pub fn read_disk_open(archive_t a, anyptr filename):i32
 
-pub #linkid archive_entry_new
-fn entry_new():archive_entry_t
+#linkid archive_entry_new
+pub fn entry_new():archive_entry_t
 
 #linkid archive_read_next_header2
 fn read_next_header2(archive_t a, archive_entry_t e):i32

--- a/tests/features/cases/20250405_02_compress/archive.n
+++ b/tests/features/cases/20250405_02_compress/archive.n
@@ -1,5 +1,5 @@
-type archive_t = anyptr
-type archive_entry_t = anyptr
+pub type archive_t = anyptr
+pub type archive_entry_t = anyptr
 
 #linkid archive_write_new
 pub fn write_new():archive_t
@@ -23,76 +23,76 @@ pub fn read_disk_open(archive_t a, anyptr filename):i32
 pub fn entry_new():archive_entry_t
 
 #linkid archive_read_next_header2
-fn read_next_header2(archive_t a, archive_entry_t e):i32
+pub fn read_next_header2(archive_t a, archive_entry_t e):i32
 
 #linkid archive_error_string
-fn error_string(archive_t a):anyptr
+pub fn error_string(archive_t a):anyptr
 
 #linkid archive_read_disk_descend
-fn read_disk_descend(archive_t a):i32
+pub fn read_disk_descend(archive_t a):i32
 
 #linkid archive_write_header
-fn write_header(archive_t a, archive_entry_t entry):i32
+pub fn write_header(archive_t a, archive_entry_t entry):i32
 
 #linkid archive_entry_pathname
-fn entry_pathname(archive_entry_t entry):anyptr
+pub fn entry_pathname(archive_entry_t entry):anyptr
 
 #linkid archive_entry_set_pathname
-fn entry_set_pathname(archive_entry_t entry, anyptr pathname)
+pub fn entry_set_pathname(archive_entry_t entry, anyptr pathname)
 
 #linkid archive_entry_sourcepath
-fn entry_sourcepath(archive_entry_t entry):anyptr
+pub fn entry_sourcepath(archive_entry_t entry):anyptr
 
 #linkid archive_entry_free
-fn entry_free(archive_entry_t entry)
+pub fn entry_free(archive_entry_t entry)
 
 #linkid archive_write_data
-fn write_data(archive_t a, anyptr buf, int len):int
+pub fn write_data(archive_t a, anyptr buf, int len):int
 
 #linkid archive_read_close
-fn read_close(archive_t a):i32
+pub fn read_close(archive_t a):i32
 
 #linkid archive_read_free
-fn read_free(archive_t a):i32
+pub fn read_free(archive_t a):i32
 
 #linkid archive_write_close
-fn write_close(archive_t a):i32
+pub fn write_close(archive_t a):i32
 
 #linkid archive_write_free
-fn write_free(archive_t a):i32
+pub fn write_free(archive_t a):i32
 
 #linkid archive_read_new
-fn read_new():archive_t
+pub fn read_new():archive_t
 
 #linkid archive_write_disk_new
-fn write_disk_new():archive_t
+pub fn write_disk_new():archive_t
 
 #linkid archive_write_disk_set_options
-fn write_disk_set_options(archive_t ext, i32 flags):i32
+pub fn write_disk_set_options(archive_t ext, i32 flags):i32
 
 #linkid archive_write_disk_set_standard_lookup
-fn write_disk_set_standard_lookup(archive_t ext):i32
+pub fn write_disk_set_standard_lookup(archive_t ext):i32
 
 #linkid archive_read_support_format_all
-fn read_support_format_all(archive_t a):i32
+pub fn read_support_format_all(archive_t a):i32
 
 #linkid archive_read_support_filter_all
-fn read_support_filter_all(archive_t a):i32
+pub fn read_support_filter_all(archive_t a):i32
 
 #linkid archive_read_support_filter_gzip
-fn read_support_filter_gzip(archive_t a):i32
+pub fn read_support_filter_gzip(archive_t a):i32
 
 #linkid archive_read_support_format_tar
-fn read_support_format_tar(archive_t a):i32
+pub fn read_support_format_tar(archive_t a):i32
 
 #linkid archive_read_open_filename
-fn read_open_filename(archive_t a, anyptr filename, uint block_size):i32
+pub fn read_open_filename(archive_t a, anyptr filename, uint block_size):i32
 
 #linkid archive_read_next_header
-fn read_next_header(archive_t a, ptr<archive_entry_t> entry_ptr):i32
+pub fn read_next_header(archive_t a, ptr<archive_entry_t> entry_ptr):i32
 
 #linkid archive_read_data_block
-fn read_data_block(archive_t ar, ptr<anyptr> buf, ptr<uint> size, ptr<i64> offset):i32
+pub fn read_data_block(archive_t ar, ptr<anyptr> buf, ptr<uint> size, ptr<i64> offset):i32
 
 #linkid archive_write_data_block
-fn write_data_block(archive_t aw, anyptr buf, uint size, i64 offset):i32
+pub fn write_data_block(archive_t aw, anyptr buf, uint size, i64 offset):i32

--- a/tests/features/cases/20250405_02_compress/archive.n
+++ b/tests/features/cases/20250405_02_compress/archive.n
@@ -1,25 +1,25 @@
 type archive_t = anyptr
 type archive_entry_t = anyptr
 
-#linkid archive_write_new
+pub #linkid archive_write_new
 fn write_new():archive_t
 
-#linkid archive_write_add_filter_gzip
+pub #linkid archive_write_add_filter_gzip
 fn write_add_filter_gzip(archive_t a)
 
-#linkid archive_write_set_format_ustar
+pub #linkid archive_write_set_format_ustar
 fn write_set_format_ustar(archive_t a)
 
-#linkid archive_write_open_filename
+pub #linkid archive_write_open_filename
 fn write_open_filename(archive_t a, anyptr filename)
 
-#linkid archive_read_disk_new
+pub #linkid archive_read_disk_new
 fn read_disk_new():archive_t
 
-#linkid archive_read_disk_open
+pub #linkid archive_read_disk_open
 fn read_disk_open(archive_t a, anyptr filename):i32
 
-#linkid archive_entry_new
+pub #linkid archive_entry_new
 fn entry_new():archive_entry_t
 
 #linkid archive_read_next_header2

--- a/tests/features/cases/20250405_02_compress/package.toml
+++ b/tests/features/cases/20250405_02_compress/package.toml
@@ -1,5 +1,5 @@
 name = "compress"
-version = "v1.3.2"
+version = "v1.6.0"
 authors = ["weiwenhao 1101140857@qq.com"]
 description = "compress gzip"
 license = "MIT"

--- a/tests/features/cases/20250405_02_compress/tgz/tgz.n
+++ b/tests/features/cases/20250405_02_compress/tgz/tgz.n
@@ -25,7 +25,7 @@ i32 ARCHIVE_EXTRACT_UNLINK = 0x0010
 i32 ARCHIVE_EXTRACT_ACL = 0x0020
 i32 ARCHIVE_EXTRACT_FFLAGS = 0x0040
 
-bool verbose = false
+pub bool verbose = false
 
 fn logf(string format, ...[any] args) {
     if !verbose {
@@ -40,7 +40,7 @@ fn logf(string format, ...[any] args) {
  * @sources 是具体的文件夹或者目录名称，不支持按通配符号，如 * 或者 . 来匹配所有文件
  * @workdir 表示具体的工作目录, 相关 sources 都是在 workdir 中被找到的
  */
-fn encode(string workdir, string tgz_path, [string] sources):void! {
+pub fn encode(string workdir, string tgz_path, [string] sources):void! {
     if workdir.len() == 0 {
         throw errorf('workdir is empty')
     }
@@ -146,7 +146,7 @@ fn encode(string workdir, string tgz_path, [string] sources):void! {
 
 
 // 在指定目录将 tgz path 进行解压
-fn decode(string workdir, string tgz_path):void! {
+pub fn decode(string workdir, string tgz_path):void! {
     if tgz_path.len() == 0 {
         throw errorf('tgz_path is empty')
     }

--- a/tests/features/cases/20250424_00_parker/cgroup.n
+++ b/tests/features/cases/20250424_00_parker/cgroup.n
@@ -66,7 +66,7 @@ fn cgroup_t.clear(*self):void! {
     os.rmdir(self.path, true)
 }
 
-fn init():cgroup_t! {
+pub fn init():cgroup_t! {
     if !path.exists('/sys/fs/cgroup') {
         throw errorf('cgroup new err=' + 'path /sys/fs/cgroup not found')
     }

--- a/tests/features/cases/20250424_00_parker/log.n
+++ b/tests/features/cases/20250424_00_parker/log.n
@@ -3,7 +3,7 @@ import syscall
 import time
 import fmt
 
-bool verbose = false
+pub bool verbose = false
 
 fn set_verbose() {
     verbose = true

--- a/tests/features/cases/20250424_00_parker/tests/mockdir/node.n
+++ b/tests/features/cases/20250424_00_parker/tests/mockdir/node.n
@@ -1,7 +1,7 @@
 import syscall
 import co
 
-int count = 10
+pub int count = 10
 
 fn main() {
     var str = syscall.get_env('REPEAT_COUNT')

--- a/tests/features/cases/20260102_00_tank/raylib.n
+++ b/tests/features/cases/20260102_00_tank/raylib.n
@@ -675,23 +675,23 @@ type automation_event_list_t = struct{
     anyptr events
 }
 
-pub #linkid WindowShouldClose
-fn window_should_close():bool
+#linkid WindowShouldClose
+pub fn window_should_close():bool
 
-pub #linkid BeginDrawing
-fn begin_drawing()
+#linkid BeginDrawing
+pub fn begin_drawing()
 
-pub #linkid ClearBackground
-fn clear_background(color_t color)
+#linkid ClearBackground
+pub fn clear_background(color_t color)
 
-pub #linkid EndDrawing
-fn end_drawing()
+#linkid EndDrawing
+pub fn end_drawing()
 
-pub #linkid InitWindow
-fn init_window(i32 width, i32 height, anyptr title)
+#linkid InitWindow
+pub fn init_window(i32 width, i32 height, anyptr title)
 
-pub #linkid CloseWindow
-fn close_window()
+#linkid CloseWindow
+pub fn close_window()
 
 
 #linkid IsWindowReady
@@ -769,11 +769,11 @@ fn set_window_focused()
 #linkid GetWindowHandle
 fn get_window_handle():anyptr
 
-pub #linkid GetScreenWidth
-fn get_screen_width():i32
+#linkid GetScreenWidth
+pub fn get_screen_width():i32
 
-pub #linkid GetScreenHeight
-fn get_screen_height():i32
+#linkid GetScreenHeight
+pub fn get_screen_height():i32
 
 #linkid GetRenderWidth
 fn get_render_width():i32
@@ -958,14 +958,14 @@ fn get_camera_matrix_2d(camera2d_t camera):matrix_t
 
 
 // Timing-related functions
-pub #linkid SetTargetFPS
-fn set_target_fps(i32 fps)
+#linkid SetTargetFPS
+pub fn set_target_fps(i32 fps)
 
-pub #linkid GetFrameTime
-fn get_frame_time():f32
+#linkid GetFrameTime
+pub fn get_frame_time():f32
 
-pub #linkid GetTime
-fn get_time():f64
+#linkid GetTime
+pub fn get_time():f64
 
 #linkid GetFPS
 fn get_fps():i32
@@ -984,8 +984,8 @@ fn wait_time(f64 seconds)
 #linkid SetRandomSeed
 fn set_random_seed(u32 seed)
 
-pub #linkid GetRandomValue
-fn get_random_value(i32 min, i32 max):i32
+#linkid GetRandomValue
+pub fn get_random_value(i32 min, i32 max):i32
 
 #linkid LoadRandomSequence
 fn load_random_sequence(u32 count, i32 min, i32 max):ptr<i32>
@@ -1174,14 +1174,14 @@ fn stop_automation_event_recording()
 fn play_automation_event(automation_event_t event)
 
 // Input-related functions: keyboard
-pub #linkid IsKeyPressed
-fn is_key_pressed(i32 key):bool
+#linkid IsKeyPressed
+pub fn is_key_pressed(i32 key):bool
 
 #linkid IsKeyPressedRepeat
 fn is_key_pressed_repeat(i32 key):bool
 
-pub #linkid IsKeyDown
-fn is_key_down(i32 key):bool
+#linkid IsKeyDown
+pub fn is_key_down(i32 key):bool
 
 #linkid IsKeyReleased
 fn is_key_released(i32 key):bool
@@ -1334,20 +1334,20 @@ fn get_shapes_texture():texture2d_t
 fn get_shapes_texture_rectangle():rectangle_t
 
 // Basic shapes drawing functions
-pub #linkid DrawPixel
-fn draw_pixel(i32 pos_x, i32 pos_y, color_t color)
+#linkid DrawPixel
+pub fn draw_pixel(i32 pos_x, i32 pos_y, color_t color)
 
 #linkid DrawPixelV
 fn draw_pixel_v(vector2_t position, color_t color)
 
-pub #linkid DrawLine
-fn draw_line(i32 start_pos_x, i32 start_pos_y, i32 end_pos_x, i32 end_pos_y, color_t color)
+#linkid DrawLine
+pub fn draw_line(i32 start_pos_x, i32 start_pos_y, i32 end_pos_x, i32 end_pos_y, color_t color)
 
 #linkid DrawLineV
 fn draw_line_v(vector2_t start_pos, vector2_t end_pos, color_t color)
 
-pub #linkid DrawLineEx
-fn draw_line_ex(vector2_t start_pos, vector2_t end_pos, f32 thick, color_t color)
+#linkid DrawLineEx
+pub fn draw_line_ex(vector2_t start_pos, vector2_t end_pos, f32 thick, color_t color)
 
 #linkid DrawLineStrip
 fn draw_line_strip(ptr<vector2_t> points, i32 point_count, color_t color)
@@ -1367,8 +1367,8 @@ fn draw_circle_sector_lines(vector2_t center, f32 radius, f32 start_angle, f32 e
 #linkid DrawCircleGradient
 fn draw_circle_gradient(i32 center_x, i32 center_y, f32 radius, color_t inner, color_t outer)
 
-pub #linkid DrawCircleV
-fn draw_circle_v(vector2_t center, f32 radius, color_t color)
+#linkid DrawCircleV
+pub fn draw_circle_v(vector2_t center, f32 radius, color_t color)
 
 #linkid DrawCircleLines
 fn draw_circle_lines(i32 center_x, i32 center_y, f32 radius, color_t color)
@@ -1388,8 +1388,8 @@ fn draw_ring(vector2_t center, f32 inner_radius, f32 outer_radius, f32 start_ang
 #linkid DrawRingLines
 fn draw_ring_lines(vector2_t center, f32 inner_radius, f32 outer_radius, f32 start_angle, f32 end_angle, i32 segments, color_t color)
 
-pub #linkid DrawRectangle
-fn draw_rectangle(i32 pos_x, i32 pos_y, i32 width, i32 height, color_t color)
+#linkid DrawRectangle
+pub fn draw_rectangle(i32 pos_x, i32 pos_y, i32 width, i32 height, color_t color)
 
 #linkid DrawRectangleV
 fn draw_rectangle_v(vector2_t position, vector2_t size, color_t color)
@@ -1409,8 +1409,8 @@ fn draw_rectangle_gradient_h(i32 pos_x, i32 pos_y, i32 width, i32 height, color_
 #linkid DrawRectangleGradientEx
 fn draw_rectangle_gradient_ex(rectangle_t rec, color_t top_left, color_t bottom_left, color_t top_right, color_t bottom_right)
 
-pub #linkid DrawRectangleLines
-fn draw_rectangle_lines(i32 pos_x, i32 pos_y, i32 width, i32 height, color_t color)
+#linkid DrawRectangleLines
+pub fn draw_rectangle_lines(i32 pos_x, i32 pos_y, i32 width, i32 height, color_t color)
 
 #linkid DrawRectangleLinesEx
 fn draw_rectangle_lines_ex(rectangle_t rec, f32 line_thick, color_t color)
@@ -1493,8 +1493,8 @@ fn get_spline_point_bezier_quad(vector2_t p1, vector2_t c2, vector2_t p3, f32 t)
 fn get_spline_point_bezier_cubic(vector2_t p1, vector2_t c2, vector2_t c3, vector2_t p4, f32 t):vector2_t
 
 // Basic shapes collision detection functions
-pub #linkid CheckCollisionRecs
-fn check_collision_recs(rectangle_t rec1, rectangle_t rec2):bool
+#linkid CheckCollisionRecs
+pub fn check_collision_recs(rectangle_t rec1, rectangle_t rec2):bool
 
 #linkid CheckCollisionCircles
 fn check_collision_circles(vector2_t center1, f32 radius1, vector2_t center2, f32 radius2):bool
@@ -1832,8 +1832,8 @@ fn draw_texture_n_patch(texture2d_t texture, npatch_info_t n_patch_info, rectang
 #linkid ColorIsEqual
 fn color_is_equal(color_t col1, color_t col2):bool
 
-pub #linkid Fade
-fn fade(color_t color, f32 alpha):color_t
+#linkid Fade
+pub fn fade(color_t color, f32 alpha):color_t
 
 #linkid ColorToInt
 fn color_to_int(color_t color):i32
@@ -1919,8 +1919,8 @@ fn export_font_as_code(font_t font, anyptr file_name):bool
 #linkid DrawFPS
 fn draw_fps(i32 pos_x, i32 pos_y)
 
-pub #linkid DrawText
-fn draw_text(anyptr text, i32 pos_x, i32 pos_y, i32 font_size, color_t color)
+#linkid DrawText
+pub fn draw_text(anyptr text, i32 pos_x, i32 pos_y, i32 font_size, color_t color)
 
 #linkid DrawTextEx
 fn draw_text_ex(font_t font, anyptr text, vector2_t position, f32 font_size, f32 spacing, color_t tint)
@@ -1938,8 +1938,8 @@ fn draw_text_codepoints(font_t font, ptr<i32> codepoints, i32 codepoint_count, v
 #linkid SetTextLineSpacing
 fn set_text_line_spacing(i32 spacing)
 
-pub #linkid MeasureText
-fn measure_text(anyptr text, i32 font_size):i32
+#linkid MeasureText
+pub fn measure_text(anyptr text, i32 font_size):i32
 
 #linkid MeasureTextEx
 fn measure_text_ex(font_t font, anyptr text, f32 font_size, f32 spacing):vector2_t
@@ -2481,5 +2481,5 @@ fn attach_audio_mixed_processor(audio_callback_t processor)
 #linkid DetachAudioMixedProcessor
 fn detach_audio_mixed_processor(audio_callback_t processor)
 
-pub #linkid Vector2Distance
-fn vector2_distance(vector2_t v1, vector2_t v2):f32
+#linkid Vector2Distance
+pub fn vector2_distance(vector2_t v1, vector2_t v2):f32

--- a/tests/features/cases/20260102_00_tank/raylib.n
+++ b/tests/features/cases/20260102_00_tank/raylib.n
@@ -47,10 +47,10 @@ i32 KEY_EIGHT = 56
 i32 KEY_NINE = 57
 i32 KEY_SEMICOLON = 59
 i32 KEY_EQUAL = 61
-i32 KEY_A = 65
+pub i32 KEY_A = 65
 i32 KEY_B = 66
 i32 KEY_C = 67
-i32 KEY_D = 68
+pub i32 KEY_D = 68
 i32 KEY_E = 69
 i32 KEY_F = 70
 i32 KEY_G = 71
@@ -62,14 +62,14 @@ i32 KEY_L = 76
 i32 KEY_M = 77
 i32 KEY_N = 78
 i32 KEY_O = 79
-i32 KEY_P = 80
+pub i32 KEY_P = 80
 i32 KEY_Q = 81
-i32 KEY_R = 82
-i32 KEY_S = 83
+pub i32 KEY_R = 82
+pub i32 KEY_S = 83
 i32 KEY_T = 84
 i32 KEY_U = 85
 i32 KEY_V = 86
-i32 KEY_W = 87
+pub i32 KEY_W = 87
 i32 KEY_X = 88
 i32 KEY_Y = 89
 i32 KEY_Z = 90
@@ -79,17 +79,17 @@ i32 KEY_RIGHT_BRACKET = 93
 i32 KEY_GRAVE = 96
 
 // Function keys
-i32 KEY_SPACE = 32
+pub i32 KEY_SPACE = 32
 i32 KEY_ESCAPE = 256
-i32 KEY_ENTER = 257
+pub i32 KEY_ENTER = 257
 i32 KEY_TAB = 258
 i32 KEY_BACKSPACE = 259
 i32 KEY_INSERT = 260
 i32 KEY_DELETE = 261
-i32 KEY_RIGHT = 262
-i32 KEY_LEFT = 263
-i32 KEY_DOWN = 264
-i32 KEY_UP = 265
+pub i32 KEY_RIGHT = 262
+pub i32 KEY_LEFT = 263
+pub i32 KEY_DOWN = 264
+pub i32 KEY_UP = 265
 i32 KEY_PAGE_UP = 266
 i32 KEY_PAGE_DOWN = 267
 i32 KEY_HOME = 268
@@ -314,7 +314,7 @@ i32 FONT_BITMAP = 1   // Bitmap font generation, no anti-aliasing
 i32 FONT_SDF = 2      // SDF font generation, requires external shader
 
 // Color blending modes (pre-defined)
-i32 BLEND_ALPHA = 0                // Blend textures considering alpha (default)
+pub i32 BLEND_ALPHA = 0                // Blend textures considering alpha (default)
 i32 BLEND_ADDITIVE = 1             // Blend textures adding colors
 i32 BLEND_MULTIPLIED = 2           // Blend textures multiplying colors
 i32 BLEND_ADD_COLORS = 3           // Blend textures adding colors (alternative)
@@ -353,18 +353,18 @@ i32 NPATCH_NINE_PATCH = 0                // Npatch layout: 3x3 tiles
 i32 NPATCH_THREE_PATCH_VERTICAL = 1      // Npatch layout: 1x3 tiles
 i32 NPATCH_THREE_PATCH_HORIZONTAL = 2    // Npatch layout: 3x1 tiles
 
-var LIGHTGRAY = color_t{r: 200, g: 200, b: 200, a: 255}
-var GRAY = color_t{r: 130, g: 130, b: 130, a: 255}
-var DARKGRAY = color_t{r: 80, g: 80, b: 80, a: 255}
-var YELLOW = color_t{r: 253, g: 249, b: 0, a: 255}
-var GOLD = color_t{r: 255, g: 203, b: 0, a: 255}
-var ORANGE = color_t{r: 255, g: 161, b: 0, a: 255}
+pub var LIGHTGRAY = color_t{r: 200, g: 200, b: 200, a: 255}
+pub var GRAY = color_t{r: 130, g: 130, b: 130, a: 255}
+pub var DARKGRAY = color_t{r: 80, g: 80, b: 80, a: 255}
+pub var YELLOW = color_t{r: 253, g: 249, b: 0, a: 255}
+pub var GOLD = color_t{r: 255, g: 203, b: 0, a: 255}
+pub var ORANGE = color_t{r: 255, g: 161, b: 0, a: 255}
 var PINK = color_t{r: 255, g: 109, b: 194, a: 255}
-var RED = color_t{r: 230, g: 41, b: 55, a: 255}
-var MAROON = color_t{r: 190, g: 33, b: 55, a: 255}
-var GREEN = color_t{r: 0, g: 228, b: 48, a: 255}
+pub var RED = color_t{r: 230, g: 41, b: 55, a: 255}
+pub var MAROON = color_t{r: 190, g: 33, b: 55, a: 255}
+pub var GREEN = color_t{r: 0, g: 228, b: 48, a: 255}
 var LIME = color_t{r: 0, g: 158, b: 47, a: 255}
-var DARKGREEN = color_t{r: 0, g: 117, b: 44, a: 255}
+pub var DARKGREEN = color_t{r: 0, g: 117, b: 44, a: 255}
 var SKYBLUE = color_t{r: 102, g: 191, b: 255, a: 255}
 var BLUE = color_t{r: 0, g: 121, b: 241, a: 255}
 var DARKBLUE = color_t{r: 0, g: 82, b: 172, a: 255}
@@ -374,13 +374,13 @@ var DARKPURPLE = color_t{r: 112, g: 31, b: 126, a: 255}
 var BEIGE = color_t{r: 211, g: 176, b: 131, a: 255}
 var BROWN = color_t{r: 127, g: 106, b: 79, a: 255}
 var DARKBROWN = color_t{r: 76, g: 63, b: 47, a: 255}
-var WHITE = color_t{r: 255, g: 255, b: 255, a: 255}
-var BLACK = color_t{r: 0, g: 0, b: 0, a: 255}
+pub var WHITE = color_t{r: 255, g: 255, b: 255, a: 255}
+pub var BLACK = color_t{r: 0, g: 0, b: 0, a: 255}
 var BLANK = color_t{r: 0, g: 0, b: 0, a: 0}
 var MAGENTA = color_t{r: 255, g: 0, b: 255, a: 255}
-var RAYWHITE = color_t{r: 245, g: 245, b: 245, a: 255}
+pub var RAYWHITE = color_t{r: 245, g: 245, b: 245, a: 255}
 
-type vector2_t = struct{
+pub type vector2_t = struct{
     f32 x     // Vector x component
     f32 y     // Vector y component
 }
@@ -420,14 +420,14 @@ type matrix_t = struct{
     f32 m15
 }
 
-type color_t = struct{
+pub type color_t = struct{
     u8 r
     u8 g
     u8 b
     u8 a
 }
 
-type rectangle_t = struct{
+pub type rectangle_t = struct{
     f32 x        // Rectangle top-left corner position x
     f32 y        // Rectangle top-left corner position y
     f32 width    // Rectangle width
@@ -675,22 +675,22 @@ type automation_event_list_t = struct{
     anyptr events
 }
 
-#linkid WindowShouldClose
+pub #linkid WindowShouldClose
 fn window_should_close():bool
 
-#linkid BeginDrawing
+pub #linkid BeginDrawing
 fn begin_drawing()
 
-#linkid ClearBackground
+pub #linkid ClearBackground
 fn clear_background(color_t color)
 
-#linkid EndDrawing
+pub #linkid EndDrawing
 fn end_drawing()
 
-#linkid InitWindow
+pub #linkid InitWindow
 fn init_window(i32 width, i32 height, anyptr title)
 
-#linkid CloseWindow
+pub #linkid CloseWindow
 fn close_window()
 
 
@@ -769,10 +769,10 @@ fn set_window_focused()
 #linkid GetWindowHandle
 fn get_window_handle():anyptr
 
-#linkid GetScreenWidth
+pub #linkid GetScreenWidth
 fn get_screen_width():i32
 
-#linkid GetScreenHeight
+pub #linkid GetScreenHeight
 fn get_screen_height():i32
 
 #linkid GetRenderWidth
@@ -958,13 +958,13 @@ fn get_camera_matrix_2d(camera2d_t camera):matrix_t
 
 
 // Timing-related functions
-#linkid SetTargetFPS
+pub #linkid SetTargetFPS
 fn set_target_fps(i32 fps)
 
-#linkid GetFrameTime
+pub #linkid GetFrameTime
 fn get_frame_time():f32
 
-#linkid GetTime
+pub #linkid GetTime
 fn get_time():f64
 
 #linkid GetFPS
@@ -984,7 +984,7 @@ fn wait_time(f64 seconds)
 #linkid SetRandomSeed
 fn set_random_seed(u32 seed)
 
-#linkid GetRandomValue
+pub #linkid GetRandomValue
 fn get_random_value(i32 min, i32 max):i32
 
 #linkid LoadRandomSequence
@@ -1174,13 +1174,13 @@ fn stop_automation_event_recording()
 fn play_automation_event(automation_event_t event)
 
 // Input-related functions: keyboard
-#linkid IsKeyPressed
+pub #linkid IsKeyPressed
 fn is_key_pressed(i32 key):bool
 
 #linkid IsKeyPressedRepeat
 fn is_key_pressed_repeat(i32 key):bool
 
-#linkid IsKeyDown
+pub #linkid IsKeyDown
 fn is_key_down(i32 key):bool
 
 #linkid IsKeyReleased
@@ -1334,19 +1334,19 @@ fn get_shapes_texture():texture2d_t
 fn get_shapes_texture_rectangle():rectangle_t
 
 // Basic shapes drawing functions
-#linkid DrawPixel
+pub #linkid DrawPixel
 fn draw_pixel(i32 pos_x, i32 pos_y, color_t color)
 
 #linkid DrawPixelV
 fn draw_pixel_v(vector2_t position, color_t color)
 
-#linkid DrawLine
+pub #linkid DrawLine
 fn draw_line(i32 start_pos_x, i32 start_pos_y, i32 end_pos_x, i32 end_pos_y, color_t color)
 
 #linkid DrawLineV
 fn draw_line_v(vector2_t start_pos, vector2_t end_pos, color_t color)
 
-#linkid DrawLineEx
+pub #linkid DrawLineEx
 fn draw_line_ex(vector2_t start_pos, vector2_t end_pos, f32 thick, color_t color)
 
 #linkid DrawLineStrip
@@ -1367,7 +1367,7 @@ fn draw_circle_sector_lines(vector2_t center, f32 radius, f32 start_angle, f32 e
 #linkid DrawCircleGradient
 fn draw_circle_gradient(i32 center_x, i32 center_y, f32 radius, color_t inner, color_t outer)
 
-#linkid DrawCircleV
+pub #linkid DrawCircleV
 fn draw_circle_v(vector2_t center, f32 radius, color_t color)
 
 #linkid DrawCircleLines
@@ -1388,7 +1388,7 @@ fn draw_ring(vector2_t center, f32 inner_radius, f32 outer_radius, f32 start_ang
 #linkid DrawRingLines
 fn draw_ring_lines(vector2_t center, f32 inner_radius, f32 outer_radius, f32 start_angle, f32 end_angle, i32 segments, color_t color)
 
-#linkid DrawRectangle
+pub #linkid DrawRectangle
 fn draw_rectangle(i32 pos_x, i32 pos_y, i32 width, i32 height, color_t color)
 
 #linkid DrawRectangleV
@@ -1409,7 +1409,7 @@ fn draw_rectangle_gradient_h(i32 pos_x, i32 pos_y, i32 width, i32 height, color_
 #linkid DrawRectangleGradientEx
 fn draw_rectangle_gradient_ex(rectangle_t rec, color_t top_left, color_t bottom_left, color_t top_right, color_t bottom_right)
 
-#linkid DrawRectangleLines
+pub #linkid DrawRectangleLines
 fn draw_rectangle_lines(i32 pos_x, i32 pos_y, i32 width, i32 height, color_t color)
 
 #linkid DrawRectangleLinesEx
@@ -1493,7 +1493,7 @@ fn get_spline_point_bezier_quad(vector2_t p1, vector2_t c2, vector2_t p3, f32 t)
 fn get_spline_point_bezier_cubic(vector2_t p1, vector2_t c2, vector2_t c3, vector2_t p4, f32 t):vector2_t
 
 // Basic shapes collision detection functions
-#linkid CheckCollisionRecs
+pub #linkid CheckCollisionRecs
 fn check_collision_recs(rectangle_t rec1, rectangle_t rec2):bool
 
 #linkid CheckCollisionCircles
@@ -1832,7 +1832,7 @@ fn draw_texture_n_patch(texture2d_t texture, npatch_info_t n_patch_info, rectang
 #linkid ColorIsEqual
 fn color_is_equal(color_t col1, color_t col2):bool
 
-#linkid Fade
+pub #linkid Fade
 fn fade(color_t color, f32 alpha):color_t
 
 #linkid ColorToInt
@@ -1919,7 +1919,7 @@ fn export_font_as_code(font_t font, anyptr file_name):bool
 #linkid DrawFPS
 fn draw_fps(i32 pos_x, i32 pos_y)
 
-#linkid DrawText
+pub #linkid DrawText
 fn draw_text(anyptr text, i32 pos_x, i32 pos_y, i32 font_size, color_t color)
 
 #linkid DrawTextEx
@@ -1938,7 +1938,7 @@ fn draw_text_codepoints(font_t font, ptr<i32> codepoints, i32 codepoint_count, v
 #linkid SetTextLineSpacing
 fn set_text_line_spacing(i32 spacing)
 
-#linkid MeasureText
+pub #linkid MeasureText
 fn measure_text(anyptr text, i32 font_size):i32
 
 #linkid MeasureTextEx
@@ -2481,5 +2481,5 @@ fn attach_audio_mixed_processor(audio_callback_t processor)
 #linkid DetachAudioMixedProcessor
 fn detach_audio_mixed_processor(audio_callback_t processor)
 
-#linkid Vector2Distance
+pub #linkid Vector2Distance
 fn vector2_distance(vector2_t v1, vector2_t v2):f32

--- a/tests/features/cases/20260102_00_tank/utils/utils.n
+++ b/tests/features/cases/20260102_00_tank/utils/utils.n
@@ -5,13 +5,13 @@ import time
 import mem
 import libc
 
-#linkid abs
+pub #linkid abs
 fn abs(i32 x):i32
 
-#linkid fmaxf
+pub #linkid fmaxf
 fn fmaxf(f32 x, f32 y):f32
 
-#linkid fminf
+pub #linkid fminf
 fn fminf(f32 x, f32 y):f32
 
 

--- a/tests/features/cases/20260102_00_tank/utils/utils.n
+++ b/tests/features/cases/20260102_00_tank/utils/utils.n
@@ -5,14 +5,14 @@ import time
 import mem
 import libc
 
-pub #linkid abs
-fn abs(i32 x):i32
+#linkid abs
+pub fn abs(i32 x):i32
 
-pub #linkid fmaxf
-fn fmaxf(f32 x, f32 y):f32
+#linkid fmaxf
+pub fn fmaxf(f32 x, f32 y):f32
 
-pub #linkid fminf
-fn fminf(f32 x, f32 y):f32
+#linkid fminf
+pub fn fminf(f32 x, f32 y):f32
 
 
 fn logf(string format, ...[any] args) {

--- a/tests/features/cases/20260103_00_selective_imports/math_module.n
+++ b/tests/features/cases/20260103_00_selective_imports/math_module.n
@@ -1,20 +1,20 @@
 // Module with various symbols for testing selective imports
-f64 PI = 3.141593
+pub f64 PI = 3.141593
 f64 E = 2.718282
 
-fn sqrt(f64 x):f64 {
+pub fn sqrt(f64 x):f64 {
     return 4.0  // Simplified for testing - just return 4 for sqrt(16)
 }
 
-fn pow(f64 x, f64 y):f64 {
+pub fn pow(f64 x, f64 y):f64 {
     return 8.0  // Simplified for testing - just return 8 for pow(2,3)
 }
 
-fn add(int a, int b):int {
+pub fn add(int a, int b):int {
     return a + b
 }
 
-fn multiply(int a, int b):int {
+pub fn multiply(int a, int b):int {
     return a * b
 }
 
@@ -24,17 +24,17 @@ fn internal_helper():int {
     return 42
 }
 
-type Point = struct {
+pub type Point = struct {
     int x
     int y
 }
 
-type Color = enum {
+pub type Color = enum {
     RED,
     GREEN,
     BLUE,
 }
 
-fn log(string msg) {
+pub fn log(string msg) {
     println('math_module:', msg)
 }

--- a/tests/features/cases/20260103_00_selective_imports/utils.n
+++ b/tests/features/cases/20260103_00_selective_imports/utils.n
@@ -1,8 +1,8 @@
 // Helper module for mixed import testing
-int MAX_SIZE = 100
-int MIN_SIZE = 10
+pub int MAX_SIZE = 100
+pub int MIN_SIZE = 10
 
-fn format_string(string s):string {
+pub fn format_string(string s):string {
     return s
 }
 

--- a/tests/features/cases/20260103_01_selective_imports_modules/lib/math.n
+++ b/tests/features/cases/20260103_01_selective_imports_modules/lib/math.n
@@ -1,14 +1,14 @@
 // Math library module
-fn add(int a, int b):int {
+pub fn add(int a, int b):int {
     return a + b
 }
 
-fn multiply(int a, int b):int {
+pub fn multiply(int a, int b):int {
     return a * b
 }
 
-fn square(int x):int {
+pub fn square(int x):int {
     return x * x
 }
 
-int MATH_CONSTANT = 42
+pub int MATH_CONSTANT = 42

--- a/tests/features/cases/20260103_01_selective_imports_modules/utils/types.n
+++ b/tests/features/cases/20260103_01_selective_imports_modules/utils/types.n
@@ -1,15 +1,15 @@
 // Types module
-type Point = struct {
+pub type Point = struct {
     int x
     int y
 }
 
-type Color = struct {
+pub type Color = struct {
     int r
     int g
     int b
 }
 
-fn createPoint(int x, int y):Point {
+pub fn createPoint(int x, int y):Point {
     return Point{x: x, y: y}
 }

--- a/tests/features/cases/20260125_00_toylang/lexer/lexer.n
+++ b/tests/features/cases/20260125_00_toylang/lexer/lexer.n
@@ -9,7 +9,7 @@ type Lexer = struct {
     string ch          // current char under examination
 }
 
-fn newLexer(string input): Lexer {
+pub fn newLexer(string input): Lexer {
     var l = Lexer {
         input: input,
         position: 0,
@@ -34,7 +34,7 @@ fn Lexer.readChar(*self) {
     }
 }
 
-fn Lexer.nextToken(*self): token.Token {
+pub fn Lexer.nextToken(*self): token.Token {
     // Implementation of tokenization logic goes here
     self.skipWhitespace()
     var tk =  match self.ch {

--- a/tests/features/cases/20260125_00_toylang/token/token.n
+++ b/tests/features/cases/20260125_00_toylang/token/token.n
@@ -1,28 +1,28 @@
 import fmt
 
 // token kind
-const TokenKindEof = 0 // end of file
+pub const TokenKindEof = 0 // end of file
 const TokenKindIdent = 1 // identifier
-const TokenKindNumber = 2 // number literal
+pub const TokenKindNumber = 2 // number literal
 const TokenKindString = 3 // string literal
-const TokenKindPlus = 4 // +
-const TokenKindMinus = 5 // -
-const TokenKindAsterisk = 6 // *
-const TokenKindSlash = 7 // /
-const TokenKindPercent = 8 // %
-const TokenKindAssign = 9 // =
+pub const TokenKindPlus = 4 // +
+pub const TokenKindMinus = 5 // -
+pub const TokenKindAsterisk = 6 // *
+pub const TokenKindSlash = 7 // /
+pub const TokenKindPercent = 8 // %
+pub const TokenKindAssign = 9 // =
 const TokenKindEqual = 10 // ==
 const TokenKindNotEqual = 11 // !=
-const TokenKindLess = 12 // <
+pub const TokenKindLess = 12 // <
 const TokenKindLessEqual = 13 // <=
 const TokenKindGreater = 14 // >
 const TokenKindGreaterEqual = 15 // >=
-const TokenKindSemicolon = 16 // ;
-const TokenKindComma = 17 // ,
-const TokenKindLParen = 18 // (
-const TokenKindRParen = 19 // )
-const TokenKindLBrace = 20 // {
-const TokenKindRBrace = 21 // }
+pub const TokenKindSemicolon = 16 // ;
+pub const TokenKindComma = 17 // ,
+pub const TokenKindLParen = 18 // (
+pub const TokenKindRParen = 19 // )
+pub const TokenKindLBrace = 20 // {
+pub const TokenKindRBrace = 21 // }
 const TokenKindIf = 22 // if
 const TokenKindElse = 23 // else
 const TokenKindReturn = 24 // return
@@ -40,7 +40,7 @@ const TokenKindRBracket = 35 // ]
 const TokenKindColon = 36 // :
 const TokenKindDot = 37 // .
 const TokenKindPipe = 38 // |
-const TokenKindUnknown = 39 // unknown
+pub const TokenKindUnknown = 39 // unknown
 
 type SourcePos = struct {
     int line // line number
@@ -51,13 +51,13 @@ fn SourcePos.toString(*self): string {
     return "(line: " + fmt.sprintf("%d",self.line) + ", column: " + fmt.sprintf("%d",self.column) + ")"
 }
 
-type Token = struct {
+pub type Token = struct {
     int kind        // token kind
     string literal  // token literal
     SourcePos pos      // position in source
 }
 
-fn newToken( int kind,  string literal, int line, int column): Token {
+pub fn newToken( int kind,  string literal, int line, int column): Token {
     return Token{
         kind: kind,
         literal: literal,
@@ -68,7 +68,7 @@ fn newToken( int kind,  string literal, int line, int column): Token {
     }
 }
 
-fn Token.toString(*self): string {
+pub fn Token.toString(*self): string {
     var kind = match self.kind {
         TokenKindEof -> "TokenKindEof"
         TokenKindIdent -> "TokenKindIdent"
@@ -117,7 +117,7 @@ fn Token.toString(*self): string {
 
 {string:int} keywords = {}
 
-fn init() {
+pub fn init() {
    keywords = {
        "if": TokenKindIf,
        "else": TokenKindElse,
@@ -130,7 +130,7 @@ fn init() {
    }
 }
 
-fn lookupKeyword(string ident): int {
+pub fn lookupKeyword(string ident): int {
     // return keywords[ident] or { TokenKindIdent }
     var kind = keywords[ident] catch e { 
         return TokenKindIdent 

--- a/tests/features/cases/20260224_00_global_eval.testar
+++ b/tests/features/cases/20260224_00_global_eval.testar
@@ -66,20 +66,20 @@ fn main() {}
 --- a.n
 import 'b.n'.{b}
 
-int a = b
+pub int a = b
 
 --- b.n
 import 'c.n'.{c}
 
-int b = c
+pub int b = c
 
 --- c.n
 import 'a.n'.{a}
 
-int c = a
+pub int c = a
 
 --- output.txt
-nature-test/c.n:3:9: global initializer cannot reference global var 'nature-test.a.a'
+nature-test/c.n:3:13: global initializer cannot reference global var 'nature-test.a.a'
 
 === test_global_auto_infer
 --- main.n

--- a/tests/features/cases/20260726_00_module_layout/codec/codec.n
+++ b/tests/features/cases/20260726_00_module_layout/codec/codec.n
@@ -3,9 +3,9 @@ mod codec
 import strings
 
 // top-level globals are shared by the whole module
-int shared_count = 7
+pub int shared_count = 7
 
-fn decode(int v):int {
+pub fn decode(int v):int {
     return v + scale()
 }
 

--- a/tests/features/cases/20260726_00_module_layout/codec/encode.n
+++ b/tests/features/cases/20260726_00_module_layout/codec/encode.n
@@ -2,16 +2,16 @@ mod codec
 
 import fmt
 
-fn encode(int v):string {
+pub fn encode(int v):string {
     // cross-file forward reference: scale is defined in codec.n
     return fmt.sprintf('enc-%d', v * scale())
 }
 
-fn encode_all(int v):string {
+pub fn encode_all(int v):string {
     return encode(v) + '|' + decode_tag()
 }
 
-fn version_tag():string {
+pub fn version_tag():string {
     // shared_count is declared in codec.n, top-level declarations are shared by the whole module
     return fmt.sprintf('v%d', shared_count)
 }

--- a/tests/features/cases/20260726_00_module_layout/codec/helper.n
+++ b/tests/features/cases/20260726_00_module_layout/codec/helper.n
@@ -1,4 +1,4 @@
 // a file without mod in the same directory stays the standalone module modtest.codec.helper
-fn tag():string {
+pub fn tag():string {
     return 'codec.helper'
 }

--- a/tests/features/cases/20260726_00_module_layout/fmtx.n
+++ b/tests/features/cases/20260726_00_module_layout/fmtx.n
@@ -1,3 +1,3 @@
-fn name():string {
+pub fn name():string {
     return 'fmtx'
 }

--- a/tests/features/cases/20260726_00_module_layout/fmtx/utils.n
+++ b/tests/features/cases/20260726_00_module_layout/fmtx/utils.n
@@ -1,3 +1,3 @@
-fn name():string {
+pub fn name():string {
     return 'fmtx.utils'
 }

--- a/tests/features/cases/20260726_00_module_layout/nested/deep.n
+++ b/tests/features/cases/20260726_00_module_layout/nested/deep.n
@@ -1,5 +1,5 @@
 mod deep
 
-fn name():string {
+pub fn name():string {
     return 'deep'
 }

--- a/tests/features/cases/20260726_00_module_layout/net/http/http.n
+++ b/tests/features/cases/20260726_00_module_layout/net/http/http.n
@@ -2,6 +2,6 @@ mod http
 
 const PROTO = 'http/1.1'
 
-fn response():string {
+pub fn response():string {
     return 'resp'
 }

--- a/tests/features/cases/20260726_00_module_layout/net/http/request.n
+++ b/tests/features/cases/20260726_00_module_layout/net/http/request.n
@@ -1,5 +1,5 @@
 mod /* part of http */ http
 
-fn request():string {
+pub fn request():string {
     return 'req:' + PROTO
 }

--- a/tests/features/cases/20260726_00_module_layout/plat/plat.n
+++ b/tests/features/cases/20260726_00_module_layout/plat/plat.n
@@ -1,5 +1,5 @@
 mod plat
 
-fn name():string {
+pub fn name():string {
     return 'modtest.plat'
 }

--- a/tests/features/cases/20260726_00_module_layout/plat/target.darwin.n
+++ b/tests/features/cases/20260726_00_module_layout/plat/target.darwin.n
@@ -1,5 +1,5 @@
 mod plat
 
-fn target():string {
+pub fn target():string {
     return 'variant'
 }

--- a/tests/features/cases/20260726_00_module_layout/plat/target.linux.n
+++ b/tests/features/cases/20260726_00_module_layout/plat/target.linux.n
@@ -1,5 +1,5 @@
 mod plat
 
-fn target():string {
+pub fn target():string {
     return 'variant'
 }

--- a/tests/features/cases/20260726_00_module_layout/plat/target.n
+++ b/tests/features/cases/20260726_00_module_layout/plat/target.n
@@ -1,5 +1,5 @@
 mod plat
 
-fn target():string {
+pub fn target():string {
     return 'plain'
 }

--- a/tests/features/cases/20260726_00_module_layout/plat/target.windows.n
+++ b/tests/features/cases/20260726_00_module_layout/plat/target.windows.n
@@ -1,5 +1,5 @@
 mod plat
 
-fn target():string {
+pub fn target():string {
     return 'variant'
 }

--- a/tests/features/cases/20260726_00_module_layout/same/same.n
+++ b/tests/features/cases/20260726_00_module_layout/same/same.n
@@ -1,5 +1,5 @@
 // A same-named source is a single-file directory module, so it may omit mod.
 
-fn name():string {
+pub fn name():string {
     return 'modtest.same'
 }

--- a/tests/features/cases/20260726_00_module_layout/standalone.n
+++ b/tests/features/cases/20260726_00_module_layout/standalone.n
@@ -2,7 +2,7 @@
 import modtest.codec
 import 'fmtx.n'
 
-fn codec_encode(int v):string {
+pub fn codec_encode(int v):string {
     // codec was already imported by main.n, it is not built again here
     return codec.encode(v) + '/' + fmtx.name()
 }

--- a/tests/features/cases/20260726_01_module_errors.testar
+++ b/tests/features/cases/20260726_01_module_errors.testar
@@ -336,7 +336,7 @@ fn main() {
 --- mods/a.n
 mod mods
 
-fn broken():int {
+pub fn broken():int {
     string s = 'x'
     return s
 }

--- a/tests/features/cases/20260726_02_module_no_package.testar
+++ b/tests/features/cases/20260726_02_module_no_package.testar
@@ -20,7 +20,7 @@ fn main() {
 }
 
 --- helper.n
-fn tag():string {
+pub fn tag():string {
     return 'helper'
 }
 

--- a/tests/features/cases/20260726_03_build_target/lib/lib.n
+++ b/tests/features/cases/20260726_03_build_target/lib/lib.n
@@ -5,6 +5,6 @@ fn main() {
     println('should never be selected')
 }
 
-fn helper():string {
+pub fn helper():string {
     return 'helper'
 }

--- a/tests/features/cases/20260807_00_pub_acl/err_local_pub.n
+++ b/tests/features/cases/20260807_00_pub_acl/err_local_pub.n
@@ -1,0 +1,4 @@
+fn main() {
+    pub var x = 1
+    println(x)
+}

--- a/tests/features/cases/20260807_00_pub_acl/err_member.n
+++ b/tests/features/cases/20260807_00_pub_acl/err_member.n
@@ -1,0 +1,5 @@
+import 'mod.n' as math
+
+fn main() {
+    println(math.private_fn())
+}

--- a/tests/features/cases/20260807_00_pub_acl/err_method.n
+++ b/tests/features/cases/20260807_00_pub_acl/err_method.n
@@ -1,0 +1,6 @@
+import 'mod.n' as math
+
+fn main() {
+    var p = math.pub_pair_t{x: 3, y: 4}
+    println(p.priv_mul())
+}

--- a/tests/features/cases/20260807_00_pub_acl/err_select.n
+++ b/tests/features/cases/20260807_00_pub_acl/err_select.n
@@ -1,0 +1,5 @@
+import 'mod.n'.{private_fn}
+
+fn main() {
+    println(private_fn())
+}

--- a/tests/features/cases/20260807_00_pub_acl/err_star.n
+++ b/tests/features/cases/20260807_00_pub_acl/err_star.n
@@ -1,0 +1,5 @@
+import 'mod.n' as *
+
+fn main() {
+    println(private_fn())
+}

--- a/tests/features/cases/20260807_00_pub_acl/err_type.n
+++ b/tests/features/cases/20260807_00_pub_acl/err_type.n
@@ -1,0 +1,6 @@
+import 'mod.n' as math
+
+fn main() {
+    var v = math.private_t{x: 1}
+    println(v.v)
+}

--- a/tests/features/cases/20260807_00_pub_acl/main.n
+++ b/tests/features/cases/20260807_00_pub_acl/main.n
@@ -1,0 +1,10 @@
+import 'mod.n' as math
+
+fn main() {
+    var p = math.pub_pair_t{x: 3, y: 4}
+    println(math.pub_add(1, 2))
+    println(math.PUB_CONST)
+    println(p.sum())
+    math.pub_counter += 1
+    println(math.pub_counter)
+}

--- a/tests/features/cases/20260807_00_pub_acl/mod.n
+++ b/tests/features/cases/20260807_00_pub_acl/mod.n
@@ -1,0 +1,32 @@
+pub fn pub_add(int a, int b):int {
+    return a + b
+}
+
+fn private_fn():int {
+    return 42
+}
+
+pub const PUB_CONST = 100
+
+const PRIVATE_CONST = 200
+
+pub type pub_pair_t = struct {
+    int x
+    int y
+}
+
+type private_t = struct {
+    int v
+}
+
+pub var pub_counter = 1
+
+var private_counter = 1
+
+pub fn pub_pair_t.sum(*self):int {
+    return self.x + self.y
+}
+
+fn pub_pair_t.priv_mul(*self):int {
+    return self.x * self.y
+}

--- a/tests/features/cases/20260807_01_label_pub.testar
+++ b/tests/features/cases/20260807_01_label_pub.testar
@@ -1,0 +1,22 @@
+=== valid_label_before_pub
+--- main.n
+#linkid gzwrite
+pub fn gzwrite(anyptr outfile, anyptr buf, int len):int
+
+fn main() {
+    println(1)
+}
+
+--- output.txt
+1
+
+=== invalid_pub_before_label
+--- main.n
+pub #linkid gzwrite
+fn gzwrite(anyptr outfile, anyptr buf, int len):int
+
+fn main() {
+}
+
+--- output.txt
+nature-test/main.n:1:12: pub must follow declaration labels

--- a/tests/features/cases/20260807_01_label_pub.testar
+++ b/tests/features/cases/20260807_01_label_pub.testar
@@ -19,4 +19,14 @@ fn main() {
 }
 
 --- output.txt
-nature-test/main.n:1:12: pub must follow declaration labels
+nature-test/main.n:1:12: non-declaration statement outside fn body
+
+=== invalid_label_and_pub_same_line
+--- main.n
+#linkid gzwrite pub fn gzwrite(anyptr outfile, anyptr buf, int len):int
+
+fn main() {
+}
+
+--- output.txt
+nature-test/main.n:1:20: expected ';' found 'pub'


### PR DESCRIPTION
Summary: add module-level pub visibility for functions, types, constants, variables, typed globals, and impl methods; keep visibility metadata on registered symbols; centralize cross-module access checks; make star and selective imports lazy; migrate standard-library and feature sources; remove the temporary disable-acl escape hatch.

Diagnostics: align cross-module private function/type errors with Go (undefined: package.name) and private method errors with Go (receiver.method undefined (cannot refer to unexported method method)), while retaining original source names in diagnostics.

NLS migration:
- Lexer, parser, AST declarations, symbol ownership, and semantic resolution now use pub visibility.
- Cross-module qualified, selective, star-import, type, and impl-method access checks match the compiler diagnostics.
- Completion filters private symbols and the workspace index recognizes pub fn/fx, pub type, pub const, pub var, typed globals, and pub label continuations such as #where/#linkid.
- Existing multi-file module fixtures now mark externally used declarations explicitly pub.

Verification:
- Go 1.26.1 cross-package private function, type, method, and dot-import examples compared.
- cmake -B build -S .
- cmake --build build --target nature 20260807_00_pub_acl -- -j8
- cd build && ctest -R 20260807_00_pub_acl -V
- cd nls && cargo test --all --quiet
- cd nls && cargo build --release

feature/json-enhance remains excluded from this PR. The only std/json change here is the pub annotation required by the visibility migration.

CI:
- test-local now runs cargo test --all --locked in nls/ for Linux arm64 and macOS arm64 runners.

Parser ordering:
- Declaration labels now precede pub; legacy pub label declarations are rejected.
- The label/pub ordering regression is covered by the 20260807_01_label_pub testar cases.