### PR TITLE
fix: rebuild peephole use_count from the working op list

### DIFF
--- a/src/peephole/amd64.c
+++ b/src/peephole/amd64.c
@@ -179,8 +179,6 @@ static bool peephole_lea_fusion(closure_t *c, basic_block_t *block, slice_t *ops
 }
 
 static inline void amd64_peephole_handle_block(closure_t *c, basic_block_t *block) {
-    peephole_build_use_count(block);
-
     slice_t *ops = slice_new();
 
     LINKED_FOR(block->operations) {
@@ -195,6 +193,10 @@ static inline void amd64_peephole_handle_block(closure_t *c, basic_block_t *bloc
     while (changed && iterations < max_iterations) {
         changed = false;
         iterations++;
+
+        // the previous round's rewrites changed the operand uses, so the counts have
+        // to be rebuilt or move elimination drops a def that is still referenced
+        peephole_build_use_count(block, ops);
 
         slice_t *new_ops = slice_new();
         int cursor = 0;

--- a/src/peephole/arm64.c
+++ b/src/peephole/arm64.c
@@ -463,8 +463,6 @@ static bool peephole_fma_recognition(closure_t *c, basic_block_t *block, slice_t
 }
 
 static inline void arm64_peephole_handle_block(closure_t *c, basic_block_t *block) {
-    peephole_build_use_count(block);
-
     slice_t *ops = slice_new();
 
     LINKED_FOR(block->operations) {
@@ -479,6 +477,10 @@ static inline void arm64_peephole_handle_block(closure_t *c, basic_block_t *bloc
     while (changed && iterations < max_iterations) {
         changed = false;
         iterations++;
+
+        // the previous round's rewrites changed the operand uses, so the counts have
+        // to be rebuilt or move elimination drops a def that is still referenced
+        peephole_build_use_count(block, ops);
 
         slice_t *new_ops = slice_new();
         int cursor = 0;

--- a/src/peephole/peephole.h
+++ b/src/peephole/peephole.h
@@ -24,28 +24,30 @@ static inline bool peephole_is_in_live_out(basic_block_t *block, lir_var_t *var)
 /**
  * 构建 block 的变量使用计数表
  * 仅统计 USE 标志的变量出现次数
+ *
+ * Counts over `ops`, the list the optimization loop is actually rewriting.
+ * block->operations is only written back once the loop ends, so counting from it
+ * would miss this round's rewrites: an op the loop replaced still contributes its
+ * old uses, and an op the loop inserted contributes none.
  */
-static inline void peephole_build_use_count(basic_block_t *block) {
+static inline void peephole_build_use_count(basic_block_t *block, slice_t *ops) {
     if (block->use_count) {
         table_free(block->use_count);
     }
 
     block->use_count = table_new();
 
-    linked_node *current = linked_first(block->operations);
-    while (current != NULL && current->value != NULL) {
-        lir_op_t *op = current->value;
+    for (int i = 0; i < ops->count; ++i) {
+        lir_op_t *op = ops->take[i];
 
         // 提取该指令中所有 use 的变量
         slice_t *use_operands = extract_op_operands(op, FLAG(LIR_OPERAND_VAR), FLAG(LIR_FLAG_USE), true);
-        for (int i = 0; i < use_operands->count; ++i) {
-            lir_var_t *use_var = use_operands->take[i];
+        for (int j = 0; j < use_operands->count; ++j) {
+            lir_var_t *use_var = use_operands->take[j];
             intptr_t count = (intptr_t) table_get(block->use_count, use_var->ident);
             table_set(block->use_count, use_var->ident, (void *) (count + 1));
         }
         slice_free(use_operands); // 释放临时 slice
-
-        current = current->succ;
     }
 }
 


### PR DESCRIPTION
## The defect

`peephole_build_use_count` was called once before the optimization loop, but the loop rewrites the ops it counts.

arm64 strength reduction rewrites `MUL t,v` into `ADD v,v` **in place** ([arm64.c:261](src/peephole/arm64.c)), raising v's use count from one to two while the table still reports one. A later move elimination round then treats v as single-use, deletes the instruction defining it, and rewrites only one of the two operands. Register allocation aborts on the missing interval:

```
Assertion failed: (interval), function operand_interval, file interval.c, line 491.
```

The safepoint emitted in the entry block breaks the adjacency move elimination needs, so only a function without one is exposed. Today that means only `.x` functions, which is why this has not been hit on master — but it is a general codegen defect, not an x mode one, and it is reachable from `.n` the moment any pass stops emitting that safepoint.

## The fix

Rebuild the counts at the top of every round.

Counting also has to come from `ops` rather than `block->operations`. The loop keeps its result in the `ops` slice and only writes `block->operations` back once it ends ([amd64.c:228](src/peephole/amd64.c)), so counting from the block still misses the round's rewrites — it keeps the uses of ops the loop replaced and sees none from ops it inserted. That second direction is the same defect this fixes, so the signature takes the slice.

An earlier version of this fix counted from `block->operations`. It happened to work on arm64 only because that backend rewrites op objects in place and the slice shares their pointers; on amd64, where `peephole_lea_fusion` only builds new ops and consumes old ones, it was a no-op.

## Verification

Reproduced with a `.x` function using a fn value (which emits no safepoint), then confirmed fixed. Targeted regressions pass on both backends: list, float, interface, const_string_pool, x_syntax, allocator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
