### PR TITLE
fix(runtime): bound the TLS handshake with the connect timeout

### DIFF
--- a/runtime/nutils/tls.h
+++ b/runtime/nutils/tls.h
@@ -202,6 +202,12 @@ static int mbedtls_recv_cb(void *ctx, unsigned char *buf, size_t len) {
 
     global_waiting_send(uv_async_tls_read, conn, 0, 0);
     // may be error
+    if (conn->read_timeout) {
+        // Map the read timer (armed for handshake reads since
+        // rt_uv_tls_connect) to mbedTLS's own timeout error so the caller
+        // sees "operation timed out" instead of an errno misread.
+        return MBEDTLS_ERR_SSL_TIMEOUT;
+    }
     return (int) conn->read_len;
 }
 
@@ -335,6 +341,12 @@ void rt_uv_tls_connect(n_tls_conn_t *n_conn, n_string_t addr, n_int64_t port, n_
     conn->ref_count = 3;
     n_conn->conn = conn;
     conn->co = co;
+    // The connect timer is stopped once TCP connects (on_tls_connect_cb),
+    // but the mbedtls handshake still reads from the socket.  Without a read
+    // timeout here the handshake can block forever behind a peer that
+    // accepts TCP and then never answers TLS bytes.  Reuse the existing
+    // read-timeout timer path so connect_timeout() bounds the handshake too.
+    conn->read_timeout_ms = timeout_ms;
 
     DEBUGF("[rt_uv_tls_connect] malloc new conn=%p, co=%p, p_index=%d", conn, conn->co, p->index);
 


### PR DESCRIPTION
# Issue: TLS handshake has no timeout after TCP connect succeeds — client hangs forever behind a blackholed proxy

**Nature v0.7.4** (release build 2026-08-09), macOS arm64.  Reproduced with the local source tree at commit `4b9e7563`.

## Summary

`tls.connect_timeout(host, port, timeout_ms)` only applies its timer to the TCP connect phase.  Once the TCP connection is established, the mbedTLS handshake runs with **no timeout at all**: if the peer accepts the connection but never responds to the TLS handshake (e.g. a blackholing proxy/firewall that drops TLS bytes while completing TCP), the calling coroutine blocks forever.  `http.client` requests (which call `tls.connect_timeout` with the configured timeout, e.g. `--timeout-ms 12000`) therefore hang permanently instead of failing after `timeout_ms`.

## Repro

- Point an `http.client` GET/POST at an HTTPS endpoint whose TCP connect succeeds but whose TLS bytes are dropped (any transparent "blackhole" proxy; macOS network filter at `198.18.x.x` reproduces it).
- Wait any amount of time: the request never returns, `--timeout-ms`/`request.timeout(ms)` is never observed, and no read timeout fires either.

Observed in Adou (a Nature app using `http.client`): a provider request hung for 120 s+, ignoring both `timeout_ms` and `--max-retries 0`.

## Root cause

All in `runtime/nutils/tls.h`:

1. `on_tls_connect_cb` stops the connect timer as soon as TCP connects:

   ```c
   if (uv_is_active((uv_handle_t *) &conn->timer)) {
       uv_timer_stop(&conn->timer);
   }
   ```

2. The handshake loop then calls `mbedtls_ssl_handshake`, which on `MBEDTLS_ERR_SSL_WANT_READ` blocks inside `mbedtls_recv_cb` → `global_waiting_send(uv_async_tls_read, ...)`.

3. `uv_async_tls_read` arms a read timer only when `conn->read_timeout_ms > 0`:

   ```c
   if (conn->read_timeout_ms > 0 && !uv_is_closing((uv_handle_t *) &conn->timer)) {
       uv_timer_start(&conn->timer, on_tls_read_timeout_cb, conn->read_timeout_ms, 0);
   }
   ```

   but `read_timeout_ms` is only ever assigned in `rt_uv_tls_read` (the *post-handshake* application-data read).  During the handshake path (`rt_uv_tls_connect` → `mbedtls_recv_cb`) it stays at the `mallocz` default of `0`, so no timer is started.

Result: connect timer stopped (step 1), read timer never started (step 3) → the handshake can wait forever.

## Suggested fix

Carry the connect timeout into the handshake phase, e.g.:

- In `rt_uv_tls_connect`, set `conn->read_timeout_ms = timeout_ms` (so `uv_async_tls_read` arms its existing timer during handshake reads), or
- In `on_tls_connect_cb`, restart the timer instead of stopping it (`uv_timer_start(&conn->timer, on_tls_timeout_cb, <remaining>, 0)`) so the handshake is still bounded.

The first option is the smallest change and reuses the existing `on_tls_read_timeout_cb` machinery.  Note `on_tls_timeout_cb`/`on_tls_read_timeout_cb` already wake the coroutine with an error (`rti_co_throw` + `co_ready`), so the handshake loop will observe the failure via the socket callback.

## Workaround used by the reporter

Application-level watchdog: the affected app (Adou) now arms a coroutine that writes an error and calls `syscall.exit(1)` after the configured budget, because the hung coroutine cannot be interrupted.  This is a stopgap; the runtime should time out the handshake itself.