### PR TITLE
fix: guard string.find_after against nil data of zero-value strings

### DIFF
--- a/std/strings/strings.n
+++ b/std/strings/strings.n
@@ -27,6 +27,12 @@ pub fn string.find_after(self, string sub, int after):int {
         return -1
     }
 
+    // zero-value string fields carry a nil data ptr, libc.strstr on it would
+    // segfault, an empty haystack never contains sub anyway
+    if self.len() == 0 {
+        return -1
+    }
+
     if (n == 1) {
         return self.find_char(sub[0], after)
     }

--- a/tests/features/20260823_00_nil_string_find.c
+++ b/tests/features/20260823_00_nil_string_find.c
@@ -1,0 +1,5 @@
+#include "tests/test.h"
+
+int main(void) {
+    TEST_EXEC_IMM
+}

--- a/tests/features/cases/20260823_00_nil_string_find.n
+++ b/tests/features/cases/20260823_00_nil_string_find.n
@@ -1,0 +1,36 @@
+// regression for issue #318: a zero-value string field carries a nil data ptr,
+// find_after must not hand it to libc.strstr
+type opts_t = struct {
+    string api_key
+    int n
+}
+
+fn main(): void {
+    var o = new opts_t(n = 1)
+
+    // len reads the zeroed length field only
+    assert(o.api_key.len() == 0)
+
+    // multi-char needle used to hit libc.strstr(NULL, ...) -> SIGSEGV
+    assert(o.api_key.contains('sk-ant-oat') == false)
+    assert(o.api_key.find('sk-ant') == -1)
+    assert(o.api_key.find_after('sk-ant', 0) == -1)
+
+    // single-char needle walks the find_char path
+    assert(o.api_key.contains('x') == false)
+    assert(o.api_key.find('x') == -1)
+
+    // empty literal haystack stays -1 as well
+    var s = ''
+    assert(s.contains('abc') == false)
+    assert(s.find('abc') == -1)
+
+    // non-empty strings keep working through strstr
+    var t = 'hello world'
+    assert(t.contains('world') == true)
+    assert(t.find('world') == 6)
+    assert(t.find('nope') == -1)
+    assert(t.contains('') == false)
+
+    println('nil string find ok')
+}


### PR DESCRIPTION
## Summary

Fixes #318.

A `string` struct field declared without a default value is zero-initialized on `new T(...)`, leaving its data pointer nil and its length 0. `string.find_after` handed that pointer straight to `libc.strstr`, so any multi-character `.contains()` / `.find()` on such a field segfaulted deterministically (`strstr(NULL, ...)`).

## Root cause

- `opts.api_key.len()` reads only the zeroed length field → safe, returns 0
- `.contains('sk-ant-oat')` / `.find('sk-ant')` (needle length ≥ 2) reach the `libc.strstr(base + after, sub)` call in `std/strings/strings.n` → SIGSEGV
- single-char needles walk the pure-nature `find_char` loop and were already safe

This matches the lldb trace in the issue comments (`_platform_strstr + 52, address=0x0`). Note the original issue-body repro (map field with `{}` default) does not crash; map defaults produce valid empty maps.

## Fix (+6 lines)

`find_after` returns `-1` early when the haystack is empty:

- an empty haystack can never contain `sub`
- valid empty strings already resolved to `-1` via `strstr` returning NULL, so semantics are unchanged for all callers (`find` / `split` / `replace` / `contains`)

## Test

New regression case `tests/features/cases/20260823_00_nil_string_find.n` covers:

- multi-char `contains` / `find` / `find_after` on a zero-value string field (SIGSEGV before this change)
- single-char needle and empty-literal haystack paths
- non-empty strings keep working through `strstr`

Verified the test fails with SegFault when the fix is reverted and passes with it.

## Verification

```
cmake -B build -S . && cmake --build build -- -j8
cd build && ctest
```

226 tests: 223 passed. The 3 failures (`20250716_00_tcp`, `20250723_00_udp`, `20250802_02_http`) are pre-existing local-environment failures (proxy DNS interception, fake-IP range) — they fail identically without this change.