### PR TITLE
fix(std): parse HTTP status lines without pre-filled vec padding

### DIFF
--- a/std/http/client.n
+++ b/std/http/client.n
@@ -259,7 +259,10 @@ fn request_t.tcp_buf(&self):[u8]! {
 
 #local
 fn read_until_space(ref<buf.reader<types.connable>> br):string! {
-    var bytes = vec<u8>.new(0, 32)
+    // vec<u8>.new(0, 32) pre-fills 32 zero bytes that are included in the
+    // `as string` result, corrupting every status line parse. Build the token
+    // from an empty vec instead.
+    var bytes = vec<u8>.new(0, 0)
     for true {
         var b = br.read_byte()
         if b == ' '.char() {


### PR DESCRIPTION
## Problem

Self-hosted runner CI (run #8, darwin-arm64) fails `test_basic_https`: the response body is received but `resp.status` parses as `0` instead of `200`:

```
Assert (false) failed: test_basic_https status code 256 ... failed: 120.235.139.252
0
panic: 'assertion failed' at nature-test/main.n:8:29
```

## Root cause

`read_until_space()` builds the token with `vec<u8>.new(0, 32)`, which pre-fills 32 zero bytes. Those bytes are included in the `as string` result, so the version token carries leading NULs and the status token fails `to_int()` — every response status parses as `0`, making every `http.client` request look like a non-2xx error.

## Fix

Build the token from an empty vec instead.

## Verification

- Reproduced on the Mac mini self-hosted runner: build at the old commit → `status=0`; with this patch → `status=200`.
- `http` test suite: 3/3 passed.