### PR TITLE
fix(std/process): honor command_t.cwd

### DIFF
--- a/runtime/nutils/process.c
+++ b/runtime/nutils/process.c
@@ -150,6 +150,7 @@ static void uv_async_process_spawn(process_context_t *ctx, coroutine_t *co) {
     options.file = rt_string_ref(&ctx->cmd.name);
     options.args = ctx->args;
     options.env = ctx->envs;
+    options.cwd = ctx->cmd.cwd.length ? rt_string_ref(&ctx->cmd.cwd) : NULL;
 
     // 将子进程的标准流连接到父进程 pipe
     uv_stdio_container_t stdio[3];

--- a/tests/features/cases/20250318_00_process.testar
+++ b/tests/features/cases/20250318_00_process.testar
@@ -88,3 +88,41 @@ fn main():void! {
 }
 --- output.txt
 process exited 0 0\s\s
+
+=== test_cwd
+--- main.n
+import io
+import process
+import os
+import syscall
+
+fn main():void! {
+    var args = os.args()
+    if args.len() > 1 && args[1] == 'cwd_child' {
+        var _ = syscall.stat('marker') catch err {
+            println('cwd failed')
+            return
+        }
+        println('cwd ok')
+        return
+    }
+
+    string target = 'process-cwd'
+    syscall.mkdir(target, 0755)
+    int marker = syscall.open(target + '/marker', syscall.O_CREAT | syscall.O_RDWR, 0644)
+    syscall.write(marker, 'ok'.ref(), 2)
+    syscall.close(marker)
+
+    var output = io.buffer.new()
+    var cmd = process.command(args[0], ['cwd_child'])
+    cmd.cwd = target
+    cmd.stdout = output
+    var p = cmd.spawn()
+    p.wait()
+
+    assert((output.read_all() as string).trim(['\n', '\r']) == 'cwd ok')
+    println('process cwd option ok')
+}
+
+--- output.txt
+process cwd option ok


### PR DESCRIPTION
## Summary

- pass a non-empty `command_t.cwd` to libuv through `uv_process_options_t.cwd`
- preserve inherited working-directory behavior when `cwd` is empty
- add a process feature regression test covering child-relative file resolution

## Tests

- `cmake -B build-runtime -S runtime -DCMAKE_BUILD_TYPE=Release && cmake --build build-runtime --target runtime`
- `cmake --build build -- -j8`
- `ctest --test-dir build -R '^(20250318_00_process|20260816_00_process_stdin)$' --output-on-failure -V`
