### PR TITLE
fix(compiler): avoid expanding large array initialization

### DIFF
--- a/src/linear.c
+++ b/src/linear.c
@@ -1475,9 +1475,15 @@ static void linear_vardef(module_t *m, ast_vardef_stmt_t *stmt) {
     // 左值右值主要提现在，vardef/var_tup_def/assign/call(arg)
     lir_operand_t *dst = linear_var_decl(m, &stmt->var_decl);
     assert(stmt->right);
-    lir_operand_t *src = linear_expr(m, *stmt->right, NULL);
-
-    linear_super_move(m, stmt->var_decl.type, dst, src);
+    bool direct_heap_array_init = stmt->right->assert_type == AST_EXPR_ARRAY_NEW &&
+                                  stmt->var_decl.type.in_heap &&
+                                  stmt->var_decl.type.array->element_type.storage_kind == STORAGE_KIND_DIR;
+    if (direct_heap_array_init) {
+        linear_expr(m, *stmt->right, dst);
+    } else {
+        lir_operand_t *src = linear_expr(m, *stmt->right, NULL);
+        linear_super_move(m, stmt->var_decl.type, dst, src);
+    }
 
     // 将 dst 值 copy 出来进行重新分配改写
     linear_escape_rewrite(m, &stmt->var_decl, false);
@@ -2614,7 +2620,12 @@ static lir_operand_t *linear_array_new(module_t *m, ast_expr_t expr, lir_operand
 
     int64_t offset = 0;
     // 无论 array 分配在栈还是堆，都需要进行数据初始化，当然有一些例外情况可以进行优化
-    for (int i = 0; i < type_array.array->length; ++i) {
+    uint64_t initialize_length = type_array.array->length;
+    if (arr_in_heap && type_array.array->element_type.storage_kind == STORAGE_KIND_DIR) {
+        initialize_length = ast->elements->length;
+    }
+
+    for (uint64_t i = 0; i < initialize_length; ++i) {
         lir_operand_t *item_target = linear_inline_arr_element_addr_not_check(m, target_ref, int_operand(i),
                                                                               type_array);
 
@@ -2626,12 +2637,7 @@ static lir_operand_t *linear_array_new(module_t *m, ast_expr_t expr, lir_operand
             ast_expr_t *item_expr = ct_list_value(ast->elements, i);
             linear_expr(m, *item_expr, item_target);
         } else {
-            // in stack
-            if (arr_in_heap && type_array.array->element_type.storage_kind == STORAGE_KIND_DIR) {
-                // default is zero, not need set default value
-            } else {
-                linear_default_operand(m, type_array.array->element_type, item_target);
-            }
+            linear_default_operand(m, type_array.array->element_type, item_target);
         }
     }
 

--- a/tests/features/20260824_00_large_fixed_array.c
+++ b/tests/features/20260824_00_large_fixed_array.c
@@ -1,0 +1,7 @@
+#include "tests/test.h"
+
+int main(void) {
+    alarm(10);
+    TEST_EXEC_IMM
+    alarm(0);
+}

--- a/tests/features/cases/20260824_00_large_fixed_array.n
+++ b/tests/features/cases/20260824_00_large_fixed_array.n
@@ -1,0 +1,18 @@
+fn main(): void {
+    [i64; 500000] values = []
+
+    assert(values[0] == 0)
+    assert(values[250000] == 0)
+    assert(values[499999] == 0)
+
+    values[0] = 42
+    values[499999] = 7
+    assert(values[0] == 42)
+    assert(values[499999] == 7)
+
+    [i64; 500000] initialized = [1, 2, 3]
+    assert(initialized[0] == 1)
+    assert(initialized[2] == 3)
+    assert(initialized[3] == 0)
+    assert(initialized[499999] == 0)
+}


### PR DESCRIPTION
## Summary

- initialize heap-backed fixed arrays with scalar elements directly in their final destination
- generate initialization LIR only for explicitly supplied array-literal elements because GC allocations already provide zeroed memory
- preserve the existing initialization paths for stack arrays and arrays with indirect elements
- add a regression test for empty and partially initialized fixed arrays with 500,000 i64 elements

## Root cause

A local fixed-array declaration first allocated a temporary array and then copied the entire value into the declared variable. lir_memory_mov expanded the 4 MiB copy into 500,000 eight-byte copies and about one million move operations. SSA processing over the resulting temporary variables then became pathologically expensive.

linear_array_new also iterated over the full declared array length even when the array was heap allocated, its scalar tail was already zeroed, and no default-value stores were needed. It still emitted index, multiplication, and address-calculation LIR for every omitted element.

The change is limited to heap-backed fixed-array literals whose elements use direct scalar storage. Those literals are initialized in place, and only explicit elements produce LIR. Other array categories continue through the original path.

## Reproduction

The new test uses the issue reproducer size:

    [i64; 500000] values = []

Before the fix, the test did not finish compilation within 10 seconds and was terminated by SIGALRM. After the fix, the same compile-and-run test completes in about 1.2 seconds. A direct command-line build with the rebuilt compiler completed in about 0.89 seconds.

## Tests

- runtime target rebuilt successfully
- nature target and all test binaries rebuilt successfully
- six focused array, escape-analysis, and indirect-element-array tests passed
- final regression and compatibility rerun passed 3 of 3 tests
- git diff --check passed

Fixes #321.