### PR TITLE
fix(runtime): detach GC worker threads

### DIFF
--- a/runtime/allocator.c
+++ b/runtime/allocator.c
@@ -1422,6 +1422,19 @@ uint64_t runtime_malloc_bytes() {
     return allocated_bytes;
 }
 
+static void runtime_gc_start() {
+    uv_thread_t thread;
+    int result = uv_thread_create(&thread, runtime_gc, NULL);
+    if (result != 0) {
+        gc_stage = GC_STAGE_OFF;
+        assertf(false, "create gc thread failed: %d", result);
+        return;
+    }
+
+    result = rt_thread_detach(thread);
+    assertf(result == 0, "detach gc thread failed: %d", result);
+}
+
 void runtime_eval_gc() {
     mutex_lock(&gc_stage_locker);
 
@@ -1440,8 +1453,7 @@ void runtime_eval_gc() {
     }
 
     gc_stage = GC_STAGE_START;
-    uv_thread_t runtime_gc_thread;
-    uv_thread_create(&runtime_gc_thread, runtime_gc, NULL);
+    runtime_gc_start();
 
 EXIT:
     mutex_unlock(&gc_stage_locker);
@@ -1460,8 +1472,7 @@ void runtime_force_gc() {
     }
 
     gc_stage = GC_STAGE_START;
-    uv_thread_t runtime_gc_thread;
-    uv_thread_create(&runtime_gc_thread, runtime_gc, NULL);
+    runtime_gc_start();
 
 EXIT:
     mutex_unlock(&gc_stage_locker);

--- a/runtime/uv_compat.h
+++ b/runtime/uv_compat.h
@@ -44,4 +44,12 @@
 #pragma pop_macro("WORD")
 #endif
 
+static inline int rt_thread_detach(uv_thread_t thread) {
+#ifdef __WINDOWS
+    return CloseHandle(thread) ? 0 : -1;
+#else
+    return pthread_detach(thread);
+#endif
+}
+
 #endif // NATURE_RUNTIME_UV_COMPAT_H

--- a/tests/features/20260824_04_gc_worker_cleanup.c
+++ b/tests/features/20260824_04_gc_worker_cleanup.c
@@ -1,0 +1,83 @@
+#include "tests/test.h"
+
+#ifndef __WINDOWS
+#include <signal.h>
+#include <sys/wait.h>
+
+#ifdef __DARWIN
+#include <libproc.h>
+#include <sys/resource.h>
+
+static uint64_t process_footprint(pid_t pid) {
+    struct rusage_info_v4 usage = {0};
+    int result = proc_pid_rusage(pid, RUSAGE_INFO_V4, (rusage_info_t *) &usage);
+    assertf(result == 0, "proc_pid_rusage failed: %s", strerror(errno));
+    return usage.ri_phys_footprint;
+}
+#endif
+
+static bool wait_for_marker(FILE *output, const char *marker) {
+    char line[256];
+    while (fgets(line, sizeof(line), output)) {
+        if (strstr(line, marker)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+int main(void) {
+    feature_test_build();
+
+    int output_pipe[2];
+    assertf(pipe(output_pipe) == 0, "pipe failed: %s", strerror(errno));
+
+    pid_t child = fork();
+    assertf(child >= 0, "fork failed: %s", strerror(errno));
+    if (child == 0) {
+        close(output_pipe[0]);
+        dup2(output_pipe[1], STDOUT_FILENO);
+        close(output_pipe[1]);
+        if (WORKDIR) {
+            VOID chdir(WORKDIR);
+        }
+        execl(BUILD_OUTPUT, BUILD_OUTPUT, NULL);
+        _exit(127);
+    }
+
+    close(output_pipe[1]);
+    FILE *output = fdopen(output_pipe[0], "r");
+    assert(output);
+
+    bool baseline_ready = wait_for_marker(output, "gc-worker-baseline");
+#ifdef __DARWIN
+    uint64_t baseline = baseline_ready ? process_footprint(child) : 0;
+#endif
+    bool completed = baseline_ready && wait_for_marker(output, "gc-worker-done");
+#ifdef __DARWIN
+    uint64_t after = completed ? process_footprint(child) : 0;
+#endif
+
+    kill(child, SIGKILL);
+    fclose(output);
+
+    int status = 0;
+    waitpid(child, &status, 0);
+    assertf(baseline_ready, "GC worker fixture exited before reporting baseline");
+    assertf(completed, "GC worker fixture exited before completing GC cycles");
+
+#ifdef __DARWIN
+    uint64_t growth = after > baseline ? after - baseline : 0;
+    const uint64_t max_growth = 16 * 1024 * 1024;
+    LOGF("GC worker footprint growth: %llu bytes", (unsigned long long) growth);
+    assertf(growth < max_growth,
+            "physical footprint grew across GC cycles: %llu bytes (limit %llu)",
+            (unsigned long long) growth, (unsigned long long) max_growth);
+#endif
+    return 0;
+}
+#else
+int main(void) {
+    TEST_EXEC_IMM
+}
+#endif

--- a/tests/features/cases/20260824_04_gc_worker_cleanup.n
+++ b/tests/features/cases/20260824_04_gc_worker_cleanup.n
@@ -1,0 +1,38 @@
+import co
+import fmt
+import runtime
+
+fn churn(int cycle):string {
+    [string] parts = []
+    for int j = 0; j < 64; j += 1 {
+        var src = fmt.sprintf('churn-payload-line-%d-x%d', j, cycle)
+        parts.push(src.slice(0, 6))
+        parts.push(src.slice(6, 12))
+        parts.push(src.slice(3, 9))
+    }
+    return parts[0]
+}
+
+fn main():void! {
+    var anchor = ''
+
+    // Warm up the scheduler and GC before measuring process footprint.
+    for int cycle = 0; cycle < 20; cycle += 1 {
+        anchor = churn(cycle)
+        runtime.gc()
+        co.sleep(15)
+    }
+
+    println('gc-worker-baseline')
+    co.sleep(500)
+
+    for int cycle = 0; cycle < 800; cycle += 1 {
+        anchor = churn(cycle)
+        runtime.gc()
+        co.sleep(15)
+    }
+
+    assert(anchor.len() > 0)
+    println('gc-worker-done')
+    co.sleep(1000)
+}


### PR DESCRIPTION
## Summary

- detach each short-lived GC worker so exited thread resources are reclaimed
- keep GC execution off the sysmon thread and preserve the existing asynchronous behavior
- use pthread_detach on POSIX and CloseHandle on Windows
- add a Darwin footprint regression test covering repeated forced GC cycles

## Testing

- cmake --build build-runtime --target runtime -- -j8
- related GC suite: 6/6 passed
- ctest --test-dir build -R ^20260824_04_gc_worker_cleanup$ -V
- Darwin regression result: about 7.77 MB footprint growth after 800 cycles, versus about 33.9 MB before the fix

Closes #328