### PR TITLE
ci: fix self-hosted runner label case in test-local workflow

### DIFF
--- a/.github/workflows/test-local.yml
+++ b/.github/workflows/test-local.yml
@@ -20,9 +20,9 @@ jobs:
       matrix:
         include:
           - target: linux-arm64
-            runs-on: [self-hosted, linux, arm64]
+            runs-on: [self-hosted, Linux, ARM64]
           - target: darwin-arm64
-            runs-on: [self-hosted, macos, arm64]
+            runs-on: [self-hosted, macOS, ARM64]
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout


### PR DESCRIPTION
## 问题

`test-local.yml` 里的 `runs-on` label 是小写（`linux`/`macos`/`arm64`），而 org 注册的 self-hosted runner 的 read-only label 是大写（`Linux`/`macOS`/`ARM64`）。GitHub 的 label 匹配大小写敏感，且小写名是保留 label 无法添加到 runner 上，导致 job 永远 queued、无 runner 接单。

## 修复

将 label 与注册的 runner 对齐：

- `[self-hosted, linux, arm64]` → `[self-hosted, Linux, ARM64]`（匹配 macmini-linux）
- `[self-hosted, macos, arm64]` → `[self-hosted, macOS, ARM64]`（匹配 macmini）