### PR TITLE
fix(runtime): preserve buffered channel references during GC

### DIFF
--- a/runtime/rt_chan.c
+++ b/runtime/rt_chan.c
@@ -9,6 +9,16 @@ typedef struct {
 
 static void selunlock(scase *cases, int16_t *lockorder, int16_t norder);
 
+static inline rtype_t *chan_msg_rtype(n_chan_t *chan) {
+    rtype_t *rtype = rt_find_rtype(chan->msg_rhash);
+    assert(rtype && "cannot find channel message rtype");
+    return rtype;
+}
+
+static inline void chan_buf_copy(n_chan_t *chan, void *dst, void *src) {
+    rti_write_barrier_rtype(dst, src, chan_msg_rtype(chan));
+}
+
 static inline bool buf_empty(n_chan_t *ch) {
     return ch->buf_front == ch->buf_rear;
 }
@@ -149,7 +159,8 @@ static inline linkco_t *waitq_pop(waitq_t *waitq) {
  * @param stack_ptr
  * @return
  */
-static void rt_msg_transmit(coroutine_t *co, void *stack_ptr, void *msg_ptr, bool pull, int64_t size) {
+static void rt_msg_transmit(coroutine_t *co, void *stack_ptr, void *msg_ptr, bool pull, int64_t size,
+                            rtype_t *dst_rtype) {
     // 计算基于 share_stack_ptr 得到的 offset(正数)
     aco_share_stack_t *share_stack = co->aco.share_stack;
     aco_save_stack_t *save_stack = &co->aco.save_stack;
@@ -170,6 +181,8 @@ static void rt_msg_transmit(coroutine_t *co, void *stack_ptr, void *msg_ptr, boo
 
     if (pull) {
         memmove(stack_ptr, msg_ptr, size);
+    } else if (dst_rtype) {
+        rti_write_barrier_rtype(msg_ptr, stack_ptr, dst_rtype);
     } else {
         memmove(msg_ptr, stack_ptr, size);
     }
@@ -196,6 +209,7 @@ n_chan_t *rt_chan_new(int64_t rhash, int64_t ele_rhash, int64_t buf_len) {
 
     n_chan_t *chan = rti_gc_malloc(rtype->gc_heap_size, rtype);
     chan->msg_size = element_rtype->storage_size;
+    chan->msg_rhash = ele_rhash;
     pthread_mutex_init(&chan->lock, NULL);
 
     // ele_rhash
@@ -213,7 +227,7 @@ static void rt_send(n_chan_t *chan, linkco_t *linkco, void *msg_ptr, scase *case
     linkco->success = true;
 
     if (linkco->data) {
-        rt_msg_transmit(linkco->co, linkco->data, msg_ptr, true, chan->msg_size);
+        rt_msg_transmit(linkco->co, linkco->data, msg_ptr, true, chan->msg_size, NULL);
         linkco->data = NULL;
     }
 
@@ -249,7 +263,7 @@ bool rt_chan_send(n_chan_t *chan, void *msg_ptr, bool try) {
         // 直接将 msg push 到 chan 中, 不阻塞当前 buf
         void *dst_ptr = buf_next_ref(chan);
 
-        memmove(dst_ptr, msg_ptr, chan->msg_size);
+        chan_buf_copy(chan, dst_ptr, msg_ptr);
 
         pthread_mutex_unlock(&chan->lock);
         return true;
@@ -305,7 +319,7 @@ static void rt_recv(n_chan_t *chan, linkco_t *linkco, void *msg_ptr, scase *case
     assert(msg_ptr);
     if (buf_empty(chan)) {
         DEBUGF("[rt_chan_recv] sendq have, buf empty,  will direct wakeup")
-        rt_msg_transmit(linkco->co, linkco->data, msg_ptr, false, chan->msg_size);
+        rt_msg_transmit(linkco->co, linkco->data, msg_ptr, false, chan->msg_size, NULL);
     } else {
         assert(buf_full(chan));
 
@@ -316,7 +330,7 @@ static void rt_recv(n_chan_t *chan, linkco_t *linkco, void *msg_ptr, scase *case
 
         // copy linkco->data to buf tail
         void *dst_ptr = buf_next_ref(chan);
-        rt_msg_transmit(linkco->co, linkco->data, dst_ptr, false, chan->msg_size);
+        rt_msg_transmit(linkco->co, linkco->data, dst_ptr, false, chan->msg_size, chan_msg_rtype(chan));
     }
 
     linkco->data = NULL;
@@ -707,7 +721,7 @@ BUFRECV:
 BUFSEND:
     case_success = true;
     void *dst_ptr = buf_next_ref(c);
-    memmove(dst_ptr, cas->msg_ptr, c->msg_size);
+    chan_buf_copy(c, dst_ptr, cas->msg_ptr);
     selunlock(cases, lockorder, cases_count);
     goto RETC;
 

--- a/tests/features/20260829_00_chan_gc.c
+++ b/tests/features/20260829_00_chan_gc.c
@@ -1,0 +1,5 @@
+#include "tests/test.h"
+
+int main(void) {
+    feature_testar_test(NULL);
+}

--- a/tests/features/cases/20260829_00_chan_gc.testar
+++ b/tests/features/cases/20260829_00_chan_gc.testar
@@ -1,0 +1,110 @@
+=== test_buffered_chan_gc[exclude_os=windows,repeat=5]
+--- main.n
+import co
+import runtime
+
+const SEED_COUNT = 128
+const MESSAGE_COUNT = 5000
+const GC_COUNT = 200
+const LIVE_COUNT = 50000
+
+type payload_t = struct {
+    int sequence
+    ref<int> marker
+}
+
+fn new_payload(int sequence): ref<payload_t> {
+    return new payload_t(
+        sequence = sequence,
+        marker = new int(sequence),
+    )
+}
+
+fn seed(chan<ref<payload_t>?> messages): void! {
+    for int sequence = 0; sequence < SEED_COUNT; sequence += 1 {
+        messages.send(new_payload(sequence))
+    }
+}
+
+fn send_one(chan<ref<payload_t>?> messages, int sequence): void! {
+    ref<payload_t> payload = new_payload(sequence)
+    for true {
+        bool sent = messages.try_send(payload)
+        if sent {
+            return
+        }
+        co.yield()
+    }
+}
+
+fn producer(chan<ref<payload_t>?> messages, chan<bool> done): void! {
+    for int sequence = SEED_COUNT; sequence < MESSAGE_COUNT; sequence += 1 {
+        send_one(messages, sequence)
+    }
+    done.send(true)
+}
+
+fn consumer(chan<ref<payload_t>?> messages, chan<bool> done): void! {
+    bool ok = true
+    for int expected = 0; expected < MESSAGE_COUNT; expected += 1 {
+        var payload = messages.recv()
+        if !(payload is ref<payload_t>) {
+            if ok {
+                println('type mismatch at', expected)
+            }
+            ok = false
+        } else {
+            ref<payload_t> payload_ref = payload as ref<payload_t>
+            if payload_ref.sequence != expected || *payload_ref.marker != expected {
+                if ok {
+                    println('payload mismatch expected', expected, 'got', payload_ref.sequence, *payload_ref.marker)
+                }
+                ok = false
+            }
+        }
+        if expected % 8 == 0 {
+            co.sleep(1)
+        }
+    }
+    done.send(ok)
+}
+
+fn gc_worker(chan<bool> done): void! {
+    for int i = 0; i < GC_COUNT; i += 1 {
+        runtime.gc()
+        co.sleep(1)
+    }
+    done.send(true)
+}
+
+fn main(): void! {
+    var messages = chan<ref<payload_t>?>.new(SEED_COUNT)
+    var producer_done = chan<bool>.new(1)
+    var consumer_done = chan<bool>.new(1)
+    var gc_done = chan<bool>.new(1)
+
+    seed(messages)
+
+    var live = vec<ref<int>>.cap_of(LIVE_COUNT)
+    ref<int> shared = new int(1)
+    for int i = 0; i < LIVE_COUNT; i += 1 {
+        live.push(shared)
+    }
+
+    runtime.gc()
+    co.sleep(500)
+
+    go gc_worker(gc_done)
+    co.sleep(1)
+    go consumer(messages, consumer_done)
+    go producer(messages, producer_done)
+
+    producer_done.recv()
+    bool consumer_ok = consumer_done.recv()
+    gc_done.recv()
+    assert(live.len() == LIVE_COUNT)
+    assert(consumer_ok)
+    println('ok')
+}
+--- output.txt
+ok

--- a/utils/type.h
+++ b/utils/type.h
@@ -507,6 +507,7 @@ typedef struct {
     int64_t buf_rear;
 
     int64_t msg_size;
+    int64_t msg_rhash; // element type hash, used for GC-aware buffered copies
     pthread_mutex_t lock;
     bool closed;
     bool successful; // 默认是 true, 一旦变成 false 就永远是 false, 和 successful 对应


### PR DESCRIPTION
## Summary

- Confirmed issue #339 on macOS arm64: the supplied buffered-channel GC reproducer failed before the fix with a payload mismatch.
- Record the channel element type hash and use the existing type-aware write barrier for every copy into a buffered channel slot (direct send, select send, and blocked-sender refill).
- Add the issue reproducer as a repeated regression test.

Fixes #339

## Verification

- `cmake --build build -- -j8`
- `ctest -R "^20260829_00_chan_gc$" -V` (5 repeated runs passed)
- Affected channel tests: `20240822_00_chan`, `20240823_00_chan_buf`, `20250104_00_select`, `20260730_01_chan_close` (all passed)
- Full ctest was not completed because existing unrelated tests failed (`20250324_00_llama`, TCP/UDP network cases) and `20250802_02_http` hung on an external HTTPS request.