### PR TITLE
feat: errable in x mode

### DIFF
--- a/runtime/nutils/nutils.c
+++ b/runtime/nutils/nutils.c
@@ -714,9 +714,11 @@ void co_throw_error(n_interface_t *error, char *path, char *fn_name, n_int_t lin
     assert(error->method_count == 1);
     coroutine_t *co = coroutine_get();
     if (!co) {
-        // the value is copied into a fixed size buffer, so x mode only accepts errort.
-        // errort is the sole implementor of throwable in the tree, this guards a user defined one.
-        assertf(error->rtype && error->rtype->hash == errort_rtype.hash,
+        // the value is copied into a fixed size buffer, so it has to fit. errort is the only
+        // implementor of throwable in the tree; this guards a user defined one that is larger.
+        // The rtype hash cannot be compared against errort_rtype here: that one is fabricated by
+        // the runtime with GC_RTYPE and never matches the compiler's hash for nature's errort.
+        assertf(error->rtype && error->rtype->gc_heap_size <= sizeof(n_errort),
                 "x mode can only throw errort");
         x_store_error(error->value.ptr_value);
         return;

--- a/runtime/nutils/nutils.c
+++ b/runtime/nutils/nutils.c
@@ -672,7 +672,7 @@ static _Thread_local bool x_has_error = false;
  * Move an error into the flight slot. The value, its message bytes and the method table all
  * live in the throwing frame, which dies while unwinding, so none of them may be aliased.
  */
-static void x_store_error(n_errort *src) {
+static void x_store_error(n_errort *src, rtype_t *rtype) {
     x_flight.errort = *src;
 
     int64_t len = x_flight.errort.msg.length;
@@ -688,10 +688,13 @@ static void x_store_error(n_errort *src) {
     x_flight.errort.msg.capacity = len;
     x_flight.errort.msg.allocator = NULL;
 
+    // keep the caller's rtype: it is the compiler's rtype for nature's errort, and an
+    // `as` on the caught error compares against that one. errort_rtype is the runtime's own
+    // fabrication and substituting it here breaks interface_assert.
     x_error = (n_interface_t){
         .value.ptr_value = &x_flight.errort,
         .methods = x_errort_methods,
-        .rtype = &errort_rtype,
+        .rtype = rtype,
         .method_count = 1,
     };
     x_has_error = true;
@@ -706,7 +709,8 @@ static void x_store_error_msg(char *msg) {
         .element_size = 1,
     };
     e.panic = 1;
-    x_store_error(&e);
+    // a builtin error has no incoming interface, so it takes the same rtype fn mode gives it
+    x_store_error(&e, &errort_rtype);
 }
 
 // 基于字符串到快速设置不太需要考虑内存泄漏的问题， raw_string 都是 .data 段中的字符串
@@ -720,7 +724,7 @@ void co_throw_error(n_interface_t *error, char *path, char *fn_name, n_int_t lin
         // the runtime with GC_RTYPE and never matches the compiler's hash for nature's errort.
         assertf(error->rtype && error->rtype->gc_heap_size <= sizeof(n_errort),
                 "x mode can only throw errort");
-        x_store_error(error->value.ptr_value);
+        x_store_error(error->value.ptr_value, error->rtype);
         return;
     }
 

--- a/runtime/nutils/nutils.c
+++ b/runtime/nutils/nutils.c
@@ -657,10 +657,83 @@ void iterator_take_value(void *iterator, int64_t hash, int64_t cursor, void *val
     exit(0);
 }
 
+
+// ---- x mode error slot ------------------------------------------------------
+
+// throwable has a single method and x mode only lets errort implement it, so the table is
+// static here rather than copied out of the throwing frame, where linear lea's it onto the stack.
+static int64_t x_errort_methods[1] = {(int64_t) errort_msg};
+
+static _Thread_local x_error_buf_t x_flight = {0};
+static _Thread_local n_interface_t x_error = {0};
+static _Thread_local bool x_has_error = false;
+
+/**
+ * Move an error into the flight slot. The value, its message bytes and the method table all
+ * live in the throwing frame, which dies while unwinding, so none of them may be aliased.
+ */
+static void x_store_error(n_errort *src) {
+    x_flight.errort = *src;
+
+    int64_t len = x_flight.errort.msg.length;
+    if (len > X_ERR_MSG_CAP - 1) {
+        len = X_ERR_MSG_CAP - 1;
+    }
+    if (len > 0 && x_flight.errort.msg.data) {
+        memmove(x_flight.msg_buf, x_flight.errort.msg.data, len);
+    }
+    x_flight.msg_buf[len] = 0;
+    x_flight.errort.msg.data = (uint8_t *) x_flight.msg_buf;
+    x_flight.errort.msg.length = len;
+    x_flight.errort.msg.capacity = len;
+    x_flight.errort.msg.allocator = NULL;
+
+    x_error = (n_interface_t){
+        .value.ptr_value = &x_flight.errort,
+        .methods = x_errort_methods,
+        .rtype = &errort_rtype,
+        .method_count = 1,
+    };
+    x_has_error = true;
+}
+
+static void x_store_error_msg(char *msg) {
+    n_errort e = {0};
+    e.msg = (n_string_t){
+        .data = (uint8_t *) msg,
+        .length = (int64_t) strlen(msg),
+        .capacity = (int64_t) strlen(msg),
+        .element_size = 1,
+    };
+    e.panic = 1;
+    x_store_error(&e);
+}
+
 // 基于字符串到快速设置不太需要考虑内存泄漏的问题， raw_string 都是 .data 段中的字符串
 void co_throw_error(n_interface_t *error, char *path, char *fn_name, n_int_t line, n_int_t column) {
     assert(error->method_count == 1);
     coroutine_t *co = coroutine_get();
+    if (!co) {
+        // the value is copied into a fixed size buffer, so x mode only accepts errort.
+        // errort is the sole implementor of throwable in the tree, this guards a user defined one.
+        assertf(error->rtype && error->rtype->hash == errort_rtype.hash,
+                "x mode can only throw errort");
+        x_store_error(error->value.ptr_value);
+        return;
+    }
+
+    // An .x fn aliases its error onto the throwing frame rather than gc allocating it
+    // (interface_casting with is_x), and that frame dies while unwinding. Under a coroutine the
+    // value has to outlive it, so lift both the value and the method table onto the gc heap.
+    if (!in_heap((addr_t) error->value.ptr_value)) {
+        void *value_copy = rti_gc_malloc(error->rtype->gc_heap_size, error->rtype);
+        memmove(value_copy, error->value.ptr_value, error->rtype->gc_heap_size);
+        error->value.ptr_value = value_copy;
+
+        int64_t *methods_copy = (int64_t *) rti_array_new(&uint64_rtype, error->method_count);
+        memmove(methods_copy, error->methods, error->method_count * POINTER_SIZE);
+        error->methods = methods_copy;
+    }
 
     n_string_t err_msg = rti_error_msg(error);
     DEBUGF("[runtime.co_throw_error] co=%p, error=%p, path=%s, fn_name=%s, line=%ld, column=%ld, msg=%s", co,
@@ -695,6 +768,18 @@ void throw_index_out_error(n_int_t *index, n_int_t *len, n_bool_t be_catch) {
 
     char *msg = tlsprintf("index out of range [%d] with length %d", index, len);
 
+    if (!co) {
+        // x mode: no gc, so the message goes straight into the flight slot
+        if (be_catch) {
+            x_store_error_msg(msg);
+        } else {
+            char *x_copy = strdup(msg);
+            panic_dump(caller, x_copy);
+            free(x_copy);
+        }
+        return;
+    }
+
     if (be_catch) {
         n_interface_t error = n_error_new(string_new(msg, strlen(msg)), true);
         assert(error.method_count == 1);
@@ -723,8 +808,21 @@ void throw_index_out_error(n_int_t *index, n_int_t *len, n_bool_t be_catch) {
     }
 }
 
-n_interface_t co_remove_error() {
+n_interface_t co_remove_error(void *dst) {
     coroutine_t *co = coroutine_get();
+    if (!co) {
+        // copy the value out of the flight slot so a later throw cannot reach this handler's error
+        assert(dst);
+        x_error_buf_t *buf = dst;
+        buf->errort = x_flight.errort;
+        memmove(buf->msg_buf, x_flight.msg_buf, X_ERR_MSG_CAP);
+        buf->errort.msg.data = (uint8_t *) buf->msg_buf;
+
+        x_has_error = false;
+        n_interface_t out = x_error;
+        out.value.ptr_value = &buf->errort;
+        return out;
+    }
 
     assert(co->has_error);
     co->has_error = false;
@@ -739,6 +837,19 @@ n_interface_t co_remove_error() {
 
 uint8_t co_has_panic(bool be_catch, char *path, char *fn_name, n_int_t line, n_int_t column) {
     coroutine_t *co = coroutine_get();
+    if (!co) {
+        if (!x_has_error) {
+            return 0;
+        }
+        if (be_catch) {
+            return 1;
+        }
+
+        n_string_t x_msg = rti_error_msg(&x_error);
+        char *x_dump = tlsprintf("panic: '%s' at %s:%d:%d\n", (char *) rt_string_ref(&x_msg), path, line, column);
+        VOID write(STDOUT_FILENO, x_dump, strlen(x_dump));
+        exit(EXIT_FAILURE);
+    }
     if (!co->has_error) {
         return 0;
     }
@@ -778,6 +889,9 @@ uint8_t co_has_panic(bool be_catch, char *path, char *fn_name, n_int_t line, n_i
 
 uint8_t co_has_error(char *path, char *fn_name, n_int_t line, n_int_t column) {
     coroutine_t *co = coroutine_get();
+    if (!co) {
+        return x_has_error ? 1 : 0;
+    }
     if (!co->has_error) {
         return 0;
     }

--- a/runtime/nutils/nutils.h
+++ b/runtime/nutils/nutils.h
@@ -51,7 +51,14 @@ void co_throw_error(n_interface_t *error, char *path, char *fn_name, n_int_t lin
 
 void throw_index_out_error(n_int_t *index, n_int_t *len, n_bool_t be_catch);
 
-n_interface_t co_remove_error();
+// x mode has no coroutine, so the error in flight lives in a thread local slot. The slot is
+// only correct for the flight window, which holds one error at a time; co_remove_error copies
+// the value into caller owned storage so a later throw cannot disturb a handler's `e`.
+// The message bytes are copied too: a builtin error's message sits in the reused tlsprintf
+// buffer, and copying n_errort alone would only copy the string header.
+// x_error_buf_t and X_ERR_BUF_SIZE live in utils/type.h, linear reserves the same size.
+// dst is the caller owned x_error_buf_t, or NULL in fn mode
+n_interface_t co_remove_error(void *dst);
 
 uint8_t co_has_error(char *path, char *fn_name, n_int_t line, n_int_t column);
 

--- a/runtime/runtime.c
+++ b/runtime/runtime.c
@@ -81,7 +81,11 @@ int runtime_main(int argc, char *argv[]) {
 
         DEBUGF("[runtime_main] fn mode user code run completed, will exit");
     } else {
-        // x mode: call user_main directly, no GC and no scheduler
+        // x mode: call user_main directly, no GC and no scheduler.
+        // The coroutine key still has to exist: uv_key_get on an uncreated key returns junk
+        // rather than NULL, and the error path dispatches on coroutine_get() being NULL.
+        uv_key_create(&tls_coroutine_key);
+
         DEBUGF("[runtime_main] x mode, calling user_main directly");
         user_main();
         DEBUGF("[runtime_main] x mode user code run completed, will exit");

--- a/src/linear.c
+++ b/src/linear.c
@@ -607,6 +607,27 @@ linear_stack_vec_new(module_t *m, type_t t, uint64_t len, lir_operand_t *target)
     return target;
 }
 
+/**
+ * x mode has no gc, so the error value cannot stay on a shared runtime slot: a later throw would
+ * overwrite what a handler still holds. Hand co_remove_error a buffer in the handler's own frame
+ * and it copies the value in, giving every handler its own copy like the gc does in fn mode.
+ */
+static void linear_remove_error(module_t *m, lir_operand_t *err_operand) {
+    lir_operand_t *err_buf_ptr = int_operand(0);
+
+    if (m->is_x) {
+        type_array_t *buf_array = NEW(type_array_t);
+        buf_array->length = X_ERR_BUF_SIZE;
+        buf_array->element_type = type_kind_new(TYPE_UINT8);
+        type_t buf_type = type_new(TYPE_ARR, buf_array);
+
+        lir_operand_t *buf_target = temp_var_operand_with_alloc(m, buf_type);
+        err_buf_ptr = lea_operand_pointer(m, buf_target);
+    }
+
+    push_rt_call(m, RT_CALL_CO_REMOVE_ERROR, err_operand, 1, err_buf_ptr);
+}
+
 // target 中保存了栈地址，开始向上清理
 static void linear_default_empty_stack(module_t *m, lir_operand_t *target, uint64_t offset, uint64_t size) {
     uint64_t remind = size;
@@ -3776,7 +3797,7 @@ static lir_operand_t *linear_catch_expr(module_t *m, ast_expr_t expr, lir_operan
     // 从 catch expr 中获取 err 然后为 err 赋值
     lir_operand_t *err_operand = linear_var_decl(m, &catch_expr->catch_err);
 
-    push_rt_call(m, RT_CALL_CO_REMOVE_ERROR, err_operand, 0);
+    linear_remove_error(m, err_operand);
 
     stack_push(m->current_closure->ret_labels, catch_end_label->output);
     stack_push(m->current_closure->ret_targets, target);
@@ -3813,7 +3834,7 @@ static void linear_try_catch_stmt(module_t *m, ast_try_catch_stmt_t *try_stmt) {
 
     // 为 err 赋值
     lir_operand_t *err_operand = linear_var_decl(m, &try_stmt->catch_err);
-    push_rt_call(m, RT_CALL_CO_REMOVE_ERROR, err_operand, 0);
+    linear_remove_error(m, err_operand);
 
     stack_push(m->current_closure->ret_labels, catch_end_label->output);
 

--- a/src/peephole/amd64.c
+++ b/src/peephole/amd64.c
@@ -179,8 +179,6 @@ static bool peephole_lea_fusion(closure_t *c, basic_block_t *block, slice_t *ops
 }
 
 static inline void amd64_peephole_handle_block(closure_t *c, basic_block_t *block) {
-    peephole_build_use_count(block);
-
     slice_t *ops = slice_new();
 
     LINKED_FOR(block->operations) {
@@ -195,6 +193,10 @@ static inline void amd64_peephole_handle_block(closure_t *c, basic_block_t *bloc
     while (changed && iterations < max_iterations) {
         changed = false;
         iterations++;
+
+        // the previous round's rewrites changed the operand uses, so the counts have
+        // to be rebuilt or move elimination drops a def that is still referenced
+        peephole_build_use_count(block, ops);
 
         slice_t *new_ops = slice_new();
         int cursor = 0;

--- a/src/peephole/arm64.c
+++ b/src/peephole/arm64.c
@@ -463,8 +463,6 @@ static bool peephole_fma_recognition(closure_t *c, basic_block_t *block, slice_t
 }
 
 static inline void arm64_peephole_handle_block(closure_t *c, basic_block_t *block) {
-    peephole_build_use_count(block);
-
     slice_t *ops = slice_new();
 
     LINKED_FOR(block->operations) {
@@ -479,6 +477,10 @@ static inline void arm64_peephole_handle_block(closure_t *c, basic_block_t *bloc
     while (changed && iterations < max_iterations) {
         changed = false;
         iterations++;
+
+        // the previous round's rewrites changed the operand uses, so the counts have
+        // to be rebuilt or move elimination drops a def that is still referenced
+        peephole_build_use_count(block, ops);
 
         slice_t *new_ops = slice_new();
         int cursor = 0;

--- a/src/peephole/peephole.h
+++ b/src/peephole/peephole.h
@@ -24,28 +24,30 @@ static inline bool peephole_is_in_live_out(basic_block_t *block, lir_var_t *var)
 /**
  * 构建 block 的变量使用计数表
  * 仅统计 USE 标志的变量出现次数
+ *
+ * Counts over `ops`, the list the optimization loop is actually rewriting.
+ * block->operations is only written back once the loop ends, so counting from it
+ * would miss this round's rewrites: an op the loop replaced still contributes its
+ * old uses, and an op the loop inserted contributes none.
  */
-static inline void peephole_build_use_count(basic_block_t *block) {
+static inline void peephole_build_use_count(basic_block_t *block, slice_t *ops) {
     if (block->use_count) {
         table_free(block->use_count);
     }
 
     block->use_count = table_new();
 
-    linked_node *current = linked_first(block->operations);
-    while (current != NULL && current->value != NULL) {
-        lir_op_t *op = current->value;
+    for (int i = 0; i < ops->count; ++i) {
+        lir_op_t *op = ops->take[i];
 
         // 提取该指令中所有 use 的变量
         slice_t *use_operands = extract_op_operands(op, FLAG(LIR_OPERAND_VAR), FLAG(LIR_FLAG_USE), true);
-        for (int i = 0; i < use_operands->count; ++i) {
-            lir_var_t *use_var = use_operands->take[i];
+        for (int j = 0; j < use_operands->count; ++j) {
+            lir_var_t *use_var = use_operands->take[j];
             intptr_t count = (intptr_t) table_get(block->use_count, use_var->ident);
             table_set(block->use_count, use_var->ident, (void *) (count + 1));
         }
         slice_free(use_operands); // 释放临时 slice
-
-        current = current->succ;
     }
 }
 

--- a/src/semantic/infer.c
+++ b/src/semantic/infer.c
@@ -4431,10 +4431,8 @@ static void infer_fndef(module_t *m, ast_fndef_t *fn) {
     m->current_line = fn->line;
     m->current_column = fn->column;
 
-    // v1 x mode subset. both are demonstrated crashes rather than style rules: an errable chain
-    // aborts register allocation, and a capturing closure segfaults on the gc env promotion.
+    // x mode subset: a capturing closure segfaults on the gc env promotion, so it stays rejected.
     if (fn->is_x) {
-        INFER_ASSERTF(!fn->is_errable, "errable fn declaration is not supported in .x");
         INFER_ASSERTF(fn->capture_exprs->length == 0, "closure capture is not supported in .x");
     }
 

--- a/std/builtin/error.n
+++ b/std/builtin/error.n
@@ -7,4 +7,3 @@ pub fn errorf(string format, ...[any] args):ref<errort> {
 	return new errort(message = msg)
 }
 
-pub type errable<T> = errort|T

--- a/std/builtin/error.n
+++ b/std/builtin/error.n
@@ -1,29 +1,10 @@
 import fmt
 
-pub type throwable = interface{
-	fn msg():string
-}
-
-pub type trace_t = struct{
-    string path
-    string ident
-    int line
-    int column
-}
-
-pub type errort:throwable = struct{
-	string message
-	bool is_panic
-}
-
-pub fn errort.msg(&self):string {
-	return self.message
-}
-
+// throwable / trace_t / errort live in error.x, see the note there.
+// errorf stays here because fmt.sprintf is gc backed and x mode cannot run it.
 pub fn errorf(string format, ...[any] args):ref<errort> {
 	var msg = fmt.sprintf(format, ...args)
 	return new errort(message = msg)
 }
-
 
 pub type errable<T> = errort|T

--- a/std/builtin/error.x
+++ b/std/builtin/error.x
@@ -24,3 +24,5 @@ pub type errort:throwable = struct{
 pub fn errort.msg(&self):string {
 	return self.message
 }
+
+pub type errable<T> = errort|T

--- a/std/builtin/error.x
+++ b/std/builtin/error.x
@@ -1,0 +1,26 @@
+// The error type is x mode so that .x can catch an error and read its message.
+// The mode is part of a fn type, so an interface and its implementation have to agree:
+// leaving throwable in .n would make msg() uncallable from .x. Moving it costs .n
+// nothing, because a .n to .x call is allowed and errort is the only implementor.
+//
+// errorf stays in error.n, it needs fmt.sprintf.
+
+pub type throwable = interface{
+	fn msg():string
+}
+
+pub type trace_t = struct{
+    string path
+    string ident
+    int line
+    int column
+}
+
+pub type errort:throwable = struct{
+	string message
+	bool is_panic
+}
+
+pub fn errort.msg(&self):string {
+	return self.message
+}

--- a/tests/x/20260901_00_errable.c
+++ b/tests/x/20260901_00_errable.c
@@ -1,0 +1,5 @@
+#include "tests/test.h"
+
+int main(void) {
+    feature_testar_test(NULL);
+}

--- a/tests/x/cases/20260823_01_diagnostics.testar
+++ b/tests/x/cases/20260823_01_diagnostics.testar
@@ -49,19 +49,6 @@ pub type allocatable = interface{
 --- output.txt
 nature-test/main.x:5:2: the fn 'new' of type 'main.heap_t' mismatch interface 'nature-test.iface.allocatable'
 
-=== test_errable_definition
---- main.x
-fn risky():int! {
-    return 1
-}
-
-fn main() {
-    println(1)
-}
-
---- output.txt
-nature-test/main.x:1:3: errable fn declaration is not supported in .x
-
 === test_vec_literal
 --- main.x
 fn main() {

--- a/tests/x/cases/20260901_00_errable.testar
+++ b/tests/x/cases/20260901_00_errable.testar
@@ -123,3 +123,26 @@ pub fn risky(int v):int! {
 --- output.txt
 n caught from x: x side failure
 -1
+
+=== test_catch_assert_concrete
+--- main.x
+// `as` on a caught error compares rtype hashes, so the slot has to keep the compiler's
+// rtype rather than the one the runtime fabricates for its own errort
+fn fail():int! {
+    throw errort{message: 'boom', is_panic: false}
+}
+
+fn main() {
+    var v = fail() catch e {
+        println('msg:', e.msg())
+        var concrete = e as errort
+        println('assert:', concrete.message)
+        -1
+    }
+    println(v)
+}
+
+--- output.txt
+msg: boom
+assert: boom
+-1

--- a/tests/x/cases/20260901_00_errable.testar
+++ b/tests/x/cases/20260901_00_errable.testar
@@ -1,0 +1,129 @@
+=== test_propagate
+--- main.x
+// the errable control flow skeleton: declare, call, propagate, catch with nothing thrown
+fn risky(int v):int! {
+    return v * 2
+}
+
+fn caller(int v):int! {
+    return risky(v)
+}
+
+fn main() {
+    var a = caller(21) catch e {
+        -1
+    }
+    println('happy:', a)
+}
+
+--- output.txt
+happy: 42
+
+=== test_throw_catch
+--- main.x
+// errorf goes through fmt.sprintf, which x mode cannot run, so .x throws a struct literal
+fn risky(int v):int! {
+    if v < 0 {
+        throw errort{message: 'negative input', is_panic: false}
+    }
+    return v * 2
+}
+
+fn main() {
+    var b = risky(-1) catch e {
+        println('caught:', e.msg())
+        -2
+    }
+    println('thrown:', b)
+}
+
+--- output.txt
+caught: negative input
+thrown: -2
+
+=== test_nested_catch
+--- main.x
+// the outer error has to survive a catch that runs inside it. a single error slot
+// would let the inner throw overwrite the value the outer `e` still points at.
+fn risky(int v):int! {
+    if v < 0 {
+        throw errort{message: 'negative input', is_panic: false}
+    }
+    return v * 2
+}
+
+fn main() {
+    var c = risky(-1) catch outer {
+        var inner = risky(-1) catch e2 {
+            -3
+        }
+        println('outer after inner:', outer.msg(), inner)
+        -4
+    }
+    println('nested:', c)
+}
+
+--- output.txt
+outer after inner: negative input -3
+nested: -4
+
+=== test_catch_builtin
+--- main.x
+import allocator as ac
+
+// a builtin error is built by the runtime rather than by user code, so it exercises
+// the error value allocation path rather than the throw path
+fn main() {
+    var v = vec<int>.alloc(ac.heap, 0, 2)
+    defer v.deinit()
+
+    var x = v[5] catch e {
+        println('builtin caught:', e.msg())
+        -1
+    }
+    println(x)
+}
+
+--- output.txt
+builtin caught: index out of range [5] with length 2
+-1
+
+=== test_uncaught_panic
+--- main.x
+import allocator as ac
+
+// the uncaught path already works in x mode today, it must not regress
+fn main() {
+    var v = vec<int>.alloc(ac.heap, 0, 2)
+    defer v.deinit()
+    println(v[5])
+}
+
+--- output.txt
+panic: 'index out of range [5] with length 2' at nature-test/main.x:7:15
+
+=== test_n_catches_x_error
+--- main.n
+import "worker.x"
+
+// an .x errable fn throwing while a coroutine is live must land in the coroutine slot,
+// not in the x mode thread local one, or the .n caller never sees it
+fn main() {
+    var v = worker.risky(-1) catch e {
+        println('n caught from x:', e.msg())
+        -1
+    }
+    println(v)
+}
+
+--- worker.x
+pub fn risky(int v):int! {
+    if v < 0 {
+        throw errort{message: 'x side failure', is_panic: false}
+    }
+    return v * 2
+}
+
+--- output.txt
+n caught from x: x side failure
+-1

--- a/tests/x/cases/20260901_00_errable.testar
+++ b/tests/x/cases/20260901_00_errable.testar
@@ -43,29 +43,25 @@ thrown: -2
 
 === test_nested_catch
 --- main.x
-// the outer error has to survive a catch that runs inside it. a single error slot
-// would let the inner throw overwrite the value the outer `e` still points at.
-fn risky(int v):int! {
-    if v < 0 {
-        throw errort{message: 'negative input', is_panic: false}
-    }
-    return v * 2
+// the outer error has to survive a catch that runs inside it. the two messages differ
+// on purpose: with one shared slot the inner throw overwrites what `e` still points at,
+// and identical messages would hide that.
+fn fail(string msg):int! {
+    throw errort{message: msg, is_panic: false}
 }
 
 fn main() {
-    var c = risky(-1) catch outer {
-        var inner = risky(-1) catch e2 {
-            -3
+    fail('AAA') catch e {
+        fail('BBB') catch e2 {
+            0
         }
-        println('outer after inner:', outer.msg(), inner)
-        -4
+        println('e.msg() =', e.msg())
+        0
     }
-    println('nested:', c)
 }
 
 --- output.txt
-outer after inner: negative input -3
-nested: -4
+e.msg() = AAA
 
 === test_catch_builtin
 --- main.x

--- a/utils/type.h
+++ b/utils/type.h
@@ -611,6 +611,16 @@ typedef struct {
     uint8_t panic;
 } n_errort;
 
+// x mode copies a caught error into a buffer in the handler's own frame, see co_remove_error.
+// linear reserves X_ERR_BUF_SIZE bytes there, so both sides have to agree on this.
+#define X_ERR_MSG_CAP 160
+#define X_ERR_BUF_SIZE (sizeof(n_errort) + X_ERR_MSG_CAP)
+
+typedef struct {
+    n_errort errort;
+    char msg_buf[X_ERR_MSG_CAP];
+} x_error_buf_t;
+
 /**
  * 将 ct_rtypes 填入到 ct_rtypes 中并返回索引
  * @param rtype


### PR DESCRIPTION
## What this does

`.x` can now declare, propagate and catch errors:

```nature
fn risky(int v):int! {
    if v < 0 {
        throw errort{message: 'negative input', is_panic: false}
    }
    return v * 2
}

fn main() {
    var b = risky(-1) catch e {
        println('caught:', e.msg())
        -2
    }
}
```

The control flow was already there. errable lowers to plain calls and branches — `linear_has_error` says as much in its own comment, "不可抢占，也不 yield" — and none of it needs a safepoint. What was missing is where the error value lives, since all five runtime entry points start from `coroutine_get()`, and x mode never starts a scheduler.

Tests were written first, against output taken from running the same shapes in `.n`, so they assert parity rather than a guess.

## Where the error value lives

**Dispatch is on whether a coroutine is live, not on the mode of the throwing fn.** An `.x` fn called from `.n` under a coroutine has to put its error in the coroutine slot or the `.n` caller never sees it. `test_n_catches_x_error` pins that direction.

That dispatch needed a fix of its own. `uv_key_get` on a key that was never created returns junk rather than NULL, so `coroutine_get()` was answering with a garbage pointer in x mode and every branch took the wrong path. x mode now creates `tls_coroutine_key`.

**The value is copied to the handler rather than shared.** A single flight slot is correct between throw and catch, because only one error is in flight at a time. But the value outlives that window: `e` is an ordinary variable scoped to the catch body, so a later throw would overwrite what it still points at. `.n` does not have this problem, since every error is its own gc allocation:

```nature
fail('AAA') catch e {
    fail('BBB') catch e2 { 0 }
    println(e.msg())        // .n prints AAA
}
```

So linear reserves a buffer in the catch frame and `co_remove_error` copies the value into it. `test_nested_catch` checks it with two different messages — identical ones would have hidden a shared slot.

The message bytes are copied along with the value: copying `n_errort` alone copies the string header, and a builtin error's message sits in the reused `tlsprintf` buffer.

**x mode only accepts `errort` as a throwable.** The catch site needs a statically known buffer size and the concrete type behind the interface is not known there. `errort` is the only implementor in the tree, and the restriction also lets the runtime use a static method table instead of copying one out of the throwing frame, where linear lea's it onto the stack.

That same aliasing needed handling in the other direction. An `.x` throw under a coroutine hands over a value and a method table that live on the dying frame, so `co_throw_error` lifts both onto the gc heap when they are not already there.

## The error type moves to `.x`

The mode is part of a fn type, so an interface and its implementation have to agree on it. With `throwable` declared in `.n`, `catch e { e.msg() }` from `.x` was rejected as "calling .n fn 'msg'", and declaring it in both files collides because builtin symbols carry no module prefix.

`throwable`, `trace_t` and `errort` move into `std/builtin/error.x`. `.n` keeps calling them, since a `.n` to `.x` call is allowed, and `errort` is the only implementor so nothing else has to follow. `errorf` stays in `.n`, it needs `fmt.sprintf`.

## The peephole prerequisite

`use_count` was built once before the optimization loop, but the loop rewrites the ops it counts. arm64 strength reduction turns `MUL t,v` into `ADD v,v` in place, raising v's use count from one to two while the table still reports one; a later move elimination round then treats v as single use, deletes the def and rewrites only one of the two operands. Register allocation aborts on the missing interval.

The safepoint in the entry block breaks the adjacency move elimination needs, so only a function without one is exposed — today that means only `.x`, and it becomes reachable the moment the errable fence comes off.

Counting also has to come from `ops` rather than `block->operations`: the loop keeps its result in `ops` and only writes the block back once it ends, so counting from the block keeps the uses of ops the loop replaced and sees none from ops it inserted. That second direction is the same defect, so the signature takes the slice.

## Tests

`tests/x/cases/20260901_00_errable.testar`, six cases:

- `test_propagate` — declare, call, propagate, catch with nothing thrown
- `test_throw_catch` — throw a struct literal, catch it, read `msg()`
- `test_nested_catch` — the outer error survives a catch running inside it
- `test_catch_builtin` — catch an index out of range, which the runtime builds rather than user code
- `test_uncaught_panic` — the uncaught path already worked, guard it
- `test_n_catches_x_error` — an `.x` fn throwing under a live coroutine

`test_errable_definition` leaves the diagnostics suite, the fence it asserted is gone.

## Known boundaries

`.x` can only throw `errort`, guarded by a runtime assert. Messages are capped at 160 bytes and truncated beyond that. `errorf` is still unavailable in `.x`, it needs `fmt.sprintf`, so messages there are literals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
