### PR TITLE
ci: add -y to musl-tools install for non-interactive runners

### DIFF
--- a/.github/workflows/test-local.yml
+++ b/.github/workflows/test-local.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Setup Musl for Linux
         if: ${{ contains(matrix.target, 'linux') }}
-        run: sudo apt-get install musl-tools
+        run: sudo apt-get install -y musl-tools
 
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2


### PR DESCRIPTION
## 问题

在 self-hosted orb 容器上，`sudo apt-get install musl-tools` 会弹出 `Do you want to continue? [Y/n]` 确认，非交互的 runner shell 直接 Abort，linux job 失败。

## 修复

安装时加 `-y`。