### PR TITLE
fix(runtime): time out stalled TLS handshakes

### DIFF
--- a/runtime/nutils/tls.h
+++ b/runtime/nutils/tls.h
@@ -202,6 +202,9 @@ static int mbedtls_recv_cb(void *ctx, unsigned char *buf, size_t len) {
 
     global_waiting_send(uv_async_tls_read, conn, 0, 0);
     // may be error
+    if (conn->read_timeout) {
+        return MBEDTLS_ERR_SSL_TIMEOUT;
+    }
     return (int) conn->read_len;
 }
 
@@ -335,6 +338,7 @@ void rt_uv_tls_connect(n_tls_conn_t *n_conn, n_string_t addr, n_int64_t port, n_
     conn->ref_count = 3;
     n_conn->conn = conn;
     conn->co = co;
+    conn->read_timeout_ms = timeout_ms;
 
     DEBUGF("[rt_uv_tls_connect] malloc new conn=%p, co=%p, p_index=%d", conn, conn->co, p->index);
 

--- a/tests/features/20260811_00_tls_handshake_timeout.c
+++ b/tests/features/20260811_00_tls_handshake_timeout.c
@@ -1,0 +1,25 @@
+#include "tests/test.h"
+#include <time.h>
+
+static void test_basic() {
+#ifdef __WINDOWS
+    return;
+#else
+    struct timespec start;
+    struct timespec end;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    alarm(5);
+    char *raw = exec_output();
+    alarm(0);
+    clock_gettime(CLOCK_MONOTONIC, &end);
+
+    int64_t elapsed_ms = (end.tv_sec - start.tv_sec) * 1000 +
+                         (end.tv_nsec - start.tv_nsec) / 1000000;
+    assert_string_equal(raw, "handshake timeout\n");
+    assertf(elapsed_ms < 1000, "TLS handshake timeout took %ldms", elapsed_ms);
+#endif
+}
+
+int main(void) {
+    TEST_BASIC
+}

--- a/tests/features/cases/20260811_00_tls_handshake_timeout.n
+++ b/tests/features/cases/20260811_00_tls_handshake_timeout.n
@@ -1,0 +1,26 @@
+import co
+import net.tcp
+import net.tls
+
+fn blackhole_server():void! {
+    var server = tcp.listen('127.0.0.1:18999')
+    var conn = server.accept()
+
+    // Accept TCP but never reply to the TLS ClientHello.
+    co.sleep(2000)
+    conn.close()
+    server.close()
+}
+
+fn main() {
+    go blackhole_server()
+    co.sleep(100)
+
+    var conn = tls.connect_timeout('127.0.0.1:18999', 100) catch e {
+        println('handshake timeout')
+        return
+    }
+
+    conn.close()
+    println('unexpected handshake success')
+}


### PR DESCRIPTION
Closes #300

## Summary
- apply the connect timeout to TLS handshake reads after TCP connects
- return the mbedTLS timeout code when the libuv read timer fires
- add a deterministic local blackhole server regression test

## Reproduction
Before the fix, a 100ms TLS connect timeout returned only after the blackhole peer closed the socket, taking about 2378ms. After the fix, the client times out before the 1s test upper bound.

## Verification
- cmake --build build-runtime --target runtime -- -j8
- cmake --build build --target 20250802_00_tls 20260730_00_http_timeout 20260806_00_tcp_read_timeout 20260811_00_tls_handshake_timeout -- -j8
- ctest -R "^(20260811_00_tls_handshake_timeout|20250802_00_tls|20260730_00_http_timeout|20260806_00_tcp_read_timeout)$" -V

All 4 focused tests passed. The full test suite was not run.