### PR TITLE
fix(compiler): align global symbols

### DIFF
--- a/src/binary/coff/coff_amd64.c
+++ b/src/binary/coff/coff_amd64.c
@@ -473,8 +473,9 @@ static coff_writer_status_t coff_amd64_emit_globals(
                 context->module->asm_global_symbols->take[i];
         if (coff_amd64_is_unwind_plan_name(symbol->name)) continue;
         uint32_t offset = 0U;
+        uint32_t alignment = symbol->alignment ? symbol->alignment : 1U;
         coff_writer_status_t status = coff_section_append(
-                context->data, symbol->value, symbol->size, 1U, &offset);
+                context->data, symbol->value, symbol->size, alignment, &offset);
         if (status != COFF_WRITER_OK)
             return coff_amd64_writer_status(context, status);
         status = coff_object_define_symbol(

--- a/src/binary/elf/linker.c
+++ b/src/binary/elf/linker.c
@@ -859,15 +859,23 @@ uint64_t elf_put_str(section_t *s, char *str) {
     return offset;
 }
 
-uint64_t elf_put_data(section_t *s, uint8_t *data, uint64_t size) {
-    char *ptr = section_ptr_add(s, size);
+uint64_t elf_put_data_aligned(section_t *s, uint8_t *data, uint64_t size, uint64_t alignment) {
+    if (alignment == 0) {
+        alignment = 1;
+    }
+    size_t offset = elf_section_data_forward(s, size, alignment);
+    uint8_t *ptr = s->data + offset;
     // 如果 data 为 null, 则填入 0
     if (data) {
         memmove(ptr, data, size);
     } else {
         memset(ptr, 0, size);
     }
-    return (uint64_t) ptr - (uint64_t) s->data;
+    return offset;
+}
+
+uint64_t elf_put_data(section_t *s, uint8_t *data, uint64_t size) {
+    return elf_put_data_aligned(s, data, size, 1);
 }
 
 /**

--- a/src/binary/linker.h
+++ b/src/binary/linker.h
@@ -118,6 +118,8 @@ uint64_t elf_put_str(section_t *s, char *str);
 
 uint64_t elf_put_data(section_t *s, uint8_t *data, uint64_t size);
 
+uint64_t elf_put_data_aligned(section_t *s, uint8_t *data, uint64_t size, uint64_t alignment);
+
 void elf_resolve_common_symbols(elf_context_t *ctx);
 
 void elf_build_got_entries(elf_context_t *ctx, uint64_t got_sym_index);

--- a/src/binary/mach/mach.h
+++ b/src/binary/mach/mach.h
@@ -116,7 +116,8 @@ static inline void macho_section_realloc(mach_section_t *section, int64_t new_si
  * macho 对齐 2 的 ^
  */
 static inline size_t macho_section_data_forward(mach_section_t *ms, uint64_t size, uint64_t align) {
-    align = 1 << align;
+    uint64_t align_log2 = align;
+    align = 1ULL << align_log2;
 
     size_t offset, offset_end;
     offset = (ms->data_offset + align - 1) & -align;
@@ -127,8 +128,8 @@ static inline size_t macho_section_data_forward(mach_section_t *ms, uint64_t siz
     }
     ms->data_offset = offset_end; // forward
 
-    if (align > ms->section.align) {
-        ms->section.align = align;
+    if (align_log2 > ms->section.align) {
+        ms->section.align = align_log2;
     }
 
     return offset;
@@ -139,16 +140,30 @@ static inline void *mach_section_ptr_add(mach_section_t *ms, uint64_t size) {
     return ms->data + offset;
 }
 
-static inline int64_t mach_put_data(mach_section_t *ms, uint8_t *data, int64_t size) {
-    char *ptr = mach_section_ptr_add(ms, size);
+static inline int64_t mach_put_data_aligned(mach_section_t *ms, uint8_t *data, int64_t size, uint64_t alignment) {
+    if (alignment == 0) {
+        alignment = 1;
+    }
+    assert((alignment & (alignment - 1)) == 0);
 
+    uint64_t align_log2 = 0;
+    while ((1ULL << align_log2) < alignment) {
+        ++align_log2;
+    }
+
+    size_t offset = macho_section_data_forward(ms, size, align_log2);
+    char *ptr = (char *) ms->data + offset;
     if (data) {
         memmove(ptr, data, size);
     } else {
         memset(ptr, 0, size);
     }
 
-    return (int64_t) ptr - (int64_t) ms->data;
+    return offset;
+}
+
+static inline int64_t mach_put_data(mach_section_t *ms, uint8_t *data, int64_t size) {
+    return mach_put_data_aligned(ms, data, size, 1);
 }
 
 static uint64_t mach_put_str(mach_section_t *str_table, string_view_t *str) {

--- a/src/build/build.c
+++ b/src/build/build.c
@@ -510,7 +510,8 @@ static void elf_assembler_module(module_t *m) {
     for (int i = 0; i < m->asm_global_symbols->count; ++i) {
         asm_global_symbol_t *symbol = m->asm_global_symbols->take[i];
         // 写入到数据段
-        uint64_t offset = elf_put_data(ctx->data_section, symbol->value, symbol->size);
+        uint64_t offset =
+                elf_put_data_aligned(ctx->data_section, symbol->value, symbol->size, symbol->alignment);
 
         // 写入符号表
         Elf64_Sym sym = {
@@ -557,7 +558,8 @@ static void mach_assembler_module(module_t *m) {
     for (int i = 0; i < m->asm_global_symbols->count; ++i) {
         asm_global_symbol_t *symbol = m->asm_global_symbols->take[i];
         // 写入到数据段
-        uint64_t offset = mach_put_data(ctx->data_section, symbol->value, symbol->size);
+        uint64_t offset =
+                mach_put_data_aligned(ctx->data_section, symbol->value, symbol->size, symbol->alignment);
 
         // 写入符号表
         mach_put_sym(ctx->symtab_command, &(struct nlist_64) {
@@ -1315,6 +1317,7 @@ static void build_assembler(slice_t *modules) {
             asm_global_symbol_t *symbol = NEW(asm_global_symbol_t);
             symbol->name = var_decl->ident;
             symbol->size = var_decl->type.storage_size;
+            symbol->alignment = var_decl->type.align > 0 ? var_decl->type.align : 1;
             symbol->value = vardef->global_data;
             slice_push(m->asm_global_symbols, symbol);
         }

--- a/src/lower/lower.h
+++ b/src/lower/lower.h
@@ -24,12 +24,15 @@ static inline void lower_imm_symbol(closure_t *c, lir_operand_t *imm_operand, li
         if (imm->kind == TYPE_RAW_STRING) {
             assert(imm->string_value);
             global_symbol->size = imm->strlen + 1;
+            global_symbol->alignment = 1;
             global_symbol->value = (uint8_t *) imm->string_value;
         } else if (imm->kind == TYPE_FLOAT64) {
             global_symbol->size = type_kind_sizeof(imm->kind);
+            global_symbol->alignment = type_kind_sizeof(imm->kind);
             global_symbol->value = (uint8_t *) &imm->f64_value;
         } else if (imm->kind == TYPE_FLOAT32) {
             global_symbol->size = type_kind_sizeof(imm->kind);
+            global_symbol->alignment = type_kind_sizeof(imm->kind);
             global_symbol->value = (uint8_t *) &imm->f32_value;
         } else {
             assertf(false, "not support type %s", type_kind_str[imm->kind]);

--- a/src/types.h
+++ b/src/types.h
@@ -73,6 +73,7 @@ typedef enum {
 typedef struct {
     char *name; // 符号名称
     size_t size; // 符号大小，单位 byte, 生成符号表的时候需要使用
+    uint32_t alignment; // 符号的自然对齐，单位 byte；0 等同于 1
     uint8_t *value; // 符号值
 } asm_global_symbol_t;
 

--- a/tests/features/20260809_02_global_alignment.c
+++ b/tests/features/20260809_02_global_alignment.c
@@ -1,0 +1,14 @@
+#include "tests/test.h"
+
+static void test_basic() {
+    char *raw = exec_output();
+    char *expected = "i16: 0\n"
+                     "i32: 0\n"
+                     "i64: 0\n"
+                     "struct: 0\n";
+    assert_string_equal(raw, expected);
+}
+
+int main(void) {
+    TEST_BASIC
+}

--- a/tests/features/cases/20260809_02_global_alignment.n
+++ b/tests/features/cases/20260809_02_global_alignment.n
@@ -1,0 +1,23 @@
+type aligned_t = struct {
+    i64 value
+}
+
+u8 prefix_i16 = 1
+i16 global_i16 = 2
+u8 prefix_i32 = 1
+i32 global_i32 = 3
+u8 prefix_i64 = 1
+i64 global_i64 = 4
+u8 prefix_struct = 1
+aligned_t global_struct = aligned_t{value: 5}
+
+fn remainder(anyptr value, int alignment):int {
+    return (value as int) % alignment
+}
+
+fn main() {
+    println('i16:', remainder(&global_i16 as anyptr, 2))
+    println('i32:', remainder(&global_i32 as anyptr, 4))
+    println('i64:', remainder(&global_i64 as anyptr, 8))
+    println('struct:', remainder(&global_struct as anyptr, 8))
+}


### PR DESCRIPTION
## Summary

- carry each global symbol's existing natural type alignment into the assembler
- align ELF, Mach-O, and COFF data-section offsets before emitting globals
- preserve appropriate alignment for raw-string and floating-point constants
- add a regression test covering 2-, 4-, and 8-byte globals plus an 8-byte-aligned struct

Closes #261

## Verification

- `cmake --build build --target nature 20260809_02_global_alignment test_coff_amd64 -- -j8`
- `ctest --test-dir build -R '^(test_coff_amd64|20250227_00_global_large|20260224_00_global_eval|20260809_02_global_alignment)$' --output-on-failure`
- manually rebuilt the issue reproduction and verified `global_mutex` is 8-byte aligned (`...8028`) and lock/unlock completes

Full test suite was not run.
