### PR TITLE
fix(std): read_line terminates at EOF instead of empty lines

### DIFF
--- a/std/io/buf.n
+++ b/std/io/buf.n
@@ -141,10 +141,14 @@ pub fn reader<T>.read_until(&self, u8 delim):[u8] {
             return result
         }
 
-        // fill may read to the end of the file to generate an eof error
-        // fill will make 100 attempts until the data is filled successfully, otherwise it will throw no progress
+        // fill may read to the end of the file to generate an eof error.
+        // fill retries empty reads 100 times and then throws 'no progress',
+        // which for blocking descriptors (files, pipes) means EOF. Record it
+        // so read_line() can terminate instead of returning empty lines
+        // forever (cc103849 made read_until swallow every fill error).
         self.fill() catch e {
             has_error = true
+            self.eof = true
         }
     }
 
@@ -178,6 +182,11 @@ pub fn reader<T>.read_line(&self):string! {
     }
 
     var bytes = self.read_until('\n'.char())
+    if self.eof && bytes.len() == 0 {
+        // The underlying descriptor reached EOF with no complete line; the
+        // caller must observe the terminal condition instead of an empty line.
+        throw errorf('EOF')
+    }
 
     // 处理 \r\n
     if bytes.len() > 0 && bytes[bytes.len() - 1] == '\n'.char() {


### PR DESCRIPTION
## Summary

`buf.reader.read_line()` never reports the end of a blocking descriptor: it returns empty lines forever, so loops over piped stdin (JSONL RPC clients, `cat file | reader` style programs) hang instead of terminating.

## Root cause

`cc103849` ("read_until never throws, errors return partial data") made `read_until()` swallow **every** `fill()` error, including the `'no progress'` error that `fill()` throws after 100 empty reads. For blocking descriptors (files, pipes, terminals) an empty read means EOF, so `read_until()` returns an empty buffer, `read_line()` returns `''`, and the caller loops forever. Previously the `'no progress'` error was rethrown and `read_line()` surfaced it.

## Fix

- `read_until()`: record the terminal condition (`self.eof = true`) when `fill()` fails, keeping the "never throws, return partial data" contract for the partial-data case.
- `read_line()`: throw `EOF` when the descriptor ended with no complete line, so line readers terminate deterministically.

## Verification

- Reproducer: pipe `hello\n` into a test that loops `read_line()` until error. Before: infinite `''` lines. After: `line: hello` then `EOF` and clean exit.
- `ctest -R '20250307_00_fs|20250317_00_stdio|20250613_00_libc_stdio'` rebuilt against the patched std: 3/3 passed (the fs test relies on `file.read()` returning 0 at EOF; that contract is untouched).
- `20250802_02_http` (real HTTPS) is timing out on this machine right now for network reasons; it reproduces with the patch stashed too.

## Impact

`std/io` buffered readers. Callers that relied on `read_line()` returning empty lines at EOF would now get `EOF` (matching the pre-cc103849 terminal behavior).