### PR TITLE
refactor: remove obsolete #local labels

### DIFF
--- a/nls/syntaxes/n.tmLanguage.json
+++ b/nls/syntaxes/n.tmLanguage.json
@@ -535,7 +535,7 @@
         "annotation": {
             "patterns": [
                 {
-                    "comment": "#linkid, #where, #local, etc.",
+                    "comment": "#linkid, #where, etc.",
                     "match": "(#[a-zA-Z_][a-zA-Z0-9_]*)\\b(.*)?$",
                     "captures": {
                         "1": {

--- a/src/symbol/symbol.h
+++ b/src/symbol/symbol.h
@@ -24,7 +24,6 @@
 
 // #linkid
 #define MACRO_LINKID "linkid"
-#define MACRO_LOCAL "local"
 #define MACRO_RUNTIME_USE "runtime_use"
 #define MACRO_WHERE "where"
 

--- a/std/http/client.n
+++ b/std/http/client.n
@@ -257,7 +257,6 @@ fn request_t.tcp_buf(&self):[u8]! {
     return buf
 }
 
-#local
 fn read_until_space(ref<buf.reader<types.connable>> br):string! {
     // vec<u8>.new(0, 32) pre-fills 32 zero bytes that are included in the
     // `as string` result, corrupting every status line parse. Build the token
@@ -448,7 +447,6 @@ fn chunked_reader_t.new(ref<buf.reader<types.connable>> br):ref<chunked_reader_t
     return new chunked_reader_t(br = br)
 }
 
-#local
 fn chunked_reader_t.hex_to_int(&self, string s):int {
     var result = 0
     for int i = 0; i < s.len(); i += 1 {
@@ -465,7 +463,6 @@ fn chunked_reader_t.hex_to_int(&self, string s):int {
     return result
 }
 
-#local
 fn chunked_reader_t.fill_staging(&self):void! {
     for true {
         if self.state == 0 {

--- a/std/io/buf.n
+++ b/std/io/buf.n
@@ -24,7 +24,7 @@ pub fn reader<T>.reset(&self, T rd) {
     self.eof = false
 }
 
-#local #where T:io.reader
+#where T:io.reader
 pub fn reader<T>.fill(&self):void! {
     if self.r > 0 {
         // Copy unread data to the buffer start position
@@ -231,7 +231,7 @@ pub fn writer<T>.buffered(&self):int {
     return self.n
 }
 
-#local #where T:io.writer
+#where T:io.writer
 pub fn writer<T>.flush(&self):void! {
     if self.err {
         throw errorf('previous write error')

--- a/std/os/os.windows_amd64.n
+++ b/std/os/os.windows_amd64.n
@@ -7,16 +7,16 @@ import runtime
 
 type signal = u8
 
-#local #linkid rt_windows_find_first_utf8
+#linkid rt_windows_find_first_utf8
 fn windows_find_first(anyptr pattern, anyptr name, u64 capacity): anyptr
 
-#local #linkid rt_windows_find_next_utf8
+#linkid rt_windows_find_next_utf8
 fn windows_find_next(anyptr handle, anyptr name, u64 capacity): i32
 
-#local #linkid rt_windows_find_close_utf8
+#linkid rt_windows_find_close_utf8
 fn windows_find_close(anyptr handle): i32
 
-#local #linkid GetLastError
+#linkid GetLastError
 fn windows_last_error(): u32
 
 pub fn args():[string] {

--- a/std/syscall/syscall.windows_amd64.n
+++ b/std/syscall/syscall.windows_amd64.n
@@ -78,55 +78,55 @@ type windows_filetime_t = struct {
     u32 low
     u32 high
 }
-#local #linkid rt_windows_open_utf8
+#linkid rt_windows_open_utf8
 fn windows_open(anyptr filename, i32 flags, i32 perm): i32
-#local #linkid _read
+#linkid _read
 fn windows_read(i32 fd, anyptr buf, u32 len): i32
-#local #linkid _write
+#linkid _write
 fn windows_write(i32 fd, anyptr buf, u32 len): i32
-#local #linkid _close
+#linkid _close
 fn windows_close(i32 fd): i32
-#local #linkid _lseeki64
+#linkid _lseeki64
 fn windows_seek(i32 fd, i64 offset, i32 whence): i64
-#local #linkid rt_windows_stat_utf8
+#linkid rt_windows_stat_utf8
 fn windows_stat(anyptr filename, ptr<windows_stat64_t> result): i32
-#local #linkid _fstat64
+#linkid _fstat64
 fn windows_fstat(i32 fd, ptr<windows_stat64_t> result): i32
-#local #linkid rt_windows_mkdir_utf8
+#linkid rt_windows_mkdir_utf8
 fn windows_mkdir(anyptr path): i32
-#local #linkid rt_windows_rmdir_utf8
+#linkid rt_windows_rmdir_utf8
 fn windows_rmdir(anyptr path): i32
-#local #linkid rt_windows_unlink_utf8
+#linkid rt_windows_unlink_utf8
 fn windows_unlink(anyptr path): i32
-#local #linkid rt_windows_rename_utf8
+#linkid rt_windows_rename_utf8
 fn windows_rename(anyptr old_path, anyptr new_path): i32
-#local #linkid rt_windows_chmod_utf8
+#linkid rt_windows_chmod_utf8
 fn windows_chmod(anyptr path, i32 mode): i32
-#local #linkid rt_windows_chdir_utf8
+#linkid rt_windows_chdir_utf8
 fn windows_chdir(anyptr path): i32
-#local #linkid rt_windows_getcwd_utf8
+#linkid rt_windows_getcwd_utf8
 fn windows_getcwd(anyptr buf, u64 size): i64
-#local #linkid rt_windows_readlink_utf8
+#linkid rt_windows_readlink_utf8
 fn windows_readlink(anyptr filename, anyptr buf, u64 len): i64
-#local #linkid rt_windows_get_env_utf8
+#linkid rt_windows_get_env_utf8
 fn windows_get_env(anyptr key, anyptr value, u64 len): i64
-#local #linkid rt_windows_set_env_utf8
+#linkid rt_windows_set_env_utf8
 fn windows_set_env(anyptr key, anyptr value): i32
-#local #linkid rt_windows_env_first_utf8
+#linkid rt_windows_env_first_utf8
 fn windows_env_first(anyptr entry, u64 len): anyptr
-#local #linkid rt_windows_env_next_utf8
+#linkid rt_windows_env_next_utf8
 fn windows_env_next(anyptr iterator, anyptr entry, u64 len): i32
-#local #linkid rt_windows_env_close_utf8
+#linkid rt_windows_env_close_utf8
 fn windows_env_close(anyptr iterator): i32
-#local #linkid GetLastError
+#linkid GetLastError
 fn windows_last_error(): u32
-#local #linkid GetSystemTimeAsFileTime
+#linkid GetSystemTimeAsFileTime
 fn windows_system_time(ptr<windows_filetime_t> result): void
-#local #linkid exit
+#linkid exit
 fn windows_exit(i32 status): void
-#local #linkid getpid
+#linkid getpid
 fn windows_getpid(): i32
-#local #linkid getppid
+#linkid getppid
 fn windows_getppid(): i32
 pub fn open(string filename, int flags, u32 perm): int! {
     int native_flags = flags

--- a/std/unsafe/unsafe.n
+++ b/std/unsafe/unsafe.n
@@ -13,7 +13,7 @@ pub fn vec_new<T>(ptr<T> p, int len):vec<T>! {
     return unsafe_vec_new<T>(hash, ele_hash, len, p as anyptr)
 }
 
-#local #linkid unsafe_vec_new
+#linkid unsafe_vec_new
 pub fn unsafe_vec_new<T>(int hash, int ele_hash, int len, anyptr p):vec<T>!
 
 pub fn ptr_to<T>(anyptr p):T {

--- a/tests/features/cases/20260103_00_selective_imports/math_module.n
+++ b/tests/features/cases/20260103_00_selective_imports/math_module.n
@@ -19,7 +19,6 @@ pub fn multiply(int a, int b):int {
 }
 
 // Private function - should not be importable
-#local
 fn internal_helper():int {
     return 42
 }

--- a/tests/features/cases/20260103_00_selective_imports/utils.n
+++ b/tests/features/cases/20260103_00_selective_imports/utils.n
@@ -10,7 +10,6 @@ fn parse_int(string s):int {
     return 42
 }
 
-#local
 fn private_util():int {
     return 1
 }


### PR DESCRIPTION
## Summary

- Remove all obsolete `#local` annotations from the standard library and selective-import fixtures.
- Drop the unused `MACRO_LOCAL` definition now that module visibility is controlled by `pub`.
- Update the NLS annotation comment so it no longer advertises `#local`.

## Verification

- `cmake --build build-runtime --target runtime -- -j8`
- `cmake --build build -- -j8`
- Focused `pub`, label, selective-import, buf, unsafe, and HTTP tests passed.
- Windows amd64 runtime build passed with Zig 0.14.1.
- Windows amd64 cross-compilation passed for os/syscall, io/unsafe, and HTTP entry points.
- `jq empty nls/syntaxes/n.tmLanguage.json`
- Repository search confirms no remaining `#local` or `MACRO_LOCAL` matches in tracked files.

Full `ctest` result: 223/225 passed. The two local failures were:

- `20250324_00_llama`: the untracked `stories15M.bin` fixture is not present in this worktree.
- `20250802_02_http`: TLS handshake failed locally with `CTR_DRBG - The requested random buffer length is too big`.
