### PR TITLE
fix(macho): emit re-signable __LINKEDIT layout

### DIFF
--- a/src/ld/ld_macho.c
+++ b/src/ld/ld_macho.c
@@ -3298,13 +3298,14 @@ static size_t ld_write_load_commands(ld_context_t *ctx, uint8_t *image, const ld
     dyld.cmd = LD_LC_DYLD_INFO_ONLY;
     dyld.cmdsize = sizeof(dyld);
     dyld.rebase_off = linkedit->rebaseoff;
-    dyld.rebase_size = (uint32_t) linkedit->rebase.size;
+    dyld.rebase_size = (uint32_t) ld_align_up(linkedit->rebase.size, 8);
     dyld.bind_off = linkedit->bindoff;
-    dyld.bind_size = (uint32_t) linkedit->bind.size;
+    dyld.bind_size = (uint32_t) ld_align_up(linkedit->bind.size, 8);
     dyld.weak_bind_off = linkedit->weak_bindoff;
-    dyld.weak_bind_size = (uint32_t) linkedit->weak_bind.size;
+    dyld.weak_bind_size = (uint32_t) ld_align_up(linkedit->weak_bind.size, 8);
+    dyld.lazy_bind_off = linkedit->exportoff;
     dyld.export_off = linkedit->exportoff;
-    dyld.export_size = (uint32_t) linkedit->exports.size;
+    dyld.export_size = linkedit->exportsize;
     memcpy(image + position, &dyld, sizeof(dyld));
     position += sizeof(dyld);
 
@@ -3550,9 +3551,11 @@ static int ld_emit_image(ld_context_t *ctx) {
     if (result != LD_OK) goto cleanup;
     result = ld_make_symbol_tables(ctx, &linkedit);
     if (result != LD_OK) goto cleanup;
-    if (linkedit.rebase.size > UINT32_MAX || linkedit.bind.size > UINT32_MAX ||
-        linkedit.weak_bind.size > UINT32_MAX ||
-        linkedit.exports.size > UINT32_MAX || linkedit.function_starts.size > UINT32_MAX ||
+    if (linkedit.rebase.size > UINT32_MAX - 7U ||
+        linkedit.bind.size > UINT32_MAX - 7U ||
+        linkedit.weak_bind.size > UINT32_MAX - 7U ||
+        linkedit.exports.size > UINT32_MAX - 7U ||
+        linkedit.function_starts.size > UINT32_MAX ||
         linkedit.data_in_code.size > UINT32_MAX || linkedit.symtab.size > UINT32_MAX ||
         linkedit.strtab.size > UINT32_MAX || linkedit.indirect.size > UINT32_MAX) {
         result = ld_fail(ctx, LD_OUTPUT_ERROR, "linkedit table exceeds Mach-O 32-bit size fields");
@@ -3569,8 +3572,7 @@ static int ld_emit_image(ld_context_t *ctx) {
         result = ld_fail(ctx, LD_OUTPUT_ERROR, "linkedit data is too large");
         goto cleanup;
     }
-    cursor += linkedit.rebase.size;
-    cursor = ld_align_up(cursor, 8);
+    cursor += ld_align_up(linkedit.rebase.size, 8);
     if (cursor > UINT32_MAX) {
         result = ld_fail(ctx, LD_OUTPUT_ERROR, "linkedit offset is too large");
         goto cleanup;
@@ -3580,8 +3582,7 @@ static int ld_emit_image(ld_context_t *ctx) {
         result = ld_fail(ctx, LD_OUTPUT_ERROR, "linkedit data is too large");
         goto cleanup;
     }
-    cursor += linkedit.bind.size;
-    cursor = ld_align_up(cursor, 8);
+    cursor += ld_align_up(linkedit.bind.size, 8);
     if (cursor > UINT32_MAX) {
         result = ld_fail(ctx, LD_OUTPUT_ERROR, "linkedit offset is too large");
         goto cleanup;
@@ -3591,8 +3592,7 @@ static int ld_emit_image(ld_context_t *ctx) {
         result = ld_fail(ctx, LD_OUTPUT_ERROR, "weak bind data is too large");
         goto cleanup;
     }
-    cursor += linkedit.weak_bind.size;
-    cursor = ld_align_up(cursor, 8);
+    cursor += ld_align_up(linkedit.weak_bind.size, 8);
     if (cursor > UINT32_MAX) {
         result = ld_fail(ctx, LD_OUTPUT_ERROR, "linkedit offset is too large");
         goto cleanup;
@@ -3602,42 +3602,8 @@ static int ld_emit_image(ld_context_t *ctx) {
         result = ld_fail(ctx, LD_OUTPUT_ERROR, "export trie is too large");
         goto cleanup;
     }
-    linkedit.exportsize = (uint32_t) linkedit.exports.size;
-    cursor += linkedit.exports.size;
-    cursor = ld_align_up(cursor, 8);
-    if (cursor > UINT32_MAX) {
-        result = ld_fail(ctx, LD_OUTPUT_ERROR, "linkedit offset is too large");
-        goto cleanup;
-    }
-    linkedit.symoff = (uint32_t) cursor;
-    if (linkedit.symtab.size > UINT64_MAX - cursor) {
-        result = ld_fail(ctx, LD_OUTPUT_ERROR, "symbol table is too large");
-        goto cleanup;
-    }
-    cursor += linkedit.symtab.size;
-    cursor = ld_align_up(cursor, 8);
-    if (cursor > UINT32_MAX) {
-        result = ld_fail(ctx, LD_OUTPUT_ERROR, "linkedit offset is too large");
-        goto cleanup;
-    }
-    linkedit.stroff = (uint32_t) cursor;
-    if (linkedit.strtab.size > UINT64_MAX - cursor) {
-        result = ld_fail(ctx, LD_OUTPUT_ERROR, "string table is too large");
-        goto cleanup;
-    }
-    cursor += linkedit.strtab.size;
-    cursor = ld_align_up(cursor, 8);
-    if (cursor > UINT32_MAX) {
-        result = ld_fail(ctx, LD_OUTPUT_ERROR, "linkedit offset is too large");
-        goto cleanup;
-    }
-    linkedit.indirectoff = (uint32_t) cursor;
-    if (linkedit.indirect.size > UINT64_MAX - cursor) {
-        result = ld_fail(ctx, LD_OUTPUT_ERROR, "indirect symbol table is too large");
-        goto cleanup;
-    }
-    cursor += linkedit.indirect.size;
-    cursor = ld_align_up(cursor, 8);
+    linkedit.exportsize = (uint32_t) ld_align_up(linkedit.exports.size, 8);
+    cursor += linkedit.exportsize;
     if (cursor > UINT32_MAX) {
         result = ld_fail(ctx, LD_OUTPUT_ERROR, "linkedit offset is too large");
         goto cleanup;
@@ -3659,6 +3625,39 @@ static int ld_emit_image(ld_context_t *ctx) {
         goto cleanup;
     }
     cursor += linkedit.data_in_code.size;
+    cursor = ld_align_up(cursor, 8);
+    if (cursor > UINT32_MAX) {
+        result = ld_fail(ctx, LD_OUTPUT_ERROR, "linkedit offset is too large");
+        goto cleanup;
+    }
+    linkedit.symoff = (uint32_t) cursor;
+    if (linkedit.symtab.size > UINT64_MAX - cursor) {
+        result = ld_fail(ctx, LD_OUTPUT_ERROR, "symbol table is too large");
+        goto cleanup;
+    }
+    cursor += linkedit.symtab.size;
+    cursor = ld_align_up(cursor, 8);
+    if (cursor > UINT32_MAX) {
+        result = ld_fail(ctx, LD_OUTPUT_ERROR, "linkedit offset is too large");
+        goto cleanup;
+    }
+    linkedit.indirectoff = (uint32_t) cursor;
+    if (linkedit.indirect.size > UINT64_MAX - cursor) {
+        result = ld_fail(ctx, LD_OUTPUT_ERROR, "indirect symbol table is too large");
+        goto cleanup;
+    }
+    cursor += linkedit.indirect.size;
+    cursor = ld_align_up(cursor, 8);
+    if (cursor > UINT32_MAX) {
+        result = ld_fail(ctx, LD_OUTPUT_ERROR, "linkedit offset is too large");
+        goto cleanup;
+    }
+    linkedit.stroff = (uint32_t) cursor;
+    if (linkedit.strtab.size > UINT64_MAX - cursor) {
+        result = ld_fail(ctx, LD_OUTPUT_ERROR, "string table is too large");
+        goto cleanup;
+    }
+    cursor += linkedit.strtab.size;
     uint64_t signature_offset = ld_align_up(cursor, 16);
     size_t signature_size = 0;
     if (ctx->options->adhoc_codesign &&
@@ -3671,8 +3670,10 @@ static int ld_emit_image(ld_context_t *ctx) {
         result = ld_fail(ctx, LD_OUTPUT_ERROR, "code signature is too large");
         goto cleanup;
     }
-    uint64_t total_size = ld_align_up(signature_offset + signature_size, LD_PAGE_SIZE);
-    if (total_size < signature_offset || total_size > SIZE_MAX || total_size > UINT32_MAX) {
+    uint64_t total_size = ctx->options->adhoc_codesign
+                                  ? signature_offset + signature_size
+                                  : cursor;
+    if (total_size < cursor || total_size > SIZE_MAX || total_size > UINT32_MAX) {
         result = ld_fail(ctx, LD_OUTPUT_ERROR, "output is too large");
         goto cleanup;
     }
@@ -3681,8 +3682,8 @@ static int ld_emit_image(ld_context_t *ctx) {
         result = ld_fail(ctx, LD_OUTPUT_ERROR, "invalid __LINKEDIT layout");
         goto cleanup;
     }
-    linkedit_segment->filesize = ld_align_up(total_size - linkedit_segment->fileoff, LD_PAGE_SIZE);
-    linkedit_segment->vmsize = linkedit_segment->filesize;
+    linkedit_segment->filesize = total_size - linkedit_segment->fileoff;
+    linkedit_segment->vmsize = ld_align_up(linkedit_segment->filesize, LD_PAGE_SIZE);
     ctx->linkedit_size = linkedit_segment->filesize;
     image = calloc(1, (size_t) total_size);
     if (!image) {

--- a/tests/test_ld_macho_reloc.c
+++ b/tests/test_ld_macho_reloc.c
@@ -195,14 +195,16 @@ static void test_imported_unsigned32_is_not_pointer_bind(void) {
     assert(value == 0x10203040U);
     assert(canary == 0xa5a5f00dU);
 
-    /* An empty classic bind stream may be encoded either as zero bytes or as
-       a single BIND_OPCODE_DONE.  It must not contain an 8-byte pointer bind
-       for the four-byte relocation above. */
+    /* An empty classic bind stream may be absent or contain a
+       BIND_OPCODE_DONE followed by linker padding.  It must not contain a
+       pointer bind for the four-byte relocation above. */
     assert(dyld_info != NULL);
-    assert(dyld_info->bind_size == 0U ||
-           (dyld_info->bind_size == 1U &&
-            dyld_info->bind_off < (uint64_t) st.st_size &&
-            image[dyld_info->bind_off] == 0U));
+    assert(dyld_info->bind_off <= (uint64_t) st.st_size &&
+           dyld_info->bind_size <=
+                   (uint64_t) st.st_size - dyld_info->bind_off);
+    for (uint32_t i = 0; i < dyld_info->bind_size; i++) {
+        assert(image[dyld_info->bind_off + i] == 0U);
+    }
 
     free(image);
     unlink(object_path);

--- a/tests/test_ld_macho_synthetic.c
+++ b/tests/test_ld_macho_synthetic.c
@@ -32,6 +32,10 @@ typedef struct {
     const ld_symtab_command_t *symtab;
     const ld_dysymtab_command_t *dysymtab;
     const ld_dyld_info_command_t *dyld_info;
+    const ld_linkedit_data_command_t *function_starts;
+    const ld_linkedit_data_command_t *data_in_code;
+    const ld_linkedit_data_command_t *code_signature;
+    const ld_segment_command_64_t *linkedit;
 } test_macho_output_t;
 
 static uint32_t test_arm64_relocation_word(uint32_t symbol, bool pcrel,
@@ -168,6 +172,9 @@ static test_macho_output_t test_read_macho_output(const char *path) {
         if (command->cmd == LD_LC_SEGMENT_64) {
             const ld_segment_command_64_t *segment =
                     (const ld_segment_command_64_t *) command;
+            if (strncmp(segment->segname, "__LINKEDIT", 16) == 0) {
+                output.linkedit = segment;
+            }
             const ld_section_64_t *sections =
                     (const ld_section_64_t *) (segment + 1);
             for (uint32_t j = 0; j < segment->nsects; j++) {
@@ -194,6 +201,15 @@ static test_macho_output_t test_read_macho_output(const char *path) {
             output.symtab = (const ld_symtab_command_t *) command;
         } else if (command->cmd == LD_LC_DYLD_INFO_ONLY) {
             output.dyld_info = (const ld_dyld_info_command_t *) command;
+        } else if (command->cmd == LD_LC_FUNCTION_STARTS) {
+            output.function_starts =
+                    (const ld_linkedit_data_command_t *) command;
+        } else if (command->cmd == LD_LC_DATA_IN_CODE) {
+            output.data_in_code =
+                    (const ld_linkedit_data_command_t *) command;
+        } else if (command->cmd == LD_LC_CODE_SIGNATURE) {
+            output.code_signature =
+                    (const ld_linkedit_data_command_t *) command;
         }
         cursor += command->cmdsize;
     }
@@ -381,15 +397,15 @@ static uint64_t test_arm64_page_pair_target(uint32_t adrp, uint32_t pageoff,
     return page + (load ? immediate * 8U : immediate);
 }
 
-static void test_link_macho_fixture(const char *object_path,
-                                    const char *dylib_path,
-                                    const char *output_path, int expected,
-                                    test_ld_diagnostic_capture_t *capture) {
+static void test_link_macho_fixture_with_codesign(
+        const char *object_path, const char *dylib_path,
+        const char *output_path, int expected,
+        test_ld_diagnostic_capture_t *capture, bool adhoc_codesign) {
     unlink(output_path);
     ld_options_t options;
     ld_options_init(&options);
     options.output_path = output_path;
-    options.adhoc_codesign = false;
+    options.adhoc_codesign = adhoc_codesign;
     if (capture) {
         options.diagnostic = test_ld_capture_diagnostic;
         options.diagnostic_context = capture;
@@ -398,6 +414,84 @@ static void test_link_macho_fixture(const char *object_path,
     if (dylib_path) assert(ld_add_input(&options, dylib_path) == LD_OK);
     assert(ld_link(&options) == expected);
     ld_options_deinit(&options);
+}
+
+static void test_link_macho_fixture(const char *object_path,
+                                    const char *dylib_path,
+                                    const char *output_path, int expected,
+                                    test_ld_diagnostic_capture_t *capture) {
+    test_link_macho_fixture_with_codesign(
+            object_path, dylib_path, output_path, expected, capture, false);
+}
+
+static void test_codesigned_linkedit_layout(void) {
+    static const uint32_t text_words[] = {0xd65f03c0U};
+    const test_macho_section_fixture_t section = {
+            .segname = "__TEXT",
+            .sectname = "__text",
+            .flags = LD_S_ATTR_PURE_INSTRUCTIONS |
+                     LD_S_ATTR_SOME_INSTRUCTIONS,
+            .align = 2U,
+            .data = (const uint8_t *) text_words,
+            .size = sizeof(text_words),
+    };
+    static const char strings[] = "\0_main\0";
+    const ld_nlist_64_t symbol = {
+            .n_strx = 1U,
+            .n_type = LD_N_SECT | LD_N_EXT,
+            .n_sect = 1U,
+    };
+    char object_path[] = "/tmp/nature-ld-codesign-object-XXXXXX";
+    test_make_macho_object(object_path, &section, 1U, &symbol, 1U,
+                           strings, sizeof(strings));
+    char output_path[] = "/tmp/nature-ld-codesign-output-XXXXXX";
+    int output_fd = mkstemp(output_path);
+    assert(output_fd >= 0);
+    assert(close(output_fd) == 0);
+    test_link_macho_fixture_with_codesign(
+            object_path, NULL, output_path, LD_OK, NULL, true);
+
+    test_macho_output_t output = test_read_macho_output(output_path);
+    assert(output.linkedit && output.dyld_info && output.function_starts &&
+           output.data_in_code && output.symtab && output.dysymtab &&
+           output.code_signature);
+    assert(output.dyld_info->bind_off ==
+           output.dyld_info->rebase_off + output.dyld_info->rebase_size);
+    assert(output.dyld_info->weak_bind_off ==
+           output.dyld_info->bind_off + output.dyld_info->bind_size);
+    assert(output.dyld_info->lazy_bind_off ==
+           output.dyld_info->weak_bind_off +
+                   output.dyld_info->weak_bind_size);
+    assert(output.dyld_info->export_off ==
+           output.dyld_info->lazy_bind_off +
+                   output.dyld_info->lazy_bind_size);
+    assert(output.function_starts->dataoff ==
+           output.dyld_info->export_off + output.dyld_info->export_size);
+    assert(output.data_in_code->dataoff >=
+           output.function_starts->dataoff +
+                   output.function_starts->datasize);
+    assert(output.symtab->symoff >=
+           output.data_in_code->dataoff + output.data_in_code->datasize);
+    assert(output.dysymtab->indirectsymoff >=
+           output.symtab->symoff +
+                   output.symtab->nsyms * sizeof(ld_nlist_64_t));
+    assert(output.symtab->stroff >=
+           output.dysymtab->indirectsymoff +
+                   output.dysymtab->nindirectsyms * sizeof(uint32_t));
+    assert(output.code_signature->dataoff >=
+           output.symtab->stroff + output.symtab->strsize);
+    assert((output.code_signature->dataoff & 15U) == 0U);
+    assert((size_t) output.code_signature->dataoff +
+                   output.code_signature->datasize ==
+           output.size);
+    assert(output.linkedit->fileoff + output.linkedit->filesize ==
+           output.size);
+    assert(output.linkedit->vmsize >= output.linkedit->filesize);
+    assert((output.linkedit->vmsize & (0x4000U - 1U)) == 0U);
+
+    free(output.bytes);
+    unlink(object_path);
+    unlink(output_path);
 }
 
 static void test_local_got_and_indirect_offsets(void) {
@@ -870,6 +964,7 @@ static void test_imported_tlv_pointer(void) {
 }
 
 void test_ld_macho_synthetic(void) {
+    test_codesigned_linkedit_layout();
     test_local_got_and_indirect_offsets();
     test_weak_dylib_provider_direct_and_got_fixups();
     test_local_global_and_weak_tlv();


### PR DESCRIPTION
## Summary

- order Mach-O `__LINKEDIT` payloads like Zig/ld64: dyld info, function starts, data in code, symbols, indirect symbols, strings, then code signature
- include 8-byte padding in dyld-info command sizes so linkedit payloads remain contiguous
- end the file at the code signature while page-aligning only `__LINKEDIT.vmsize`
- add regression coverage for the signed linkedit layout and padded empty bind streams

## Bug

Apple signing tools could verify Nature linker-generated ad-hoc signatures but could not replace or enlarge them. On a real Adou binary, `codesign --force --sign - --options runtime --timestamp=none` failed with `internal error in Code Signing subsystem`, and `codesign_allocate` reported `function starts data out of place`.

The layout differed from Zig in two ways: function-start/data-in-code payloads were emitted after the symbol/string tables, and padding between dyld-info payloads was not represented in their load-command sizes. The signature was also followed by page padding instead of ending at EOF.

With this change, `codesign_allocate -a arm64 200000` succeeds on the generated 14 MB Adou executable, hardened-runtime ad-hoc re-signing succeeds, strict verification passes, and the re-signed executable runs.

## Verification

- `cmake --build build-release --target test_ld nature -- -j8`
- `ctest --test-dir build-release -R "^test_ld$" --output-on-failure`
- rebuilt Adou with the patched compiler
- `xcrun codesign_allocate -i build/bin/adou -a arm64 200000 -o <scratch>`
- `codesign --force --sign - --options runtime --timestamp=none <scratch-adou>`
- `codesign --verify --strict --deep --verbose=4 <scratch-adou>`
- `<scratch-adou> --version`