### PR TITLE
fix: any assert to IND slot write through pointer instead of address-of target

### DIFF
--- a/src/linear.c
+++ b/src/linear.c
@@ -3391,8 +3391,19 @@ static lir_operand_t *linear_as_expr(module_t *m, ast_expr_t expr, lir_operand_t
             OP_PUSH(lir_op_move(target, temp));
             return target;
         } else {
-            // indirect, like struct/vec 等总是会进行分配 def, 所以不需要特殊 def
-            lir_operand_t *output_ref = lea_operand_pointer(m, target);
+            // indirect, like struct/vec always have allocation def, so no special def needed
+            // Consistent with the any assert / any_casting / union_casting branches: a VAR target's value
+            // is the write address (a lir_stack_alloc temp object address, a map assign value slot address,
+            // or a ref field address), so move it into an anyptr temp and pass by value. Taking the address
+            // of a VAR target would make union_assert overflow the target's own spill slot and adjacent
+            // stack slots; passing IND struct params directly is also wrong, because the call ABI re-stages
+            // them by value into a temporary copy, so the assert result would be written into a dead copy.
+            lir_operand_t *output_ref = temp_var_operand(m, type_kind_new(TYPE_ANYPTR));
+            lir_operand_t *out_src = target;
+            if (target->assert_type == LIR_OPERAND_INDIRECT_ADDR || target->assert_type == LIR_OPERAND_SYMBOL_VAR) {
+                out_src = lea_operand_pointer(m, target);
+            }
+            OP_PUSH(lir_op_move(output_ref, out_src));
             uint64_t target_rtype_hash = type_hash(as_expr->target_type);
             lir_operand_t *union_ptr = temp_var_operand(m, type_kind_new(TYPE_ANYPTR));
             OP_PUSH(lir_op_move(union_ptr, src_operand));
@@ -3413,11 +3424,25 @@ static lir_operand_t *linear_as_expr(module_t *m, ast_expr_t expr, lir_operand_t
     // interface as
     if (as_expr->src.type.kind == TYPE_INTERFACE) {
         assert(as_expr->target_type.kind != TYPE_INTERFACE);
-        OP_PUSH(lir_op_nop_def(target));
 
-        lir_operand_t *output_ref = target;
+        lir_operand_t *output_ref;
         if (as_expr->target_type.storage_kind != STORAGE_KIND_IND) {
+            // nop_def marks the variable as written by the runtime, since the target may otherwise lack a def
+            OP_PUSH(lir_op_nop_def(target));
             output_ref = lea_operand_pointer(m, target);
+        } else {
+            // indirect, like struct/vec always have allocation def, so no special def needed
+            // Consistent with the any assert / union assert / any_casting branches: a VAR target's value is
+            // the write address (a lir_stack_alloc temp object address, a map assign value slot address, or
+            // a ref field address), so move it into an anyptr temp and pass by value. IND struct params must
+            // not be passed directly: the call ABI re-stages them by value (e.g. a 16B HFA expands into
+            // float registers), writing the assert result into a dead copy or a wrong address.
+            output_ref = temp_var_operand(m, type_kind_new(TYPE_ANYPTR));
+            lir_operand_t *out_src = target;
+            if (target->assert_type == LIR_OPERAND_INDIRECT_ADDR || target->assert_type == LIR_OPERAND_SYMBOL_VAR) {
+                out_src = lea_operand_pointer(m, target);
+            }
+            OP_PUSH(lir_op_move(output_ref, out_src));
         }
 
         uint64_t target_rtype_hash = type_hash(as_expr->target_type);

--- a/src/linear.c
+++ b/src/linear.c
@@ -3352,8 +3352,20 @@ static lir_operand_t *linear_as_expr(module_t *m, ast_expr_t expr, lir_operand_t
             OP_PUSH(lir_op_move(target, temp));
             return target;
         } else {
-            // indirect, like struct/vec 等总是会进行分配 def, 所以不需要特殊 def
-            lir_operand_t *output_ref = lea_operand_pointer(m, target);
+            // indirect, like struct/vec always have allocation def, so no special def needed
+            // Consistent with the any_casting/union_casting branches below: a VAR target's value is the
+            // write address (a lir_stack_alloc temp object address, a map assign value slot address, or a
+            // ref field address), so move it into an anyptr temp and pass by value. Taking the address of
+            // a VAR target would make any_assert overflow the target's own spill slot and adjacent stack
+            // slots; passing IND struct params directly is also wrong, because the call ABI re-stages them
+            // by value into a temporary copy, so the assert result would be written into a dead copy.
+            lir_operand_t *output_ref = temp_var_operand(m, type_kind_new(TYPE_ANYPTR));
+            lir_operand_t *out_src = target;
+            if (target->assert_type == LIR_OPERAND_INDIRECT_ADDR ||
+                target->assert_type == LIR_OPERAND_SYMBOL_VAR) {
+                out_src = lea_operand_pointer(m, target);
+            }
+            OP_PUSH(lir_op_move(output_ref, out_src));
             uint64_t target_rtype_hash = type_hash(as_expr->target_type);
             lir_operand_t *any_ptr = temp_var_operand(m, type_kind_new(TYPE_ANYPTR));
             OP_PUSH(lir_op_move(any_ptr, src_operand));

--- a/src/linear.c
+++ b/src/linear.c
@@ -3352,13 +3352,7 @@ static lir_operand_t *linear_as_expr(module_t *m, ast_expr_t expr, lir_operand_t
             OP_PUSH(lir_op_move(target, temp));
             return target;
         } else {
-            // indirect, like struct/vec always have allocation def, so no special def needed
-            // Consistent with the any_casting/union_casting branches below: a VAR target's value is the
-            // write address (a lir_stack_alloc temp object address, a map assign value slot address, or a
-            // ref field address), so move it into an anyptr temp and pass by value. Taking the address of
-            // a VAR target would make any_assert overflow the target's own spill slot and adjacent stack
-            // slots; passing IND struct params directly is also wrong, because the call ABI re-stages them
-            // by value into a temporary copy, so the assert result would be written into a dead copy.
+            // VAR target's value is the write address: pass it by value, lea only for I_ADDR/SYMBOL_VAR
             lir_operand_t *output_ref = temp_var_operand(m, type_kind_new(TYPE_ANYPTR));
             lir_operand_t *out_src = target;
             if (target->assert_type == LIR_OPERAND_INDIRECT_ADDR ||
@@ -3391,13 +3385,7 @@ static lir_operand_t *linear_as_expr(module_t *m, ast_expr_t expr, lir_operand_t
             OP_PUSH(lir_op_move(target, temp));
             return target;
         } else {
-            // indirect, like struct/vec always have allocation def, so no special def needed
-            // Consistent with the any assert / any_casting / union_casting branches: a VAR target's value
-            // is the write address (a lir_stack_alloc temp object address, a map assign value slot address,
-            // or a ref field address), so move it into an anyptr temp and pass by value. Taking the address
-            // of a VAR target would make union_assert overflow the target's own spill slot and adjacent
-            // stack slots; passing IND struct params directly is also wrong, because the call ABI re-stages
-            // them by value into a temporary copy, so the assert result would be written into a dead copy.
+            // VAR target's value is the write address: pass it by value, lea only for I_ADDR/SYMBOL_VAR
             lir_operand_t *output_ref = temp_var_operand(m, type_kind_new(TYPE_ANYPTR));
             lir_operand_t *out_src = target;
             if (target->assert_type == LIR_OPERAND_INDIRECT_ADDR || target->assert_type == LIR_OPERAND_SYMBOL_VAR) {
@@ -3427,16 +3415,11 @@ static lir_operand_t *linear_as_expr(module_t *m, ast_expr_t expr, lir_operand_t
 
         lir_operand_t *output_ref;
         if (as_expr->target_type.storage_kind != STORAGE_KIND_IND) {
-            // nop_def marks the variable as written by the runtime, since the target may otherwise lack a def
+            // nop_def marks the variable as written by the runtime
             OP_PUSH(lir_op_nop_def(target));
             output_ref = lea_operand_pointer(m, target);
         } else {
-            // indirect, like struct/vec always have allocation def, so no special def needed
-            // Consistent with the any assert / union assert / any_casting branches: a VAR target's value is
-            // the write address (a lir_stack_alloc temp object address, a map assign value slot address, or
-            // a ref field address), so move it into an anyptr temp and pass by value. IND struct params must
-            // not be passed directly: the call ABI re-stages them by value (e.g. a 16B HFA expands into
-            // float registers), writing the assert result into a dead copy or a wrong address.
+            // VAR target's value is the write address: pass it by value, lea only for I_ADDR/SYMBOL_VAR
             output_ref = temp_var_operand(m, type_kind_new(TYPE_ANYPTR));
             lir_operand_t *out_src = target;
             if (target->assert_type == LIR_OPERAND_INDIRECT_ADDR || target->assert_type == LIR_OPERAND_SYMBOL_VAR) {

--- a/tests/features/20260821_00_map_any_assert_assign.c
+++ b/tests/features/20260821_00_map_any_assert_assign.c
@@ -1,0 +1,6 @@
+#include "tests/test.h"
+
+int main(void) {
+    //    TEST_EXEC_IMM
+    feature_testar_test(NULL);
+}

--- a/tests/features/cases/20260821_00_map_any_assert_assign.testar
+++ b/tests/features/cases/20260821_00_map_any_assert_assign.testar
@@ -123,3 +123,84 @@ h2= v 3
 t= 0 v
 vl= v z
 arr= v b
+
+=== test_union_assert_ind_slot
+--- main.n
+// issue #315 same-family scenario: a union assert result written into an IND slot must not take the
+// address of the target either, otherwise union_assert overflows the target's spill slot and adjacent
+// slots
+type m_union = {string:any}|string
+
+fn main() {
+    any a = {'n': 'deep'}
+    m_union um = a as {string:any}
+    m_union us = 'value-string'
+
+    {string:{string:any}} m = {}
+    m['k'] = um as {string:any}
+    println('m=', m['k']['n'])
+
+    {string:string} ms = {}
+    ms['k'] = us as string
+    println('ms=', ms['k'])
+
+    var mm = um as {string:any}
+    println('mm=', mm['n'])
+
+    var ss = us as string
+    println('ss=', ss)
+}
+
+--- output.txt
+m= deep
+ms= value-string
+mm= deep
+ss= value-string
+
+=== test_interface_assert_ind_slot
+--- main.n
+// issue #315 same-family scenario: writing an interface assert result into an IND slot must pass the
+// VAR target's address by value; IND struct params must not be passed directly, or the call ABI
+// re-stages them by value (an HFA expands into float registers) and the assert result is written into
+// a dead copy or a wrong address
+type measurable<T> = interface{
+	fn area():T
+	fn perimeter():T
+}
+
+type rectangle: measurable<f64> = struct{
+	f64 width
+	f64 height
+}
+
+fn rectangle.area(&self):f64 {
+	return self.width * self.height
+}
+
+fn rectangle.perimeter(&self):f64 {
+	return 2 * (self.width + self.height)
+}
+
+type holder_t = struct {
+    rectangle r = rectangle{width: 0, height: 0}
+}
+
+fn main():void! {
+    measurable<f64> s = rectangle{width:3, height:4}
+
+    var r = s as rectangle
+    println('r=', r.width, r.height)
+
+    var h = new holder_t()
+    h.r = s as rectangle
+    println('h=', h.r.width, h.r.height)
+
+    {string:rectangle} m = {}
+    m['k'] = s as rectangle
+    println('m=', m['k'].width, m['k'].height)
+}
+
+--- output.txt
+r= 3.000000 4.000000
+h= 3.000000 4.000000
+m= 3.000000 4.000000

--- a/tests/features/cases/20260821_00_map_any_assert_assign.testar
+++ b/tests/features/cases/20260821_00_map_any_assert_assign.testar
@@ -1,8 +1,6 @@
 === test_map_assign_any_assert_return
 --- main.n
-// issue #315: writing an any assert result directly into a map value slot wrongly took the address
-// of the anyptr target, making any_assert overflow adjacent spill slots; returning the map from the
-// function then crashed reliably with SIGSEGV
+// issue #315: any assert into a map value slot wrongly took the address of the anyptr target, overflowing adjacent spill slots and crashing on return
 type options_t = struct {
     {string:string} headers = {}
 }
@@ -56,9 +54,7 @@ v
 
 === test_ind_assert_slot_targets
 --- main.n
-// issue #315 same-family scenario: any assert results written into various IND slots
-// (struct field/tuple/vec/array/map); the targets are all anyptr/ref temp variables whose
-// value is the write address, so taking their address is not allowed
+// issue #315 same-family scenario: any assert results into various IND slots whose anyptr/ref targets must be passed by value
 type holder_t = struct {
     string name = ''
     int x = 0
@@ -126,9 +122,7 @@ arr= v b
 
 === test_union_assert_ind_slot
 --- main.n
-// issue #315 same-family scenario: a union assert result written into an IND slot must not take the
-// address of the target either, otherwise union_assert overflows the target's spill slot and adjacent
-// slots
+// issue #315 same-family scenario: a union assert result into an IND slot must not take the address of the target either
 type m_union = {string:any}|string
 
 fn main() {
@@ -159,10 +153,7 @@ ss= value-string
 
 === test_interface_assert_ind_slot
 --- main.n
-// issue #315 same-family scenario: writing an interface assert result into an IND slot must pass the
-// VAR target's address by value; IND struct params must not be passed directly, or the call ABI
-// re-stages them by value (an HFA expands into float registers) and the assert result is written into
-// a dead copy or a wrong address
+// issue #315 same-family scenario: an interface assert result into an IND slot must pass the VAR target's address by value, not the IND param directly
 type measurable<T> = interface{
 	fn area():T
 	fn perimeter():T

--- a/tests/features/cases/20260821_00_map_any_assert_assign.testar
+++ b/tests/features/cases/20260821_00_map_any_assert_assign.testar
@@ -1,0 +1,125 @@
+=== test_map_assign_any_assert_return
+--- main.n
+// issue #315: writing an any assert result directly into a map value slot wrongly took the address
+// of the anyptr target, making any_assert overflow adjacent spill slots; returning the map from the
+// function then crashed reliably with SIGSEGV
+type options_t = struct {
+    {string:string} headers = {}
+}
+
+fn stream_option_headers(any value): {string:string}! {
+    if !(value is {string:any}) {throw errorf('headers must be an object')}
+    {string:string} result = {}
+    for name, item in value as {string:any} {
+        if !(item is string) {throw errorf('header must be a string')}
+        result[name] = item as string
+    }
+    return result
+}
+
+fn set_runtime_stream_options(ref<options_t> options, {string:any} value): void! {
+    if value.contains('headers') {
+        {string:string} headers = stream_option_headers(value['headers'])
+        options.headers = headers
+    }
+}
+
+fn main() {
+    var options = new options_t()
+    {string:any} headers = {}
+    headers['x-repro'] = 'yes'
+    {string:any} value = {}
+    value['headers'] = headers
+    set_runtime_stream_options(options, value) catch error {println(error.msg()); return}
+    println(options.headers['x-repro'])
+}
+
+--- output.txt
+yes
+
+=== test_map_new_any_assert_value
+--- main.n
+// issue #315 same-family scenario: map literal value is an any assert expression
+fn main() {
+    {string:string} m = {}
+    m['a'] = 'x'
+    println(m['a'])
+
+    {string:any} src = {'k': 'v'}
+    {string:string} n = {'b': src['k'] as string}
+    println(n['b'])
+}
+
+--- output.txt
+x
+v
+
+=== test_ind_assert_slot_targets
+--- main.n
+// issue #315 same-family scenario: any assert results written into various IND slots
+// (struct field/tuple/vec/array/map); the targets are all anyptr/ref temp variables whose
+// value is the write address, so taking their address is not allowed
+type holder_t = struct {
+    string name = ''
+    int x = 0
+}
+
+fn main() {
+    {string:any} src = {}
+    src['s'] = 'v'
+    src['v'] = [1, 2, 3]
+    src['set'] = {7, 8}
+    src['h'] = holder_t {name: 'nn', x: 5}
+    src['m'] = {'n': 'deep'}
+
+    {string:string} a = {}
+    a['r1'] = src['s'] as string
+    println('a=', a['r1'])
+
+    {string:[any]} av = {}
+    av['r'] = src['v'] as [any]
+    println('av=', av['r'][0], av['r'][2])
+
+    {string:{int}} aset = {}
+    aset['r'] = src['set'] as {int}
+    {int} s7 = aset['r']
+    println('aset=', s7.contains(7), s7.contains(9))
+
+    {string:holder_t} ah = {}
+    ah['r'] = src['h'] as holder_t
+    println('ah=', ah['r'].name, ah['r'].x)
+
+    {string:{string:any}} am = {}
+    am['r'] = src['m'] as {string:any}
+    println('am=', am['r']['n'])
+
+    var h = new holder_t()
+    h.name = src['s'] as string
+    println('h=', h.name)
+
+    var h2 = holder_t {name: src['s'] as string, x: 3}
+    println('h2=', h2.name, h2.x)
+
+    var t = (0, '')
+    t[1] = src['s'] as string
+    println('t=', t[0], t[1])
+
+    [string] vl = [src['s'] as string, 'z']
+    println('vl=', vl[0], vl[1])
+
+    [string] arr = ['a', 'b']
+    arr[0] = src['s'] as string
+    println('arr=', arr[0], arr[1])
+}
+
+--- output.txt
+a= v
+av= 1 3
+aset= true false
+ah= nn 5
+am= deep
+h= v
+h2= v 3
+t= 0 v
+vl= v z
+arr= v b


### PR DESCRIPTION
## Problem

Fixes #315

On macOS ARM64, extracting a `{string:any}` from an `any` value, iterating it, and returning the resulting map from a function crashes reliably with SIGSEGV. The actual trigger condition is broader than the issue title: any assignment form that writes an "assert result directly into an IND slot" can corrupt memory; whether it surfaces as a crash depends on what lives in the adjacent spill slots.

## Root cause

Three assert branches in `linear_as_expr` mishandled IND targets, each in a slightly different way:

1. **any assert**: called `lea_operand_pointer(m, target)` for VAR targets. Callers such as map assign / map literal / struct field assign / tuple assign / vec·array literal pass a target that is an anyptr/ref variable **whose value is the write address** (e.g. the value-slot pointer returned by `rt_map_assign`). Taking the address of the variable itself made `any_assert` memmove `storage_size` bytes (e.g. 48 for string) into an 8-byte spill slot, overflowing adjacent slots. When a neighbor slot held a pointer that stays live across the assert (the spilled `result` map address used after the loop), the return-copy phase dereferenced garbage → SIGSEGV.
2. **union assert**: the same unconditional `lea_operand_pointer` on VAR targets.
3. **interface assert**: passed IND struct parameters directly; the call ABI re-stages them by value (a 16-byte HFA expands into float registers), so `value_ref` received a wrong address and the result was written nowhere (or to garbage). The `nop_def` on ref VARs additionally dropped the field address obtained by the earlier `lea`.

The `any_casting`/`union_casting`/`tagged_union_casting` branches in the same function already follow the correct convention: **the VAR target's value is the write address**.

## Fix

Align all three assert branches with that convention:

- VAR target (any storage_kind, including ref types with unset storage_kind=0 produced by `type_refof`): move its value into an anyptr temp and pass by value;
- only I_ADDR/SYMBOL_VAR targets compute the address via `lea_operand_pointer`;
- IND struct parameters are never passed directly, because the call ABI re-stages >16-byte IND arguments into temporary copies.

## Scope

- Compiler: `src/linear.c` (any / union / interface assert IND branches)
- Tests: new `tests/features/cases/20260821_00_map_any_assert_assign.testar` covering map assign / map literal / struct field & literal / tuple / vec / array write points × string / map / vec / set / struct assert types, plus union and interface assert slot writes

## Verification

- Issue #315 reproducer: stable exit=139 before the fix, `yes` 20/20 after
- Probe programs covering 13 "slot write point × IND assert type" combinations pass; union/interface slot-write probes (including a 32-byte struct) pass
- Full `ctest`: 226/226 pass (macOS ARM64)
