### PR TITLE
fix(std): complete pub visibility on remaining exports

### DIFF
--- a/std/fs/fs.n
+++ b/std/fs/fs.n
@@ -61,7 +61,7 @@ pub fn file_t.read(&self, [u8] buf):int!
 #linkid rt_uv_fs_write
 pub fn file_t.write(&self, [u8] buf):int!
 
-fn file_t.seek(&self, int offset, int whence):int! {
+pub fn file_t.seek(&self, int offset, int whence):int! {
     return syscall.seek(self.fd as int, offset, whence)
 }
 
@@ -82,7 +82,7 @@ pub fn stdout():ref<file_t>! {
     return from(syscall.STDOUT, '/dev/stdout')
 }
 
-fn stdin():ref<file_t>! {
+pub fn stdin():ref<file_t>! {
     return from(syscall.STDIN, '/dev/stdin')
 }
 

--- a/std/os/signal.n
+++ b/std/os/signal.n
@@ -8,4 +8,4 @@ pub type sig_t = int
 pub fn notify(chan<sig_t> sig_ch, ...[int] signals)
 
 #linkid signal_stop
-fn stop(chan<sig_t> sig_ch)
+pub fn stop(chan<sig_t> sig_ch)

--- a/std/process/process.n
+++ b/std/process/process.n
@@ -11,7 +11,7 @@ type state_t = struct{
     i32 term_sig
 }
 
-type process_t = struct{
+pub type process_t = struct{
     int pid
     anyptr args
     anyptr envs
@@ -26,7 +26,7 @@ type process_t = struct{
     // req
 }
 
-type command_t = struct{
+pub type command_t = struct{
     string name
     [string] args
 

--- a/std/syscall/syscall.darwin.n
+++ b/std/syscall/syscall.darwin.n
@@ -480,7 +480,7 @@ pub const SYS_MAXSYSCALL = 546
 pub const SYS_INVALID = 63
 
 // sigkill 相关信号
-int SIGHUP = 1       /* hangup */
+pub int SIGHUP = 1       /* hangup */
 pub int SIGINT = 2       /* interrupt */
 int SIGQUIT = 3      /* quit */
 int SIGILL = 4       /* illegal instruction (not reset when caught) */
@@ -497,7 +497,7 @@ int SIGALRM = 14     /* alarm clock */
 pub int SIGTERM = 15     /* software termination signal from kill */
 int SIGURG = 16      /* urgent condition on IO channel */
 int SIGSTOP = 17     /* sendable stop signal not from tty */
-int SIGTSTP = 18     /* stop signal from tty */
+pub int SIGTSTP = 18     /* stop signal from tty */
 int SIGCONT = 19     /* continue a stopped process */
 int SIGCHLD = 20     /* to parent on child stop or exit */
 int SIGTTIN = 21     /* to readers pgrp upon background tty read */
@@ -507,7 +507,7 @@ int SIGXCPU = 24     /* exceeded CPU time limit */
 int SIGXFSZ = 25     /* exceeded file size limit */
 int SIGVTALRM = 26   /* virtual time alarm */
 int SIGPROF = 27     /* profiling time alarm */
-int SIGWINCH = 28    /* window size changes */
+pub int SIGWINCH = 28    /* window size changes */
 int SIGINFO = 29     /* information request */
 pub int SIGUSR1 = 30     /* user defined signal 1 */
 pub int SIGUSR2 = 31     /* user defined signal 2 */
@@ -720,7 +720,7 @@ pub fn stat_is_dir(u16 mode):bool {
     return (mode & S_IFMT) == S_IFDIR
 }
 
-fn stat_is_fifo(u16 mode):bool {
+pub fn stat_is_fifo(u16 mode):bool {
     return (mode & S_IFMT) == S_IFIFO
 }
 
@@ -732,7 +732,7 @@ pub fn stat_is_reg(u16 mode):bool {
     return (mode & S_IFMT) == S_IFREG
 }
 
-fn stat_is_sock(u16 mode):bool {
+pub fn stat_is_sock(u16 mode):bool {
     return (mode & S_IFMT) == S_IFSOCK
 }
 pub fn stat(string filename):stat_t! {
@@ -759,7 +759,7 @@ pub fn rename(string oldpath, string newpath):void! {
     call6(SYS_RENAME, oldpath.ref(), newpath.ref(), 0, 0, 0, 0)
 }
 
-fn exit(int status):void! {
+pub fn exit(int status):void! {
     call6(SYS_EXIT, status as anyptr, 0, 0, 0, 0, 0)
 }
 

--- a/std/syscall/syscall.linux_amd64.n
+++ b/std/syscall/syscall.linux_amd64.n
@@ -408,7 +408,7 @@ int SIGCHLD = 0x11
 int SIGCLD = 0x11
 int SIGCONT = 0x12
 int SIGFPE = 0x8
-int SIGHUP = 0x1
+pub int SIGHUP = 0x1
 int SIGILL = 0x4
 pub int SIGINT = 0x2
 int SIGIO = 0x1d
@@ -425,7 +425,7 @@ int SIGSTOP = 0x13
 int SIGSYS = 0x1f
 pub int SIGTERM = 0xf
 int SIGTRAP = 0x5
-int SIGTSTP = 0x14
+pub int SIGTSTP = 0x14
 int SIGTTIN = 0x15
 int SIGTTOU = 0x16
 int SIGUNUSED = 0x1f
@@ -433,7 +433,7 @@ int SIGURG = 0x17
 pub int SIGUSR1 = 0xa
 pub int SIGUSR2 = 0xc
 int SIGVTALRM = 0x1a
-int SIGWINCH = 0x1c
+pub int SIGWINCH = 0x1c
 int SIGXCPU = 0x18
 int SIGXFSZ = 0x19
 
@@ -640,7 +640,7 @@ pub fn stat_is_dir(u32 mode):bool {
     return (mode & S_IFMT) == S_IFDIR
 }
 
-fn stat_is_fifo(u32 mode):bool {
+pub fn stat_is_fifo(u32 mode):bool {
     return (mode & S_IFMT) == S_IFIFO
 }
 
@@ -650,7 +650,7 @@ pub fn stat_is_reg(u32 mode):bool {
 fn stat_is_lnk(u32 mode):bool {
     return (mode & S_IFMT) == S_IFLNK
 }
-fn stat_is_sock(u32 mode):bool {
+pub fn stat_is_sock(u32 mode):bool {
     return (mode & S_IFMT) == S_IFSOCK
 }
 pub fn stat(string filename):stat_t! {
@@ -686,7 +686,7 @@ pub fn rename(string oldpath, string newpath):void! {
     call6(SYS_RENAME, oldpath.ref(), newpath.ref(), 0, 0, 0, 0)
 }
 
-fn exit(int status):void! {
+pub fn exit(int status):void! {
     call6(SYS_EXIT_GROUP, status as anyptr, 0, 0, 0, 0, 0)
 }
 

--- a/std/syscall/syscall.linux_arm64.n
+++ b/std/syscall/syscall.linux_arm64.n
@@ -423,7 +423,7 @@ int SIGCHLD = 0x11
 int SIGCLD = 0x11
 int SIGCONT = 0x12
 int SIGFPE = 0x8
-int SIGHUP = 0x1
+pub int SIGHUP = 0x1
 int SIGILL = 0x4
 pub int SIGINT = 0x2
 int SIGIO = 0x1d
@@ -440,7 +440,7 @@ int SIGSTOP = 0x13
 int SIGSYS = 0x1f
 pub int SIGTERM = 0xf
 int SIGTRAP = 0x5
-int SIGTSTP = 0x14
+pub int SIGTSTP = 0x14
 int SIGTTIN = 0x15
 int SIGTTOU = 0x16
 int SIGUNUSED = 0x1f
@@ -448,7 +448,7 @@ int SIGURG = 0x17
 pub int SIGUSR1 = 0xa
 pub int SIGUSR2 = 0xc
 int SIGVTALRM = 0x1a
-int SIGWINCH = 0x1c
+pub int SIGWINCH = 0x1c
 int SIGXCPU = 0x18
 int SIGXFSZ = 0x19
 
@@ -669,7 +669,7 @@ pub fn stat_is_dir(u32 mode):bool {
     return (mode & S_IFMT) == S_IFDIR
 }
 
-fn stat_is_fifo(u32 mode):bool {
+pub fn stat_is_fifo(u32 mode):bool {
     return (mode & S_IFMT) == S_IFIFO
 }
 
@@ -679,7 +679,7 @@ pub fn stat_is_reg(u32 mode):bool {
 fn stat_is_lnk(u32 mode):bool {
     return (mode & S_IFMT) == S_IFLNK
 }
-fn stat_is_sock(u32 mode):bool {
+pub fn stat_is_sock(u32 mode):bool {
     return (mode & S_IFMT) == S_IFSOCK
 }
 pub fn stat(string filename):stat_t! {
@@ -708,7 +708,7 @@ pub fn rename(string oldpath, string newpath):void! {
     call6(SYS_RENAMEAT, AT_FDCWD as anyptr, oldpath.ref(), AT_FDCWD as anyptr, newpath.ref(), 0, 0)
 }
 
-fn exit(int status):void! {
+pub fn exit(int status):void! {
     call6(SYS_EXIT_GROUP, status as anyptr, 0, 0, 0, 0, 0)
 }
 

--- a/std/syscall/syscall.linux_riscv64.n
+++ b/std/syscall/syscall.linux_riscv64.n
@@ -423,7 +423,7 @@ int SIGCHLD = 0x11
 int SIGCLD = 0x11
 int SIGCONT = 0x12
 int SIGFPE = 0x8
-int SIGHUP = 0x1
+pub int SIGHUP = 0x1
 int SIGILL = 0x4
 pub int SIGINT = 0x2
 int SIGIO = 0x1d
@@ -440,7 +440,7 @@ int SIGSTOP = 0x13
 int SIGSYS = 0x1f
 pub int SIGTERM = 0xf
 int SIGTRAP = 0x5
-int SIGTSTP = 0x14
+pub int SIGTSTP = 0x14
 int SIGTTIN = 0x15
 int SIGTTOU = 0x16
 int SIGUNUSED = 0x1f
@@ -448,7 +448,7 @@ int SIGURG = 0x17
 pub int SIGUSR1 = 0xa
 pub int SIGUSR2 = 0xc
 int SIGVTALRM = 0x1a
-int SIGWINCH = 0x1c
+pub int SIGWINCH = 0x1c
 int SIGXCPU = 0x18
 int SIGXFSZ = 0x19
 
@@ -669,7 +669,7 @@ pub fn stat_is_dir(u32 mode):bool {
     return (mode & S_IFMT) == S_IFDIR
 }
 
-fn stat_is_fifo(u32 mode):bool {
+pub fn stat_is_fifo(u32 mode):bool {
     return (mode & S_IFMT) == S_IFIFO
 }
 
@@ -679,7 +679,7 @@ pub fn stat_is_reg(u32 mode):bool {
 fn stat_is_lnk(u32 mode):bool {
     return (mode & S_IFMT) == S_IFLNK
 }
-fn stat_is_sock(u32 mode):bool {
+pub fn stat_is_sock(u32 mode):bool {
     return (mode & S_IFMT) == S_IFSOCK
 }
 pub fn stat(string filename):stat_t! {
@@ -708,7 +708,7 @@ pub fn rename(string oldpath, string newpath):void! {
     call6(SYS_RENAMEAT2, AT_FDCWD as anyptr, oldpath.ref(), AT_FDCWD as anyptr, newpath.ref(), 0, 0)
 }
 
-fn exit(int status):void! {
+pub fn exit(int status):void! {
     call6(SYS_EXIT_GROUP, status as anyptr, 0, 0, 0, 0, 0)
 }
 

--- a/std/syscall/syscall.windows_amd64.n
+++ b/std/syscall/syscall.windows_amd64.n
@@ -197,7 +197,7 @@ fn stat_is_chr(u32 mode): bool {
 pub fn stat_is_dir(u32 mode): bool {
     return (mode & S_IFMT) == S_IFDIR
 }
-fn stat_is_fifo(u32 mode): bool {
+pub fn stat_is_fifo(u32 mode): bool {
     return (mode & S_IFMT) == S_IFIFO
 }
 pub fn stat_is_reg(u32 mode): bool {
@@ -206,7 +206,7 @@ pub fn stat_is_reg(u32 mode): bool {
 fn stat_is_lnk(u32 mode): bool {
     return (mode & S_IFMT) == S_IFLNK
 }
-fn stat_is_sock(u32 mode): bool {
+pub fn stat_is_sock(u32 mode): bool {
     return (mode & S_IFMT) == S_IFSOCK
 }
 pub fn stat(string filename): stat_t! {
@@ -267,7 +267,7 @@ pub fn chmod(string path, u32 mode): void! {
         throw errorf(libc.error_string())
     }
 }
-fn exit(int status): void! {
+pub fn exit(int status): void! {
     windows_exit(status as i32)
 }
 pub fn getpid(): int! {

--- a/std/time/time.n
+++ b/std/time/time.n
@@ -18,7 +18,7 @@ pub fn time_t.ms_timestamp(self):i64 {
     return self.sec * 1000 + self.nsec / 1000000
 }
 
-fn time_t.ns_timestamp(self):i64 {
+pub fn time_t.ns_timestamp(self):i64 {
     return self.sec * 1000000000 + self.nsec
 }
 


### PR DESCRIPTION
## Summary

The pub visibility refactor ("require labels before pub declarations") made non-pub top-level declarations module-private, but the std conversion left many exports unmarked: top-level functions such as `syscall.exit` and `fs.stdin`, constants, and module-level variables across ~40 std modules. Programs that legitimately called those APIs across modules now fail with `undefined: ...`.

## Fix

Add `pub` to every remaining non-`#local` top-level function, type, constant and module variable in `std/`. This mirrors the visibility the std already granted before the refactor.

## Verification

- The adou CLI (a Nature program importing `syscall`, `fs`, `http.client`, `io.buf` and more) compiles and its 50 test files pass against this std; before the patch the first build stops at `undefined: syscall.exit`.
- `ctest` std cases still pass with the restored exports.