### PR TITLE
fix(strings): preserve single token in split

### DIFF
--- a/std/strings/strings.n
+++ b/std/strings/strings.n
@@ -145,7 +145,8 @@ pub fn string.split(self, string separator):[string] {
         return result
     }
 
-    if self.len() <= separator.len() {
+    if self.len() < separator.len() {
+        result.push(self)
         return result
     }
 

--- a/tests/features/20260809_00_string_split.c
+++ b/tests/features/20260809_00_string_split.c
@@ -1,0 +1,19 @@
+#include "tests/test.h"
+
+static void test_basic() {
+    char *raw = exec_output();
+    char *expected = "1\n"
+                     "0\n"
+                     "1\n"
+                     "0\n"
+                     "1\n"
+                     "word\n"
+                     "2\n"
+                     "1\n"
+                     "2\n";
+    assert_string_equal(raw, expected);
+}
+
+int main(void) {
+    TEST_BASIC
+}

--- a/tests/features/cases/20260809_00_string_split.n
+++ b/tests/features/cases/20260809_00_string_split.n
@@ -1,0 +1,15 @@
+import strings
+
+fn dump([string] parts) {
+    println(parts.len())
+    for part in parts {
+        println(part)
+    }
+}
+
+fn main() {
+    dump('0'.split(';'))
+    dump('0'.split(';;'))
+    dump('word'.split(';'))
+    dump('1;2'.split(';'))
+}


### PR DESCRIPTION
## Summary

- return a non-empty input as the only token when the separator is longer
- let equal-length inputs use the normal separator search instead of returning early
- add regression coverage for single-token, longer-separator, and multi-token cases

## Testing

- `cmake --build build --target 20260809_00_string_split 20230901_00_strings -- -j8`
- `ctest --test-dir build -R "^(20260809_00_string_split|20230901_00_strings)$" -V`

Fixes #289