### PR TITLE
test: align buf reader EOF expectations

### DIFF
--- a/tests/features/cases/20250325_00_buf_reader.testar
+++ b/tests/features/cases/20250325_00_buf_reader.testar
@@ -313,9 +313,16 @@ fn main():void! {
     rd.write("\n\n\nHello\n\n" as [u8])
     var br = new buf.reader<ref<io.buffer>>(rd)
 
-    for int i = 0; i < 6; i += 1 {
+    for int i = 0; i < 5; i += 1 {
         var line = br.read_line()
         println("Read line: '" + line + "'")
+    }
+
+    try {
+        var line = br.read_line()
+        println("unexpected line: '" + line + "'")
+    } catch e {
+        println("catch e: " + e.msg())
     }
 }
 
@@ -325,4 +332,4 @@ Read line: ''
 Read line: ''
 Read line: 'Hello'
 Read line: ''
-Read line: ''
+catch e: EOF


### PR DESCRIPTION
## Summary

- Update the buf reader empty-line test to read the five lines present in the input.
- Assert EOF on the following read instead of expecting an extra empty line.

## Verification

- `cmake --build build --target 20250325_00_buf_reader -- -j8`
- `ctest --output-on-failure -R ^20250325_00_buf_reader$ -V`

This PR only updates the stale test expectation; it does not change `read_line` EOF behavior.