### PR TITLE
fix(register): preserve split interval next-use lookup

### DIFF
--- a/src/register/interval.c
+++ b/src/register/interval.c
@@ -1198,7 +1198,7 @@ void interval_add_use_pos(closure_t *c, interval_t *i, int position, alloc_kind_
 }
 
 
-int interval_next_use_position(interval_t *i, int after_position) {
+static int interval_segment_next_use_position(interval_t *i, int after_position) {
     linked_t *pos_list = i->use_pos_list;
 
     LINKED_FOR(pos_list) {
@@ -1208,6 +1208,27 @@ int interval_next_use_position(interval_t *i, int after_position) {
         }
     }
     return 0;
+}
+
+/**
+ * Return the earliest use position after `after_position` across an interval
+ * and all of its split children. Split segments may use different registers,
+ * but they still represent the same logical value. Blocked register
+ * allocation needs the complete next-use information to choose a victim.
+ */
+int interval_next_use_position(interval_t *i, int after_position) {
+    interval_t *parent = i->parent ? i->parent : i;
+    int result = interval_segment_next_use_position(parent, after_position);
+
+    LINKED_FOR(parent->children) {
+        interval_t *child = LINKED_VALUE();
+        int position = interval_segment_next_use_position(child, after_position);
+        if (position > 0 && (result == 0 || position < result)) {
+            result = position;
+        }
+    }
+
+    return result;
 }
 
 /**

--- a/src/register/interval.h
+++ b/src/register/interval.h
@@ -84,11 +84,8 @@ int old_interval_next_intersect(closure_t *c, interval_t *current, interval_t *s
 bool interval_is_intersect(interval_t *current, interval_t *select);
 
 /**
- * 寻找 select interval 大于 after 的第一个 use_position
- * first_use_position != first_from
- * @param select
- * @param after_position
- * @return
+ * Find the earliest use position after `after_position` across an interval and
+ * all of its split children.
  */
 int interval_next_use_position(interval_t *i, int after_position);
 


### PR DESCRIPTION
## Summary

Fix the register allocator assertion exposed after reserving AMD64 r14 for the current coroutine.

- Reserving r14 reduces the allocatable integer register set from 13 to 12, so `test_scan_stack` enters the blocked-register allocation path.
- Intervals such as `a1..a12` are split before a call. Their later use positions move to split children, while the active parent segments retain only earlier uses.
- `interval_next_use_position()` previously inspected only the supplied segment and incorrectly returned 0 for every occupied register.
- Query the parent and all split children so blocked allocation can choose a victim using the actual next-use position.
- Preserve the original allocator invariant assertion; no victim-spill fallback is added.

The split segments remain independently allocatable and do not need to use the same physical register. The complete next-use information is required only to preserve the logical value and estimate the cost of spilling its currently active segment.

## Verification

- Built the Linux AMD64 `test_scan_stack` archive that previously triggered the assertion.
- Passed `20250401_00_reg_alloc`.
- Passed AMD64, ARM64, and RISC-V encoding tests.
- Passed Test Local on darwin-arm64 and linux-arm64: https://github.com/nature-lang/nature/actions/runs/33042161054

Related to #334.