### PR TITLE
fix: stop defer emission recursing into the scope it is emitting

### DIFF
--- a/src/linear.c
+++ b/src/linear.c
@@ -56,6 +56,10 @@ typedef struct {
     uint16_t break_depth;
     uint16_t ret_depth;
     uint16_t catch_depth;
+    // set while this scope's defer bodies are being emitted. an errable call inside a defer
+    // body emits its own unwind, which walks the scope stack again and would re-enter the scope
+    // that is emitting it, recursing until the compiler's stack runs out.
+    bool emitting;
 } linear_defer_scope_t;
 
 typedef enum {
@@ -79,10 +83,16 @@ static linear_defer_scope_t *linear_defer_scope_new(module_t *m) {
 static void linear_emit_defer_stmt(module_t *m, ast_defer_stmt_t *defer_stmt);
 
 static void linear_emit_scope_defer_stmts(module_t *m, linear_defer_scope_t *scope) {
+    if (scope->emitting) {
+        return;
+    }
+
+    scope->emitting = true;
     for (int i = scope->defer_stmts->count - 1; i >= 0; --i) {
         ast_defer_stmt_t *defer_stmt = scope->defer_stmts->take[i];
         linear_emit_defer_stmt(m, defer_stmt);
     }
+    scope->emitting = false;
 }
 
 static void linear_defer_scope_enter(module_t *m) {

--- a/tests/features/cases/20260301_00_defer.testar
+++ b/tests/features/cases/20260301_00_defer.testar
@@ -190,3 +190,31 @@ fn main() {
 
 --- output.txt
 nature-test/main.n:3:14: return/break/continue/throw/ret are not allowed inside defer block
+
+=== test_defer_errable_call_in_throwing_fn
+--- main.n
+// An errable call inside a defer body emits its own unwind, which walks the defer scope stack
+// again. Without a re-entrancy guard that re-enters the scope currently being emitted and
+// recurses until the compiler's own stack runs out.
+fn cleanup():int! {
+    return 1
+}
+
+fn work():int! {
+    defer {
+        cleanup()
+    }
+    throw errorf('boom')
+}
+
+fn main() {
+    var v = work() catch e {
+        println('caught:', e.msg())
+        -1
+    }
+    println(v)
+}
+
+--- output.txt
+caught: boom
+-1


### PR DESCRIPTION
## The defect

An errable call inside a `defer` body segfaults the compiler on master:

```nature
fn cleanup():int! { return 1 }

fn work():int! {
    defer { cleanup() }
    throw errorf('boom')
}
```

`nature build` exits 139.

## Why

`linear_throw` stores the error and then calls `linear_unwind_all`, so defer bodies are emitted while the scope is still on `defer_scopes`. The errable call inside that body compiles its own unwind — `linear_has_error` → `linear_bal_error` → `linear_unwind_to_catch_depth` → `linear_unwind_scopes` — and that walk finds the very scope being emitted, emits its bodies again, and recurses until the compiler's stack runs out.

A `catch` inside a defer is already rejected ("return/break/continue/throw/ret are not allowed inside defer block"), which is why only the bare errable call reaches this.

## The fix

Mark a scope while its bodies are being emitted and skip it on re-entry. Four lines.

Regression case added to `20260301_00_defer`. Defer plus the four error suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)