### PR TITLE
fix(std): parse HTTP status lines without pre-filled vec padding

### DIFF
--- a/std/http/client.n
+++ b/std/http/client.n
@@ -259,7 +259,10 @@ fn request_t.tcp_buf(&self):[u8]! {
 
 #local
 fn read_until_space(ref<buf.reader<types.connable>> br):string! {
-    var bytes = vec<u8>.new(0, 32)
+    // vec<u8>.new(0, 32) pre-fills 32 zero bytes that are included in the
+    // `as string` result, corrupting every status line parse. Build the token
+    // from an empty vec instead.
+    var bytes = vec<u8>.new(0, 0)
     for true {
         var b = br.read_byte()
         if b == ' '.char() {


### PR DESCRIPTION
## Summary

`http.client` parses every response status line as `0`, so all responses fail the 2xx check and every request surfaces as `HTTP 0`.

## Root cause

`read_until_space()` in `std/http/client.n` builds the token with `vec<u8>.new(0, 32)`, which pre-fills the vector with 32 zero bytes. `bytes as string` includes the full vector length, so the version token becomes `<32 NUL bytes>HTTP/1.1` and the status token becomes `<32 NUL bytes>200`. `status.to_int()` then fails and the client falls back to 0.

## Fix

Build the token from an empty vec (`vec<u8>.new(0, 0)`) so `as string` returns only the pushed bytes.

## Verification

- Reproducer (local `http.server` fixture returning 200): `status=0` before, `status=200` after.
- `ctest -R http` (3 tests, including the rebuilt `20250802_02_http` against the patched std): 3/3 passed.

## Impact

`std` http client; streaming SSE users (OpenAI/Anthropic-compatible providers) were the most affected.