### PR TITLE
fix(runtime): deliver SIGWINCH through the signal channel

### DIFF
--- a/runtime/nutils/rt_signal.h
+++ b/runtime/nutils/rt_signal.h
@@ -35,6 +35,7 @@ static const int64_t all_signals[] = {
         SIGUSR1,
         SIGUSR2,
         SIGTERM, // 默认行为是终止进程
+        SIGWINCH,
 };
 #endif
 


### PR DESCRIPTION
## Summary

`os.signal.notify(ch, SIGWINCH)` never delivers terminal resize events: the signal is not in the runtime's delivery set, so no handler is installed, the signal is never recorded, and the signal loop never dispatches it.

## Fix

Add `SIGWINCH` to `all_signals` in `runtime/nutils/rt_signal.h` so it is handled like HUP/INT/USR1/USR2/TERM (install handler, record, dispatch to registered channels).

## Verification

- Reproducer: `signal.notify(ch, SIGWINCH)`, `kill(getpid(), SIGWINCH)`, then `try_recv` after a sleep. Before: `received=false`. After: `received=true`.
- The runtime test suites (fs/stdio/http) pass unchanged; SIGWINCH's default disposition is ignore, so the added handler is inert for programs that never register it.

## Impact

`runtime` signal delivery; TUI programs that track terminal size via SIGWINCH.