### PR TITLE
fix(std): handle dot path segments

### DIFF
--- a/std/path/path.n
+++ b/std/path/path.n
@@ -76,6 +76,10 @@ fn _join(string dst, string src):string {
         return src
     }
 
+    if src == '.' {
+        return dst
+    }
+
     // src 是绝对路径时不进行拼接
     if src[0] == ascii('/') {
         return src

--- a/tests/features/20260809_03_path_join.c
+++ b/tests/features/20260809_03_path_join.c
@@ -1,0 +1,15 @@
+#include "tests/test.h"
+
+static void test_basic() {
+    char *raw = exec_output();
+    char *expected = "/tmp/base\n"
+                     "/tmp/base/a\n"
+                     "/tmp/base/child\n"
+                     ".\n"
+                     "/\n";
+    assert_string_equal(raw, expected);
+}
+
+int main(void) {
+    TEST_BASIC
+}

--- a/tests/features/cases/20260809_03_path_join.n
+++ b/tests/features/cases/20260809_03_path_join.n
@@ -1,0 +1,9 @@
+import path
+
+fn main() {
+    println(path.join('/tmp/base', '.'))
+    println(path.join('/tmp/base', 'a'))
+    println(path.join('/tmp/base', '.', 'child'))
+    println(path.join('', '.'))
+    println(path.join('/', '.'))
+}


### PR DESCRIPTION
## Summary
- treat `.` as the current path when joining path segments
- avoid indexing past the end of a one-byte dot segment
- add focused regression coverage for dot, one-character, multi-segment, empty-base, and root joins

Closes #291

## Testing
- `cmake --build build --target 20260809_03_path_join 20230831_00_std -- -j8`
- `cd build && ctest -R "^(20260809_03_path_join|20230831_00_std)$" -V`

Full test suite was not run; validation was limited to the affected path tests.