### PR TITLE
fix(runtime): preserve any payloads across GC

### DIFF
--- a/src/rtype.h
+++ b/src/rtype.h
@@ -468,7 +468,9 @@ static inline rtype_t rtype_union(type_t t) {
 
 /**
  * any: { rtype_t *rtype; value_casting value; }
- * value runtime type not fixed, conservatively scan all slots
+ * The runtime type and the dynamically typed payload are both pointers in
+ * the representation. The payload is conservatively scanned because its
+ * concrete type is only known at runtime.
  */
 static inline rtype_t rtype_any(type_t t) {
     int64_t any_size = t.storage_size;
@@ -484,7 +486,10 @@ static inline rtype_t rtype_any(type_t t) {
             .length = 0,
     };
 
-    bitmap_set(CTDATA(rtype.malloc_gc_bits_offset), 0);
+    int64_t slot_count = align_up(any_size, POINTER_SIZE) / POINTER_SIZE;
+    for (int64_t i = 0; i < slot_count; ++i) {
+        bitmap_set(CTDATA(rtype.malloc_gc_bits_offset), i);
+    }
 
     return rtype;
 }

--- a/tests/features/20260827_00_json_map_any_gc.c
+++ b/tests/features/20260827_00_json_map_any_gc.c
@@ -1,0 +1,5 @@
+#include "tests/test.h"
+
+int main(void) {
+    feature_testar_test(NULL);
+}

--- a/tests/features/cases/20260827_00_json_map_any_gc.testar
+++ b/tests/features/cases/20260827_00_json_map_any_gc.testar
@@ -1,0 +1,38 @@
+=== test_json_map_any_gc[os=darwin,arch=arm64]
+--- main.n
+import co
+import json
+import runtime
+
+const CONTENT_BYTES = 16 * 1024
+const CYCLE_COUNT = 64
+
+fn fill(string seed, int wanted): string {
+    string result = ''
+    for result.len() < wanted {
+        result += seed
+    }
+    return result.slice(0, wanted)
+}
+
+fn make_document_fields(string content): any {
+    {string:any} fields = {}
+    fields['path'] = '/tmp/pelican-bike.html'
+    fields['content'] = content
+    return fields
+}
+
+fn main(): void! {
+    string document = fill('<svg><text>pelican bicycle animation</text></svg>', CONTENT_BYTES)
+    any document_fields = make_document_fields(document)
+
+    for int cycle = 0; cycle < CYCLE_COUNT; cycle += 1 {
+        string encoded = json.serialize(document_fields)
+        assert(encoded.len() == 16430)
+
+        if cycle % 8 == 7 {
+            runtime.gc()
+            co.yield()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Fix `rtype_any` GC metadata to trace every pointer-sized slot in `n_any_t`.
- Add a darwin/arm64 regression test for repeated JSON serialization of a retained `{string:any}` map across explicit GC cycles.

`n_any_t` stores both the runtime type pointer and the dynamically typed payload. The previous GC bitmap marked only the first slot, so heap-backed payloads such as maps could be reclaimed and later observed as corrupted type hashes.

Fixes #336

## Verification

- `cmake --build build --target nature 20260827_00_json_map_any_gc -- -j8`
- `ctest --test-dir build -R '^20260827_00_json_map_any_gc$' --output-on-failure`
- Focused JSON tests: `20250623_01_json`, `20250623_02_json`, `20250630_00_json_escape`, `20260729_00_json_stream`
