### PR TITLE
fix(runtime): keep map storage dense after delete

### DIFF
--- a/runtime/nutils/hash.h
+++ b/runtime/nutils/hash.h
@@ -98,8 +98,13 @@ static uint64_t find_hash_slot(uint64_t *hash_table, uint64_t capacity, uint8_t 
             return first_deleted_index != -1 ? first_deleted_index : hash_index;
         }
 
-        if (hash_value_deleted(hash_value) && first_deleted_index == -1) {
-            first_deleted_index = (int64_t) hash_index;
+        if (hash_value_deleted(hash_value)) {
+            if (first_deleted_index == -1) {
+                first_deleted_index = (int64_t) hash_index;
+            }
+            hash_index = (hash_index + 1) % capacity;
+            attempts++;
+            continue;
         }
 
         // key equal 的 slot 是最高优先且绝对正确的 slot

--- a/runtime/nutils/map.c
+++ b/runtime/nutils/map.c
@@ -203,8 +203,7 @@ n_anyptr_t rt_map_assign(n_map_t *m, void *key_ref) {
     if (hash_value_empty(hash_value)) {
         data_index = m->length++;
     } else if (hash_value_deleted(hash_value)) {
-        m->length++;
-        data_index = extract_data_index(hash_value);
+        data_index = m->length++;
     } else {
         // 绝对的修改
         data_index = extract_data_index(hash_value);
@@ -234,8 +233,35 @@ void rt_map_delete(n_map_t *m, void *key_ref) {
         return;
     }
     uint64_t hash_index = find_hash_slot(m->hash_table, m->capacity, m->key_data, m->key_rtype_hash, key_ref);
-    uint64_t *hash_value = &m->hash_table[hash_index];
-    *hash_value &= 1ULL << HASH_DELETED; // 配置删除标志即可
+    uint64_t hash_value = m->hash_table[hash_index];
+    if (hash_value_empty(hash_value) || hash_value_deleted(hash_value)) {
+        return;
+    }
+
+    uint64_t data_index = extract_data_index(hash_value);
+    uint64_t last_data_index = m->length - 1;
+    rtype_t *key_rtype = rt_find_rtype(m->key_rtype_hash);
+    rtype_t *value_rtype = rt_find_rtype(m->value_rtype_hash);
+    uint64_t key_size = key_rtype->storage_size;
+    uint64_t value_size = value_rtype->storage_size;
+
+    if (data_index != last_data_index) {
+        void *last_key_ref = m->key_data + last_data_index * key_size;
+        void *last_value_ref = m->value_data + last_data_index * value_size;
+        uint64_t last_hash_index = find_hash_slot(m->hash_table,
+                                                  m->capacity,
+                                                  m->key_data,
+                                                  m->key_rtype_hash,
+                                                  last_key_ref);
+
+        rti_write_barrier_rtype(m->key_data + data_index * key_size, last_key_ref, key_rtype);
+        rti_write_barrier_rtype(m->value_data + data_index * value_size, last_value_ref, value_rtype);
+        set_data_index(m, last_hash_index, data_index);
+    }
+
+    m->hash_table[hash_index] = (1ULL << HASH_SET) | (1ULL << HASH_DELETED);
+    memset(m->key_data + last_data_index * key_size, 0, key_size);
+    memset(m->value_data + last_data_index * value_size, 0, value_size);
     m->length--;
 }
 

--- a/tests/features/20260809_04_map_delete.c
+++ b/tests/features/20260809_04_map_delete.c
@@ -1,0 +1,21 @@
+#include "tests/test.h"
+#include <stdio.h>
+
+static void test_basic() {
+    char *raw = exec_output();
+    char *str = "1 false true\n"
+                "{\"b\":true}\n"
+                "2 true false true\n"
+                "{\"a\":1,\"c\":3}\n"
+                "3 true true true\n"
+                "{\"a\":1,\"c\":3,\"d\":4}\n"
+                "3\n"
+                "1 false true 20\n"
+                "2 true true 30 20\n"
+                "{\"q\":20,\"a\":30}\n";
+    assert_string_equal(raw, str);
+}
+
+int main(void) {
+    TEST_BASIC
+}

--- a/tests/features/cases/20260809_04_map_delete.n
+++ b/tests/features/cases/20260809_04_map_delete.n
@@ -1,0 +1,35 @@
+import json
+
+fn main() {
+    var parsed = json.parse('{"a":true,"b":false}') catch e {
+        {string:any} empty = {}
+        empty
+    } as {string:any}
+
+    parsed.del('a')
+    parsed['b'] = true
+    println(parsed.len(), parsed.contains('a'), parsed.contains('b'))
+    println(json.serialize(parsed))
+
+    var plain = {'a': 1, 'b': 2, 'c': 3}
+    plain.del('b')
+    println(plain.len(), plain.contains('a'), plain.contains('b'), plain.contains('c'))
+    println(json.serialize(plain))
+
+    plain['d'] = 4
+    println(plain.len(), plain.contains('a'), plain.contains('c'), plain.contains('d'))
+    println(json.serialize(plain))
+
+    plain.del('missing')
+    println(plain.len())
+
+    // 'a' and 'q' collide at the default map capacity. Deleting the first
+    // key must keep the rest of the probe chain reachable.
+    var collision = {'a': 10, 'q': 20}
+    collision.del('a')
+    println(collision.len(), collision.contains('a'), collision.contains('q'), collision['q'])
+
+    collision['a'] = 30
+    println(collision.len(), collision.contains('a'), collision.contains('q'), collision['a'], collision['q'])
+    println(json.serialize(collision))
+}


### PR DESCRIPTION
Closes #292

## Summary
- compact map key/value storage when deleting an entry
- preserve probe chains with tombstones and reuse tombstone slots safely
- make deleting a missing key a no-op
- add regression coverage for parsed and plain maps, reinsertion, and hash collisions

## Verification
- cmake --build build-runtime --target runtime -- -j8
- cmake --build build --target 20260809_04_map_delete 20221025_09_map 20221025_10_set 20250623_02_json -- -j8
- ctest -R "^(20260809_04_map_delete|20221025_09_map|20221025_10_set|20250623_02_json)$" -V

All 4 focused tests passed. Full test suite was not run.