### PR TITLE
fix(runtime): wake TLS writes on the calling coroutine

### DIFF
--- a/runtime/nutils/tls.h
+++ b/runtime/nutils/tls.h
@@ -18,7 +18,8 @@
 
 // TLS 连接内部结构
 typedef struct {
-    coroutine_t *co;
+    coroutine_t *connect_co;
+    coroutine_t *read_co;
     coroutine_t *write_co;
     int64_t read_len;
     void *data;
@@ -114,8 +115,8 @@ static inline void on_tls_read_cb(uv_stream_t *client_handle, ssize_t nread, con
     conn->read_started = false;
 
     // 唤醒 read co
-    DEBUGF("[on_tls_read_cb] will ready co %p", conn->co);
-    co_ready(conn->co);
+    DEBUGF("[on_tls_read_cb] will ready read co %p", conn->read_co);
+    co_ready(conn->read_co);
 }
 
 static inline void on_tls_read_timeout_cb(uv_timer_t *timer) {
@@ -129,7 +130,7 @@ static inline void on_tls_read_timeout_cb(uv_timer_t *timer) {
     conn->read_len = UV_ETIMEDOUT;
     conn->read_waiting = false;
     conn->read_started = false;
-    co_ready(conn->co);
+    co_ready(conn->read_co);
 }
 
 static inline void on_tls_write_end_cb(uv_write_t *write_req, int status) {
@@ -183,7 +184,7 @@ static void uv_async_tls_read(inner_tls_conn_t *conn) {
     if (uv_is_closing((uv_handle_t *) &conn->handle)) {
         conn->read_len = UV_ECANCELED;
         conn->read_waiting = false;
-        co_ready(conn->co);
+        co_ready(conn->read_co);
         return;
     }
     conn->read_started = true;
@@ -192,7 +193,7 @@ static void uv_async_tls_read(inner_tls_conn_t *conn) {
         conn->read_len = result;
         conn->read_waiting = false;
         conn->read_started = false;
-        co_ready(conn->co);
+        co_ready(conn->read_co);
         return;
     }
     if (conn->read_timeout_ms > 0 && !uv_is_closing((uv_handle_t *) &conn->timer)) {
@@ -206,7 +207,7 @@ static int mbedtls_recv_cb(void *ctx, unsigned char *buf, size_t len) {
     inner_tls_conn_t *conn = (inner_tls_conn_t *) ctx;
     conn->buf.base = (char *) buf;
     conn->buf.len = len;
-    conn->co = coroutine_get();
+    conn->read_co = coroutine_get();
     conn->read_waiting = true;
     conn->read_started = false;
 
@@ -293,13 +294,13 @@ static inline void on_tls_connect_cb(uv_connect_t *conn_req, int status) {
 
     if (status < 0) {
         DEBUGF("[on_tls_connect_cb] connection failed: %s", uv_strerror(status));
-        rti_co_throw(conn->co, tlsprintf("TLS connection failed: %s", uv_strerror(status)), false);
+        rti_co_throw(conn->connect_co, tlsprintf("TLS connection failed: %s", uv_strerror(status)), false);
         if (!uv_is_closing((uv_handle_t *) &conn->handle)) {
             uv_close((uv_handle_t *) &conn->handle, on_tls_close_cb);
         }
     }
 
-    co_ready(conn->co);
+    co_ready(conn->connect_co);
 }
 
 static inline void on_tls_timeout_cb(uv_timer_t *handle) {
@@ -313,8 +314,8 @@ static inline void on_tls_timeout_cb(uv_timer_t *handle) {
         uv_close((uv_handle_t *) &conn->handle, on_tls_close_cb);
     }
 
-    rti_co_throw(conn->co, "TLS connection timeout", 0);
-    co_ready(conn->co);
+    rti_co_throw(conn->connect_co, "TLS connection timeout", 0);
+    co_ready(conn->connect_co);
 }
 
 static void uv_async_tls_connect(inner_tls_conn_t *conn, struct sockaddr_in *dest, n_int64_t timeout_ms) {
@@ -347,10 +348,10 @@ void rt_uv_tls_connect(n_tls_conn_t *n_conn, n_string_t addr, n_int64_t port, n_
     // coroutine is scheduled again.
     conn->ref_count = 3;
     n_conn->conn = conn;
-    conn->co = co;
+    conn->connect_co = co;
     conn->read_timeout_ms = timeout_ms;
 
-    DEBUGF("[rt_uv_tls_connect] malloc new conn=%p, co=%p, p_index=%d", conn, conn->co, p->index);
+    DEBUGF("[rt_uv_tls_connect] malloc new conn=%p, connect_co=%p, p_index=%d", conn, conn->connect_co, p->index);
 
     // 初始化 TLS 上下文
     int ret = tls_init_ssl_context(conn, &addr);
@@ -401,7 +402,7 @@ void rt_uv_tls_connect(n_tls_conn_t *n_conn, n_string_t addr, n_int64_t port, n_
         } else {
             char error_buf[256];
             mbedtls_strerror(ret, error_buf, sizeof(error_buf));
-            rti_co_throw(conn->co, tlsprintf("tls handshake failed: %s", error_buf), false);
+            rti_co_throw(conn->connect_co, tlsprintf("tls handshake failed: %s", error_buf), false);
             n_conn->closed = true;
             global_async_send(uv_async_conn_close, conn, 0, 0);
             tls_release_conn(conn);
@@ -420,7 +421,7 @@ int64_t rt_uv_tls_read(n_tls_conn_t *n_conn, n_vec_t buf) {
         return 0;
     }
     inner_tls_conn_t *conn = n_conn->conn;
-    conn->co = co;
+    conn->read_co = co;
 
     if (!conn->handshake_done) {
         rti_co_throw(co, "tls conn handshake failed, cannot read", false);
@@ -500,7 +501,7 @@ static void uv_async_conn_close(inner_tls_conn_t *conn) {
             uv_read_stop((uv_stream_t *) &conn->handle);
             conn->read_waiting = false;
             conn->read_started = false;
-            co_ready(conn->co);
+            co_ready(conn->read_co);
         }
     }
     if (!uv_is_closing((uv_handle_t *) &conn->handle)) {
@@ -521,7 +522,7 @@ void rt_uv_tls_conn_close(n_tls_conn_t *n_conn) {
     n_conn->closed = true;
 
     // Send TLS close notify before closing the transport. mbedtls_send_cb()
-    // records the coroutine performing this write separately from conn->co,
+    // records the coroutine performing this write separately from conn->read_co,
     // which may still be a different coroutine blocked in TLS read.
     if (conn->handshake_done) {
         mbedtls_ssl_close_notify(&conn->ssl);

--- a/runtime/nutils/tls.h
+++ b/runtime/nutils/tls.h
@@ -19,6 +19,7 @@
 // TLS 连接内部结构
 typedef struct {
     coroutine_t *co;
+    coroutine_t *write_co;
     int64_t read_len;
     void *data;
     bool timeout; // 是否触发了 timeout
@@ -133,14 +134,17 @@ static inline void on_tls_read_timeout_cb(uv_timer_t *timer) {
 
 static inline void on_tls_write_end_cb(uv_write_t *write_req, int status) {
     inner_tls_conn_t *conn = CONTAINER_OF(write_req, inner_tls_conn_t, write_req);
+    coroutine_t *write_co = conn->write_co;
+    assert(write_co);
+    conn->write_co = NULL;
 
     if (status < 0) {
         char *msg = tlsprintf("tls uv_write failed: %s", uv_strerror(status));
-        DEBUGF("[on_tls_write_end_cb] failed: %s, co=%p", msg, conn->co);
+        DEBUGF("[on_tls_write_end_cb] failed: %s, co=%p", msg, write_co);
     }
 
-    co_ready(conn->co);
-    DEBUGF("[on_tls_write_end_cb] co=%p ready, status=%d", conn->co, conn->co->status);
+    co_ready(write_co);
+    DEBUGF("[on_tls_write_end_cb] co=%p ready, status=%d", write_co, write_co->status);
 }
 
 
@@ -153,13 +157,18 @@ static void uv_async_tls_write(inner_tls_conn_t *conn, char *buf, size_t len) {
     conn->write_req.data = conn;
     int result = uv_write(&conn->write_req, (uv_stream_t *) &conn->handle, &write_buf, 1, on_tls_write_end_cb);
     if (result < 0) {
-        rti_co_throw(conn->co, tlsprintf("TLS write failed: %s", uv_strerror(result)), false);
-        co_ready(conn->co);
+        coroutine_t *write_co = conn->write_co;
+        assert(write_co);
+        conn->write_co = NULL;
+        rti_co_throw(write_co, tlsprintf("TLS write failed: %s", uv_strerror(result)), false);
+        co_ready(write_co);
     }
 }
 
 static int mbedtls_send_cb(void *ctx, const unsigned char *buf, size_t len) {
     inner_tls_conn_t *conn = (inner_tls_conn_t *) ctx;
+    assert(conn->write_co == NULL);
+    conn->write_co = coroutine_get();
 
     global_waiting_send(uv_async_tls_write, conn, (void *) buf, (void *) len);
 
@@ -456,7 +465,6 @@ int64_t rt_uv_tls_write(n_tls_conn_t *n_conn, n_vec_t buf) {
     }
 
     inner_tls_conn_t *conn = n_conn->conn;
-    conn->co = co;
     conn->handle.data = conn;
     conn->user_buf = buf;
 
@@ -512,7 +520,9 @@ void rt_uv_tls_conn_close(n_tls_conn_t *n_conn) {
     inner_tls_conn_t *conn = n_conn->conn;
     n_conn->closed = true;
 
-    // 发送 TLS close notify
+    // Send TLS close notify before closing the transport. mbedtls_send_cb()
+    // records the coroutine performing this write separately from conn->co,
+    // which may still be a different coroutine blocked in TLS read.
     if (conn->handshake_done) {
         mbedtls_ssl_close_notify(&conn->ssl);
     }

--- a/tests/features/20260830_00_tls_close_pending_read.c
+++ b/tests/features/20260830_00_tls_close_pending_read.c
@@ -1,0 +1,5 @@
+#include "tests/test.h"
+
+int main(void) {
+    feature_testar_test(NULL);
+}

--- a/tests/features/cases/20260830_00_tls_close_pending_read.testar
+++ b/tests/features/cases/20260830_00_tls_close_pending_read.testar
@@ -1,0 +1,30 @@
+=== test_close_with_pending_read[timeout=15]
+--- main.n
+import co
+import net.tls
+
+fn read_pending(ref<tls.conn_t> conn, chan<bool> started, chan<bool> done):void! {
+    started.send(true)
+    var scratch = vec<u8>.new(0, 16)
+    conn.read(scratch) catch e {
+        0
+    }
+    done.send(true)
+}
+
+fn main():void! {
+    var conn = tls.connect_timeout('34.160.111.145:443', 5000)
+    var started = chan<bool>.new(1)
+    var done = chan<bool>.new(1)
+
+    go read_pending(conn, started, done)
+    started.recv()
+    co.sleep(100)
+
+    conn.close()
+    done.recv()
+    println('tls close completed')
+}
+
+--- output.txt
+tls close completed


### PR DESCRIPTION
Fixes #341.

## Reproducer first

The first commit adds a Nature `testar` regression case:

- `tests/features/20260830_00_tls_close_pending_read.c`
- `tests/features/cases/20260830_00_tls_close_pending_read.testar`

The case connects to the public TLS endpoint `34.160.111.145:443`, starts a Nature coroutine that blocks in `conn.read()`, waits briefly so the read is pending, then closes the same TLS connection from the main coroutine and waits for the reader to finish.

On the unmodified `master` runtime, this case reaches `rt_uv_tls_conn_close()` and aborts with status 134 instead of printing `tls close completed`.

## Root cause

The TLS runtime stored the read waiter in `conn->co`. `mbedtls_ssl_close_notify()` performs an asynchronous TLS write, but `on_tls_write_end_cb()` also used `conn->co` for its completion wakeup. When close was called from a different coroutine, the write completion woke the read coroutine instead of the close caller. The close caller remained parked forever; subsequent callbacks could also resume the read coroutine more than once.

## Fix

The second commit adds a dedicated `write_co`:

- `mbedtls_send_cb()` records the coroutine performing the current TLS write;
- write completion and synchronous write errors wake that `write_co`;
- `rt_uv_tls_write()` no longer overwrites the read waiter;
- `mbedtls_ssl_close_notify()` is preserved.

This PR contains no generic scheduler changes or unrelated coroutine fixes. Its diff against `master` is limited to the Nature TLS runtime and the reproducer.

## Verification

- unmodified `master`: reproducer aborts with exit status 134;
- fixed runtime: the same testar passes and prints `tls close completed`;
- `ctest --test-dir build -R '^20260830_00_tls_close_pending_read$' --output-on-failure`: passed;
- the fix was rebuilt and exercised on macOS arm64.

