### PR TITLE
fix(runtime): synchronize short string pool access

### DIFF
--- a/runtime/collector.c
+++ b/runtime/collector.c
@@ -897,11 +897,13 @@ static void scan_pool() {
     // handle n string
     n_processor_t *p = processor_index[0];
     n_string_t *value;
+    mutex_lock(&const_str_pool_locker);
     sc_map_foreach_value(&const_str_pool, value) {
         if (value && span_of((addr_t) value->data)) {
             rt_linked_fixalloc_push(&p->gc_worklist, value->data);
         }
     }
+    mutex_unlock(&const_str_pool_locker);
 }
 
 /**

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -12,6 +12,7 @@ uint64_t next_gc_bytes = 0; // 下一次 gc 的内存量
 bool gc_barrier; // gc 屏障开启标识
 
 struct sc_map_sv const_str_pool;
+mutex_t const_str_pool_locker;
 
 uint8_t gc_stage; // gc 阶段
 mutex_t gc_stage_locker;
@@ -93,6 +94,7 @@ void rtypes_deserialize() {
 
 
 void register_const_str_pool() {
+    mutex_init(&const_str_pool_locker, false);
     sc_map_init_sv(&const_str_pool, 1024, 0);
     for (int i = 0; i < rt_symdef_count; ++i) {
         symdef_t s = rt_symdef_ptr[i];

--- a/runtime/memory.h
+++ b/runtime/memory.h
@@ -22,6 +22,7 @@ extern atomic_size_t allocated_bytes; // 当前分配的内存空间
 extern uint64_t next_gc_bytes; // 下一次 gc 的内存量
 extern bool gc_barrier; // gc 屏障开启标识
 extern struct sc_map_sv const_str_pool;
+extern mutex_t const_str_pool_locker;
 
 extern uint8_t gc_stage; // gc 阶段
 extern mutex_t gc_stage_locker;

--- a/runtime/nutils/string.c
+++ b/runtime/nutils/string.c
@@ -20,10 +20,14 @@ n_string_t string_new_with_pool(void *raw_string, int64_t length) {
     DEBUGF("[string_new_with_pool] raw_string=%s, length=%lu, ptr=%p", (char *) raw_string, length, raw_string);
 
     // check const
+    mutex_lock(&const_str_pool_locker);
     n_string_t *pooled = sc_map_get_sv(&const_str_pool, (char *) raw_string);
     if (pooled && pooled->length == length) {
-        return *pooled;
+        n_string_t result = *pooled;
+        mutex_unlock(&const_str_pool_locker);
+        return result;
     }
+    mutex_unlock(&const_str_pool_locker);
     DEBUGF("[string_new_with_pool] not match, raw %s, length %ld, map get %s", (char *) raw_string, length,
            pooled ? (char *) pooled->data : "-");
 
@@ -50,7 +54,20 @@ n_string_t string_new_with_pool(void *raw_string, int64_t length) {
         n_string_t *pool_copy = malloc(sizeof(n_string_t));
         if (pool_copy != NULL) {
             *pool_copy = str;
-            sc_map_put_sv(&const_str_pool, (char *) raw_string, pool_copy);
+
+            mutex_lock(&const_str_pool_locker);
+            pooled = sc_map_get_sv(&const_str_pool, (char *) raw_string);
+            if (pooled && pooled->length == length) {
+                str = *pooled;
+                mutex_unlock(&const_str_pool_locker);
+                free(pool_copy);
+                return str;
+            }
+
+            // The map keeps key pointers instead of copying the bytes. Point
+            // the key at the pooled string so GC keeps both alive together.
+            sc_map_put_sv(&const_str_pool, (char *) pool_copy->data, pool_copy);
+            mutex_unlock(&const_str_pool_locker);
         }
     }
 

--- a/tests/features/20260812_00_const_string_pool.c
+++ b/tests/features/20260812_00_const_string_pool.c
@@ -1,0 +1,5 @@
+#include "tests/test.h"
+
+int main(void) {
+    TEST_EXEC_IMM
+}

--- a/tests/features/cases/20260812_00_const_string_pool.n
+++ b/tests/features/cases/20260812_00_const_string_pool.n
@@ -1,0 +1,34 @@
+import fmt
+
+const WORKERS = 64
+const ITERATIONS = 20000
+
+fn churn(int worker, chan<int> start, chan<int> done): void! {
+	start.recv()
+	int total = 0
+	for int i = 0; i < ITERATIONS; i += 1 {
+		string value = fmt.sprintf('%06d', (worker * ITERATIONS + i) % 1000000)
+		total += value.len()
+	}
+	done.send(total)
+}
+
+fn main(): void! {
+	var start = chan<int>.new(WORKERS)
+	var done = chan<int>.new(WORKERS)
+
+	for int worker = 0; worker < WORKERS; worker += 1 {
+		go churn(worker, start, done)
+	}
+
+	for int worker = 0; worker < WORKERS; worker += 1 {
+		start.send(worker)
+	}
+
+	int total = 0
+	for int worker = 0; worker < WORKERS; worker += 1 {
+		total += done.recv()
+	}
+
+	assert(total == WORKERS * ITERATIONS * 6)
+}


### PR DESCRIPTION
## Summary

- serialize `const_str_pool` lookups, inserts, and GC traversal with one runtime mutex
- re-check the pool while holding the lock before inserting, so concurrent creators reuse the winning entry
- store dynamic map keys in the pooled, GC-rooted string buffer instead of a transient vec buffer
- add a regression test that formats 1.28 million short strings across 64 coroutines

## Root cause

`string_new_with_pool` mutated the global `sc_map_sv` without synchronization. Concurrent inserts could remap and free the map storage while another processor was still reading or writing it, producing the `sc_map_put_sv` / `malloc_zone_error` abort from #302.

Dynamic entries also used the caller's temporary `raw_string` buffer as the map key even though `sc_map` retains key pointers. Using the pooled string's data keeps the key valid for the entry's lifetime.

The critical section only covers map operations; Nature heap allocation remains outside the lock.

## Validation

- before the fix, the regression program aborted with exit 134 in 10/10 runs
- after the fix, the standalone regression passed in 10/10 runs
- `cmake --build build-runtime --target runtime`
- `ctest --test-dir build-release -R '^20260812_00_const_string_pool$' --output-on-failure`
- `ctest --test-dir build-release -j1 -R '^(20230727_00_string|20230809_01_sprintf|20230501_00_gc)$' --output-on-failure`

Closes #302
