### PR TITLE
fix: grow bitmap at exact byte boundary

### DIFF
--- a/tests/test_bitmap.c
+++ b/tests/test_bitmap.c
@@ -154,10 +154,23 @@ static void test_bitmap_batch_operations_combined() {
     bitmap_free(b);
 }
 
+static void test_bitmap_grow_exact_byte_boundary() {
+    bitmap_t *b = bitmap_new(16);
+
+    // Bit 128 is the first bit after a 16-byte bitmap. Growing must happen
+    // when index / 8 equals the current byte capacity.
+    bitmap_grow_set(b, 16 * 8, true);
+    assert_true(b->size > 16);
+    assert_int_equal(bitmap_test(b->bits, 16 * 8), 1);
+
+    bitmap_free(b);
+}
+
 int main(void) {
     test_bitmap_base();
     test_bitmap_batch_set();
     test_bitmap_batch_clear();
     test_bitmap_batch_operations_combined();
+    test_bitmap_grow_exact_byte_boundary();
     printf("All bitmap batch tests passed!\n");
 }

--- a/utils/bitmap.h
+++ b/utils/bitmap.h
@@ -184,7 +184,7 @@ static inline char *bitmap_to_str(uint8_t *bits, uint64_t count) {
 // 如果 index 超过了
 static inline void bitmap_grow_set(bitmap_t *b, uint64_t index, bool test) {
     uint64_t need_size = index / 8;
-    if (need_size > b->size) {
+    if (need_size >= b->size) {
         uint8_t *new_bits = mallocz(need_size * 2);
         memcpy(new_bits, b->bits, b->size);
         free(b->bits);


### PR DESCRIPTION
Summary:
- Grow the bitmap when the target byte index equals the current capacity.
- Add a regression test for the first bit after the bitmap boundary.

The regression test fails on the parent revision because the bitmap size remains unchanged and passes with this fix.

Tests:
- ctest --test-dir build -R ^test_bitmap$ --output-on-failure