### PR TITLE
fix(process): forward configured stdin to child

### DIFF
--- a/runtime/nutils/process.c
+++ b/runtime/nutils/process.c
@@ -249,8 +249,8 @@ static void uv_async_process_write_stdin(process_context_t *ctx) {
     }
 
     uv_buf_t buf = uv_buf_init(ctx->stdin_pipe.buffer, ctx->stdin_pipe.buffer_count);
-    ctx->stdin_pipe.write_req.data = ctx;
-    int result = uv_write(&ctx->stdin_pipe.write_req, (uv_stream_t *) &ctx->stdin_pipe.pipe, &buf, 1,
+    ctx->stdin_write_req.data = ctx;
+    int result = uv_write(&ctx->stdin_write_req, (uv_stream_t *) &ctx->stdin_pipe.pipe, &buf, 1,
                           on_write_stdin_cb);
     if (result < 0) {
         rti_co_throw(co, tlsprintf("write stdin failed: %s", uv_strerror(result)), false);

--- a/runtime/nutils/process.c
+++ b/runtime/nutils/process.c
@@ -230,8 +230,7 @@ process_context_t *rt_uv_process_spawn(command_t *cmd) {
 
 static inline void on_write_stdin_cb(uv_write_t *req, int status) {
     process_context_t *ctx = req->data;
-    coroutine_t *co = ctx->stdin_pipe.write_co;
-    ctx->stdin_pipe.write_co = NULL;
+    coroutine_t *co = ctx->stdin_pipe.pipe.data;
 
     if (status < 0) {
         rti_co_throw(co, tlsprintf("write stdin failed: %s", uv_strerror(status)), false);
@@ -240,10 +239,9 @@ static inline void on_write_stdin_cb(uv_write_t *req, int status) {
 }
 
 static void uv_async_process_write_stdin(process_context_t *ctx) {
-    coroutine_t *co = ctx->stdin_pipe.write_co;
+    coroutine_t *co = ctx->stdin_pipe.pipe.data;
     if (ctx->stdin_pipe.closed || uv_is_closing((uv_handle_t *) &ctx->stdin_pipe.pipe)) {
         rti_co_throw(co, "stdin pipe closed", false);
-        ctx->stdin_pipe.write_co = NULL;
         co_ready(co);
         return;
     }
@@ -254,7 +252,6 @@ static void uv_async_process_write_stdin(process_context_t *ctx) {
                           on_write_stdin_cb);
     if (result < 0) {
         rti_co_throw(co, tlsprintf("write stdin failed: %s", uv_strerror(result)), false);
-        ctx->stdin_pipe.write_co = NULL;
         co_ready(co);
     }
 }
@@ -267,7 +264,7 @@ n_int_t rt_uv_process_write_stdin(process_context_t *ctx, n_vec_t buf) {
     }
 
     ctx->stdin_pipe.write_buf = buf;
-    ctx->stdin_pipe.write_co = co;
+    ctx->stdin_pipe.pipe.data = co;
     global_waiting_send(uv_async_process_write_stdin, ctx, 0, 0);
 
     if (co->has_error) {
@@ -276,32 +273,11 @@ n_int_t rt_uv_process_write_stdin(process_context_t *ctx, n_vec_t buf) {
     return buf.length;
 }
 
-static inline void on_stdin_close_cb(uv_handle_t *handle) {
-    stdin_pipe_context_t *stdin_pipe = CONTAINER_OF(handle, stdin_pipe_context_t, pipe);
-    coroutine_t *co = stdin_pipe->close_co;
-    stdin_pipe->close_co = NULL;
-    if (co) {
-        co_ready(co);
-    }
-}
-
 static inline void close_stdin_pipe(process_context_t *ctx) {
-    if (ctx->stdin_pipe.closed || uv_is_closing((uv_handle_t *) &ctx->stdin_pipe.pipe)) {
-        return;
-    }
-
     ctx->stdin_pipe.closed = true;
-    uv_close((uv_handle_t *) &ctx->stdin_pipe.pipe, on_stdin_close_cb);
-}
-
-static void uv_async_process_close_stdin(process_context_t *ctx, coroutine_t *co) {
-    if (ctx->stdin_pipe.closed || uv_is_closing((uv_handle_t *) &ctx->stdin_pipe.pipe)) {
-        co_ready(co);
-        return;
+    if (!uv_is_closing((uv_handle_t *) &ctx->stdin_pipe.pipe)) {
+        uv_close((uv_handle_t *) &ctx->stdin_pipe.pipe, NULL);
     }
-
-    ctx->stdin_pipe.close_co = co;
-    close_stdin_pipe(ctx);
 }
 
 void rt_uv_process_close_stdin(process_context_t *ctx) {
@@ -309,7 +285,8 @@ void rt_uv_process_close_stdin(process_context_t *ctx) {
         return;
     }
 
-    global_waiting_send(uv_async_process_close_stdin, ctx, coroutine_get(), 0);
+    ctx->stdin_pipe.closed = true;
+    global_async_send(close_stdin_pipe, ctx, 0, 0);
 }
 
 void uv_async_process_wait(process_context_t *ctx, coroutine_t *co) {

--- a/runtime/nutils/process.c
+++ b/runtime/nutils/process.c
@@ -6,7 +6,12 @@ typedef n_int_t *(*io_write_fn)(void *self, n_vec_t *buf);
 
 typedef n_int_t *(*io_read_fn)(void *self, n_vec_t *buf);
 
-static inline void close_stdin_pipe(process_context_t *ctx);
+static inline void close_pipe(pipe_context_t *pipe_ctx) {
+    pipe_ctx->closed = true;
+    if (!uv_is_closing((uv_handle_t *) &pipe_ctx->pipe)) {
+        uv_close((uv_handle_t *) &pipe_ctx->pipe, NULL);
+    }
+}
 
 static inline bool is_real_exit(process_context_t *ctx) {
     return ctx->exited && ctx->stderr_pipe.closed && ctx->stdout_pipe.closed;
@@ -19,8 +24,8 @@ static inline void real_exit(process_context_t *ctx) {
     assert(ctx->stderr_pipe.closed);
 
     // 关闭 pipe
-    uv_close((uv_handle_t *) &ctx->stdout_pipe.pipe, NULL);
-    uv_close((uv_handle_t *) &ctx->stderr_pipe.pipe, NULL);
+    close_pipe(&ctx->stdout_pipe);
+    close_pipe(&ctx->stderr_pipe);
 
     // 唤醒主协程
     coroutine_t *co = ctx->req.data;
@@ -44,7 +49,7 @@ static inline void on_exit_cb(uv_process_t *req, int64_t exit_status, int term_s
         free(ctx->envs);
     }
     uv_close((uv_handle_t *) req, NULL);
-    close_stdin_pipe(ctx);
+    close_pipe(&ctx->stdin_pipe);
 
     if (is_real_exit(ctx)) {
         real_exit(ctx);
@@ -89,7 +94,7 @@ static inline void on_read_stderr_cb(uv_stream_t *stream, ssize_t nread, const u
     // 尝试打印读取到的数据, 尝试将读取的数据写入到 process_context 设置的 stdin 和 stdout 中
     DEBUGF("[on_read_stderr_cb] %s: nread: %d", pipe_ctx->name, (int) nread);
 
-    pipe_ctx->read_buffer_count = nread;
+    pipe_ctx->buffer_count = nread;
 
     // 唤醒应用层消化相关数据
     co_ready(co);
@@ -128,7 +133,7 @@ static inline void on_read_stdout_cb(uv_stream_t *stream, ssize_t nread, const u
     DEBUGF("[on_read_stdout_cb] %s: nread: %d", pipe_ctx->name, (int) nread);
 
 
-    pipe_ctx->read_buffer_count = nread;
+    pipe_ctx->buffer_count = nread;
 
     // 唤醒应用层消化相关数据
     co_ready(co);
@@ -160,12 +165,9 @@ static void uv_async_process_spawn(process_context_t *ctx, coroutine_t *co) {
 
     int result = uv_spawn(&global_loop, &ctx->req, &options);
     if (result) {
-        ctx->stdin_pipe.closed = true;
-        ctx->stdout_pipe.closed = true;
-        ctx->stderr_pipe.closed = true;
-        uv_close((uv_handle_t *) &ctx->stdin_pipe.pipe, NULL);
-        uv_close((uv_handle_t *) &ctx->stdout_pipe.pipe, NULL);
-        uv_close((uv_handle_t *) &ctx->stderr_pipe.pipe, NULL);
+        close_pipe(&ctx->stdin_pipe);
+        close_pipe(&ctx->stdout_pipe);
+        close_pipe(&ctx->stderr_pipe);
         free(ctx->args);
         ctx->args = NULL;
         if (ctx->envs) {
@@ -246,7 +248,7 @@ static void uv_async_process_write_stdin(process_context_t *ctx) {
         return;
     }
 
-    uv_buf_t buf = uv_buf_init((char *) ctx->stdin_pipe.write_buf.data, ctx->stdin_pipe.write_buf.length);
+    uv_buf_t buf = uv_buf_init(ctx->stdin_pipe.buffer, ctx->stdin_pipe.buffer_count);
     ctx->stdin_pipe.write_req.data = ctx;
     int result = uv_write(&ctx->stdin_pipe.write_req, (uv_stream_t *) &ctx->stdin_pipe.pipe, &buf, 1,
                           on_write_stdin_cb);
@@ -262,8 +264,13 @@ n_int_t rt_uv_process_write_stdin(process_context_t *ctx, n_vec_t buf) {
         rti_co_throw(co, "stdin pipe closed", false);
         return 0;
     }
+    if (buf.length > sizeof(ctx->stdin_pipe.buffer)) {
+        rti_co_throw(co, "stdin write exceeds pipe buffer", false);
+        return 0;
+    }
 
-    ctx->stdin_pipe.write_buf = buf;
+    memcpy(ctx->stdin_pipe.buffer, buf.data, buf.length);
+    ctx->stdin_pipe.buffer_count = buf.length;
     ctx->stdin_pipe.pipe.data = co;
     global_waiting_send(uv_async_process_write_stdin, ctx, 0, 0);
 
@@ -273,20 +280,13 @@ n_int_t rt_uv_process_write_stdin(process_context_t *ctx, n_vec_t buf) {
     return buf.length;
 }
 
-static inline void close_stdin_pipe(process_context_t *ctx) {
-    ctx->stdin_pipe.closed = true;
-    if (!uv_is_closing((uv_handle_t *) &ctx->stdin_pipe.pipe)) {
-        uv_close((uv_handle_t *) &ctx->stdin_pipe.pipe, NULL);
-    }
-}
-
 void rt_uv_process_close_stdin(process_context_t *ctx) {
     if (ctx->stdin_pipe.closed) {
         return;
     }
 
     ctx->stdin_pipe.closed = true;
-    global_async_send(close_stdin_pipe, ctx, 0, 0);
+    global_async_send(close_pipe, &ctx->stdin_pipe, 0, 0);
 }
 
 void uv_async_process_wait(process_context_t *ctx, coroutine_t *co) {
@@ -336,7 +336,7 @@ n_string_t rt_uv_process_read_stdout(process_context_t *ctx) {
         return (n_string_t) {0};
     }
 
-    n_string_t buf_string = rt_string_ref_new(ctx->stdout_pipe.buffer, ctx->stdout_pipe.read_buffer_count);
+    n_string_t buf_string = rt_string_ref_new(ctx->stdout_pipe.buffer, ctx->stdout_pipe.buffer_count);
     DEBUGF("[rt_uv_process_read_stdout] read buf len: %d", buf_string.length);
     return buf_string;
 }
@@ -362,7 +362,7 @@ n_string_t rt_uv_process_read_stderr(process_context_t *ctx) {
     }
 
     // 提取 buf 并返回
-    n_string_t buf_string = rt_string_ref_new(ctx->stderr_pipe.buffer, ctx->stderr_pipe.read_buffer_count);
+    n_string_t buf_string = rt_string_ref_new(ctx->stderr_pipe.buffer, ctx->stderr_pipe.buffer_count);
     DEBUGF("[rt_uv_process_read_stderr] read buf len: %ld", buf_string.length);
     return buf_string;
 }

--- a/runtime/nutils/process.c
+++ b/runtime/nutils/process.c
@@ -6,6 +6,8 @@ typedef n_int_t *(*io_write_fn)(void *self, n_vec_t *buf);
 
 typedef n_int_t *(*io_read_fn)(void *self, n_vec_t *buf);
 
+static inline void close_stdin_pipe(process_context_t *ctx);
+
 static inline bool is_real_exit(process_context_t *ctx) {
     return ctx->exited && ctx->stderr_pipe.closed && ctx->stdout_pipe.closed;
 }
@@ -42,6 +44,7 @@ static inline void on_exit_cb(uv_process_t *req, int64_t exit_status, int term_s
         free(ctx->envs);
     }
     uv_close((uv_handle_t *) req, NULL);
+    close_stdin_pipe(ctx);
 
     if (is_real_exit(ctx)) {
         real_exit(ctx);
@@ -133,6 +136,7 @@ static inline void on_read_stdout_cb(uv_stream_t *stream, ssize_t nread, const u
 
 static void uv_async_process_spawn(process_context_t *ctx, coroutine_t *co) {
     // 初始化
+    uv_pipe_init(&global_loop, &ctx->stdin_pipe.pipe, 0);
     uv_pipe_init(&global_loop, &ctx->stderr_pipe.pipe, 0);
     uv_pipe_init(&global_loop, &ctx->stdout_pipe.pipe, 0);
 
@@ -142,9 +146,10 @@ static void uv_async_process_spawn(process_context_t *ctx, coroutine_t *co) {
     options.args = ctx->args;
     options.env = ctx->envs;
 
-    // 设置标准输出重定向到当前进程
+    // 将子进程的标准流连接到父进程 pipe
     uv_stdio_container_t stdio[3];
-    stdio[0].flags = UV_IGNORE;
+    stdio[0].flags = UV_CREATE_PIPE | UV_READABLE_PIPE;
+    stdio[0].data.stream = (uv_stream_t *) &ctx->stdin_pipe.pipe;
     stdio[1].flags = UV_CREATE_PIPE | UV_WRITABLE_PIPE;
     stdio[1].data.stream = (uv_stream_t *) &ctx->stdout_pipe.pipe;
     stdio[2].flags = UV_CREATE_PIPE | UV_WRITABLE_PIPE;
@@ -155,6 +160,18 @@ static void uv_async_process_spawn(process_context_t *ctx, coroutine_t *co) {
 
     int result = uv_spawn(&global_loop, &ctx->req, &options);
     if (result) {
+        ctx->stdin_pipe.closed = true;
+        ctx->stdout_pipe.closed = true;
+        ctx->stderr_pipe.closed = true;
+        uv_close((uv_handle_t *) &ctx->stdin_pipe.pipe, NULL);
+        uv_close((uv_handle_t *) &ctx->stdout_pipe.pipe, NULL);
+        uv_close((uv_handle_t *) &ctx->stderr_pipe.pipe, NULL);
+        free(ctx->args);
+        ctx->args = NULL;
+        if (ctx->envs) {
+            free(ctx->envs);
+            ctx->envs = NULL;
+        }
         rti_co_throw(co, (char *) uv_strerror(result), false);
     } else {
         // 设置 pid 的值
@@ -209,6 +226,90 @@ process_context_t *rt_uv_process_spawn(command_t *cmd) {
 
     DEBUGF("[rt_uv_process_spawn] end, ctx: %p", ctx)
     return ctx;
+}
+
+static inline void on_write_stdin_cb(uv_write_t *req, int status) {
+    process_context_t *ctx = req->data;
+    coroutine_t *co = ctx->stdin_pipe.write_co;
+    ctx->stdin_pipe.write_co = NULL;
+
+    if (status < 0) {
+        rti_co_throw(co, tlsprintf("write stdin failed: %s", uv_strerror(status)), false);
+    }
+    co_ready(co);
+}
+
+static void uv_async_process_write_stdin(process_context_t *ctx) {
+    coroutine_t *co = ctx->stdin_pipe.write_co;
+    if (ctx->stdin_pipe.closed || uv_is_closing((uv_handle_t *) &ctx->stdin_pipe.pipe)) {
+        rti_co_throw(co, "stdin pipe closed", false);
+        ctx->stdin_pipe.write_co = NULL;
+        co_ready(co);
+        return;
+    }
+
+    uv_buf_t buf = uv_buf_init((char *) ctx->stdin_pipe.write_buf.data, ctx->stdin_pipe.write_buf.length);
+    ctx->stdin_pipe.write_req.data = ctx;
+    int result = uv_write(&ctx->stdin_pipe.write_req, (uv_stream_t *) &ctx->stdin_pipe.pipe, &buf, 1,
+                          on_write_stdin_cb);
+    if (result < 0) {
+        rti_co_throw(co, tlsprintf("write stdin failed: %s", uv_strerror(result)), false);
+        ctx->stdin_pipe.write_co = NULL;
+        co_ready(co);
+    }
+}
+
+n_int_t rt_uv_process_write_stdin(process_context_t *ctx, n_vec_t buf) {
+    coroutine_t *co = coroutine_get();
+    if (ctx->stdin_pipe.closed) {
+        rti_co_throw(co, "stdin pipe closed", false);
+        return 0;
+    }
+
+    ctx->stdin_pipe.write_buf = buf;
+    ctx->stdin_pipe.write_co = co;
+    global_waiting_send(uv_async_process_write_stdin, ctx, 0, 0);
+
+    if (co->has_error) {
+        return 0;
+    }
+    return buf.length;
+}
+
+static inline void on_stdin_close_cb(uv_handle_t *handle) {
+    stdin_pipe_context_t *stdin_pipe = CONTAINER_OF(handle, stdin_pipe_context_t, pipe);
+    coroutine_t *co = stdin_pipe->close_co;
+    stdin_pipe->close_co = NULL;
+    if (co) {
+        co_ready(co);
+    }
+}
+
+static inline void close_stdin_pipe(process_context_t *ctx) {
+    if (ctx->stdin_pipe.closed || uv_is_closing((uv_handle_t *) &ctx->stdin_pipe.pipe)) {
+        return;
+    }
+
+    ctx->stdin_pipe.closed = true;
+    uv_close((uv_handle_t *) &ctx->stdin_pipe.pipe, on_stdin_close_cb);
+}
+
+static void uv_async_process_close_stdin(process_context_t *ctx, coroutine_t *co) {
+    if (ctx->stdin_pipe.closed || uv_is_closing((uv_handle_t *) &ctx->stdin_pipe.pipe)) {
+        co_ready(co);
+        return;
+    }
+
+    ctx->stdin_pipe.close_co = co;
+    close_stdin_pipe(ctx);
+}
+
+void rt_uv_process_close_stdin(process_context_t *ctx) {
+    if (ctx->stdin_pipe.closed) {
+        return;
+    }
+
+    global_waiting_send(uv_async_process_close_stdin, ctx, coroutine_get(), 0);
 }
 
 void uv_async_process_wait(process_context_t *ctx, coroutine_t *co) {

--- a/runtime/nutils/process.h
+++ b/runtime/nutils/process.h
@@ -27,10 +27,9 @@ typedef struct {
 typedef struct {
     uv_pipe_t pipe;
     char buffer[1024];
-    int64_t read_buffer_count;
+    int64_t buffer_count;
     const char *name;
     uv_write_t write_req;
-    n_vec_t write_buf;
     bool closed;
 } pipe_context_t;
 

--- a/runtime/nutils/process.h
+++ b/runtime/nutils/process.h
@@ -29,7 +29,6 @@ typedef struct {
     char buffer[1024];
     int64_t buffer_count;
     const char *name;
-    uv_write_t write_req;
     bool closed;
 } pipe_context_t;
 
@@ -47,6 +46,7 @@ typedef struct {
     pipe_context_t stdin_pipe;
     pipe_context_t stdout_pipe;
     pipe_context_t stderr_pipe;
+    uv_write_t stdin_write_req;
     uv_process_t req; // 程序启动成功后, pid 存储在 req 中
 } process_context_t;
 

--- a/runtime/nutils/process.h
+++ b/runtime/nutils/process.h
@@ -29,17 +29,10 @@ typedef struct {
     char buffer[1024];
     int64_t read_buffer_count;
     const char *name;
-    bool closed;
-} pipe_context_t;
-
-typedef struct {
-    uv_pipe_t pipe;
     uv_write_t write_req;
     n_vec_t write_buf;
-    coroutine_t *write_co;
-    coroutine_t *close_co;
     bool closed;
-} stdin_pipe_context_t;
+} pipe_context_t;
 
 typedef struct {
     int64_t pid;
@@ -52,7 +45,7 @@ typedef struct {
     int32_t term_sig;
     command_t cmd;
 
-    stdin_pipe_context_t stdin_pipe;
+    pipe_context_t stdin_pipe;
     pipe_context_t stdout_pipe;
     pipe_context_t stderr_pipe;
     uv_process_t req; // 程序启动成功后, pid 存储在 req 中

--- a/runtime/nutils/process.h
+++ b/runtime/nutils/process.h
@@ -1,10 +1,10 @@
 #ifndef NATURE_PROCESS_H
 #define NATURE_PROCESS_H
 
-#include "runtime/uv_compat.h"
-#include "vec.h"
-#include "utils/helper.h"
 #include "runtime/processor.h"
+#include "runtime/uv_compat.h"
+#include "utils/helper.h"
+#include "vec.h"
 
 typedef struct {
     n_string_t stdout_text;
@@ -33,6 +33,15 @@ typedef struct {
 } pipe_context_t;
 
 typedef struct {
+    uv_pipe_t pipe;
+    uv_write_t write_req;
+    n_vec_t write_buf;
+    coroutine_t *write_co;
+    coroutine_t *close_co;
+    bool closed;
+} stdin_pipe_context_t;
+
+typedef struct {
     int64_t pid;
     char **args; // exit 释放
     char **envs; // exit 释放
@@ -43,6 +52,7 @@ typedef struct {
     int32_t term_sig;
     command_t cmd;
 
+    stdin_pipe_context_t stdin_pipe;
     pipe_context_t stdout_pipe;
     pipe_context_t stderr_pipe;
     uv_process_t req; // 程序启动成功后, pid 存储在 req 中
@@ -51,6 +61,10 @@ typedef struct {
 n_string_t rt_uv_process_read_stdout(process_context_t *ctx);
 
 n_string_t rt_uv_process_read_stderr(process_context_t *ctx);
+
+n_int_t rt_uv_process_write_stdin(process_context_t *ctx, n_vec_t buf);
+
+void rt_uv_process_close_stdin(process_context_t *ctx);
 
 void rt_uv_process_wait(process_context_t *ctx);
 

--- a/std/process/process.n
+++ b/std/process/process.n
@@ -74,20 +74,19 @@ pub fn command_t.spawn(&self):ref<process_t>! {
 fn command_t.uv_spawn(&self, ref<command_t> cmd):ref<process_t>!
 
 fn process_t.handle_stdin(&self):void! {
+    defer self.close_stdin()
+
     var buf = vec<u8>.new(0, 1024)
     for true {
         int n = self.cmd.stdin.read(buf) catch e {
-            self.close_stdin()
             return
         }
 
         if n <= 0 {
-            self.close_stdin()
             return
         }
 
         self.write_stdin(buf.slice(0, n)) catch e {
-            self.close_stdin()
             return
         }
     }

--- a/std/process/process.n
+++ b/std/process/process.n
@@ -64,6 +64,7 @@ pub fn command_t.spawn(&self):ref<process_t>! {
     // Scheduling in the current thread will not cause competition
     go p.handle_stdout()
     go p.handle_stderr()
+    go p.handle_stdin()
 
     return p
 }
@@ -71,6 +72,32 @@ pub fn command_t.spawn(&self):ref<process_t>! {
 
 #linkid rt_uv_process_spawn
 fn command_t.uv_spawn(&self, ref<command_t> cmd):ref<process_t>!
+
+fn process_t.handle_stdin(&self):void! {
+    var buf = vec<u8>.new(0, 1024)
+    for true {
+        int n = self.cmd.stdin.read(buf) catch e {
+            self.close_stdin()
+            return
+        }
+
+        if n <= 0 {
+            self.close_stdin()
+            return
+        }
+
+        self.write_stdin(buf.slice(0, n)) catch e {
+            self.close_stdin()
+            return
+        }
+    }
+}
+
+#linkid rt_uv_process_write_stdin
+fn process_t.write_stdin(&self, [u8] buf):int!
+
+#linkid rt_uv_process_close_stdin
+fn process_t.close_stdin(&self):void
 
 fn process_t.handle_stdout(&self):void! {
     for true {

--- a/tests/features/20260816_00_process_stdin.c
+++ b/tests/features/20260816_00_process_stdin.c
@@ -1,0 +1,5 @@
+#include "tests/test.h"
+
+int main(void) {
+    feature_testar_test(NULL);
+}

--- a/tests/features/cases/20260816_00_process_stdin.testar
+++ b/tests/features/cases/20260816_00_process_stdin.testar
@@ -1,0 +1,22 @@
+=== custom_command_stdin_reaches_child
+--- main.n
+import io
+import process
+
+fn main():void! {
+    var input = new io.buffer()
+    input.write('stdin-probe\n' as [u8])
+    var output = new io.buffer()
+
+    var cmd = process.command('/bin/cat', [])
+    cmd.stdin = input
+    cmd.stdout = output
+    var child = cmd.spawn()
+    child.wait()
+
+    assert(output.read_all() as string == 'stdin-probe\n')
+    println('stdin forwarded')
+}
+
+--- output.txt
+stdin forwarded

--- a/tests/features/cases/20260816_00_process_stdin.testar
+++ b/tests/features/cases/20260816_00_process_stdin.testar
@@ -4,8 +4,13 @@ import io
 import process
 
 fn main():void! {
+    var expected = vec<u8>.new(0, 2048)
+    for int i = 0; i < 200; i += 1 {
+        expected.append('stdin-probe\n' as [u8])
+    }
+
     var input = new io.buffer()
-    input.write('stdin-probe\n' as [u8])
+    input.write(expected)
     var output = new io.buffer()
 
     var cmd = process.command('/bin/cat', [])
@@ -14,7 +19,7 @@ fn main():void! {
     var child = cmd.spawn()
     child.wait()
 
-    assert(output.read_all() as string == 'stdin-probe\n')
+    assert(output.read_all() as string == expected as string)
     println('stdin forwarded')
 }
 

--- a/tests/windows/feature-eligibility-policy.tsv
+++ b/tests/windows/feature-eligibility-policy.tsv
@@ -11,3 +11,4 @@
 20250616_02_libc_fcntl	skip	all scenarios are explicitly linux-only
 20260102_00_tank	skip	requires an interactive raylib window
 20260118_00_mix_stack	skip	ships ELF or Mach-O fixture objects, not AMD64 COFF
+20260816_00_process_stdin	skip	requires the Unix /bin/cat executable


### PR DESCRIPTION
## Summary

- connect child fd 0 to a parent-side libuv pipe
- pump the configured `command_t.stdin` reader into the pipe with write backpressure
- close stdin on reader EOF, process exit, and spawn failure
- add a Unix regression test using `/bin/cat` and exclude it from Windows feature tests

Closes #308

## Verification

- `cmake -B build-runtime -S runtime -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build-runtime --target runtime -- -j8`
- `cmake --build build -- -j8`
- `ctest --test-dir build -R "^(20250318_00_process|20260816_00_process_stdin)$" -V`
- Full `ctest --test-dir build --output-on-failure`: 222/225 passed. The three failures are unrelated external-network cases: `20250716_00_tcp`, `20250723_00_udp`, and `20250802_02_http`.