### PR TITLE
fix(compiler): preserve dereferenced pointer receivers

### DIFF
--- a/src/linear.c
+++ b/src/linear.c
@@ -2329,6 +2329,20 @@ static lir_operand_t *linear_binary(module_t *m, ast_expr_t expr, lir_operand_t 
 static lir_operand_t *linear_unary(module_t *m, ast_expr_t expr, lir_operand_t *target) {
     ast_unary_expr_t *unary_expr = expr.value;
 
+    // Preserve the original lvalue for &(*p). Evaluating *p first copies
+    // indirect values such as vec and struct headers into a temporary, so a
+    // pointer-receiver method would mutate the temporary instead of *p.
+    if (unary_expr->op == AST_OP_LA && unary_expr->operand.assert_type == AST_EXPR_UNARY) {
+        ast_unary_expr_t *inner_unary = unary_expr->operand.value;
+        if (inner_unary->op == AST_OP_IA) {
+            lir_operand_t *src = linear_expr(m, inner_unary->operand, NULL);
+            if (!target) {
+                target = temp_var_operand_with_alloc(m, expr.type);
+            }
+            return linear_super_move(m, expr.type, target, src);
+        }
+    }
+
     lir_operand_t *first = linear_expr(m, unary_expr->operand, NULL);
 
     // 判断 first 的类型，如果是 imm 数，则直接对 int_value 取反，否则使用 lir minus  指令编译

--- a/tests/features/20260809_01_deref_receiver.c
+++ b/tests/features/20260809_01_deref_receiver.c
@@ -1,0 +1,14 @@
+#include "tests/test.h"
+
+static void test_basic() {
+    char *raw = exec_output();
+    char *expected = "issue: 1 42\n"
+                     "field: 1 7\n"
+                     "method: 1\n"
+                     "copy: 0\n";
+    assert_string_equal(raw, expected);
+}
+
+int main(void) {
+    TEST_BASIC
+}

--- a/tests/features/cases/20260809_01_deref_receiver.n
+++ b/tests/features/cases/20260809_01_deref_receiver.n
@@ -1,0 +1,42 @@
+type holder_t = struct {
+    [int] values
+}
+
+type counter_t = struct {
+    int value
+}
+
+fn counter_t.increment(*self) {
+    self.value = self.value + 1
+}
+
+fn append_value(ptr<[int]> values, int value) {
+    (*values).push(value)
+}
+
+fn increment_value(ptr<counter_t> counter) {
+    (*counter).increment()
+}
+
+fn append_copy(ptr<[int]> values) {
+    var copied = *values
+    copied.push(99)
+}
+
+fn main() {
+    [int] values = []
+    append_value(&values, 42)
+    println('issue:', values.len(), values[0])
+
+    var holder = holder_t{values: []}
+    append_value(&holder.values, 7)
+    println('field:', holder.values.len(), holder.values[0])
+
+    var counter = counter_t{value: 0}
+    increment_value(&counter)
+    println('method:', counter.value)
+
+    [int] original = []
+    append_copy(&original)
+    println('copy:', original.len())
+}


### PR DESCRIPTION
## Summary

- preserve the original lvalue when lowering `&(*p)` instead of materializing `*p` into a temporary
- make pointer-receiver mutations update vector headers reached through `ptr<[T]>` and struct fields
- cover custom `*self` methods while retaining explicit dereference-copy semantics

## Testing

- `cmake --build build --target nature 20260809_01_deref_receiver 20240316_02_unary_ia 20240329_00_struct_ptr -- -j8`
- `ctest --test-dir build -R "^(20260809_01_deref_receiver|20240316_02_unary_ia|20240329_00_struct_ptr)$" -V`

Fixes #263