### PR TITLE
feat: errable in x mode via a { err, value } return pair

### DIFF
--- a/runtime/nutils/nutils.c
+++ b/runtime/nutils/nutils.c
@@ -1034,6 +1034,25 @@ n_int_t rt_errno() {
     return errno;
 }
 
+
+/**
+ * A .x error is a pointer to an immutable descriptor in .data. Its message bytes sit inline right
+ * after the header, so msg() is a non owning view: no allocation, and the bytes outlive every
+ * frame. allocator is left NULL, matching how the rest of x mode marks storage it does not own.
+ */
+n_string_t rt_x_errdesc_msg(void *self) {
+    uint8_t *desc = self;
+    int32_t len = *(int32_t *) desc;
+
+    n_string_t result = {0};
+    result.data = desc + X_ERRDESC_HEADER_SIZE;
+    result.length = len;
+    result.capacity = len;
+    result.element_size = 1;
+    result.allocator = NULL;
+    return result;
+}
+
 n_anyptr_t rt_array_new(int64_t element_hash, int64_t length) {
     if (length < 0) {
         rti_throw("array_new length must be non-negative", true);

--- a/runtime/nutils/nutils.c
+++ b/runtime/nutils/nutils.c
@@ -1053,6 +1053,19 @@ n_string_t rt_x_errdesc_msg(void *self) {
     return result;
 }
 
+/**
+ * Bridge for a .n fn calling an errable .x fn. The .x side returned a descriptor pointer, which
+ * .n's error path knows nothing about, so build a real gc errort from it and hand it to the
+ * coroutine exactly as a .n throw would. Copying the message is required: the descriptor is
+ * immortal but n_errort wants an owned n_string_t.
+ */
+void co_throw_error_from_desc(void *desc, char *path, char *fn_name, n_int_t line, n_int_t column) {
+    n_string_t view = rt_x_errdesc_msg(desc);
+    n_interface_t error = n_error_new(string_new((char *) view.data, view.length), false);
+    co_throw_error(&error, path, fn_name, line, column);
+}
+
+
 n_anyptr_t rt_array_new(int64_t element_hash, int64_t length) {
     if (length < 0) {
         rti_throw("array_new length must be non-negative", true);

--- a/runtime/nutils/nutils.c
+++ b/runtime/nutils/nutils.c
@@ -1075,6 +1075,12 @@ void rt_x_index_panic(n_int_t *index, n_int_t *len, char *path, n_int_t line, n_
     exit(EXIT_FAILURE);
 }
 
+void rt_x_panic(char *msg, char *path, n_int_t line, n_int_t column) {
+    char *dump = tlsprintf("panic: '%s' at %s:%ld:%ld\n", msg, path, line, column);
+    VOID write(STDOUT_FILENO, dump, strlen(dump));
+    exit(EXIT_FAILURE);
+}
+
 void co_throw_error_from_desc(void *desc, char *path, char *fn_name, n_int_t line, n_int_t column) {
     n_string_t view = rt_x_errdesc_msg(desc);
     n_interface_t error = n_error_new(string_new((char *) view.data, view.length), false);

--- a/runtime/nutils/nutils.c
+++ b/runtime/nutils/nutils.c
@@ -1059,6 +1059,22 @@ n_string_t rt_x_errdesc_msg(void *self) {
  * coroutine exactly as a .n throw would. Copying the message is required: the descriptor is
  * immortal but n_errort wants an owned n_string_t.
  */
+
+/**
+ * Uncaught index-out-of-range raised from .x. Same message and exit as the fn mode path, but it
+ * resolves the caller directly instead of going through throw_index_out_error, which begins with
+ * coroutine_get(). x mode never creates the coroutine tls key, so reading it is undefined.
+ */
+void rt_x_index_panic(n_int_t *index, n_int_t *len, char *path, n_int_t line, n_int_t column) {
+    // the site is passed in rather than recovered from the return address: linear knows it
+    // statically, and the caller table lookup the fn mode path uses does not resolve from here
+    // one tlsprintf: it hands back a reused static buffer, so nesting two calls clobbers the first
+    char *dump = tlsprintf("panic: 'index out of range [%d] with length %d' at %s:%ld:%ld\n",
+                           index, len, path, line, column);
+    VOID write(STDOUT_FILENO, dump, strlen(dump));
+    exit(EXIT_FAILURE);
+}
+
 void co_throw_error_from_desc(void *desc, char *path, char *fn_name, n_int_t line, n_int_t column) {
     n_string_t view = rt_x_errdesc_msg(desc);
     n_interface_t error = n_error_new(string_new((char *) view.data, view.length), false);

--- a/runtime/nutils/nutils.h
+++ b/runtime/nutils/nutils.h
@@ -89,6 +89,9 @@ n_anyptr_t rt_array_new(int64_t element_hash, int64_t length);
 // x mode error descriptor: [i32 len][i32 flags][bytes][NUL] in .data
 n_string_t rt_x_errdesc_msg(void *self);
 
+// .n caller receiving an error from an .x callee
+void co_throw_error_from_desc(void *desc, char *path, char *fn_name, n_int_t line, n_int_t column);
+
 n_vec_t unsafe_vec_new(int64_t hash, int64_t element_hash, int64_t len, void *data_ptr);
 
 n_string_t rt_strerror();

--- a/runtime/nutils/nutils.h
+++ b/runtime/nutils/nutils.h
@@ -86,6 +86,9 @@ void rt_assert(n_bool_t cond);
 // allocate array data by element rtype hash
 n_anyptr_t rt_array_new(int64_t element_hash, int64_t length);
 
+// x mode error descriptor: [i32 len][i32 flags][bytes][NUL] in .data
+n_string_t rt_x_errdesc_msg(void *self);
+
 n_vec_t unsafe_vec_new(int64_t hash, int64_t element_hash, int64_t len, void *data_ptr);
 
 n_string_t rt_strerror();

--- a/runtime/nutils/nutils.h
+++ b/runtime/nutils/nutils.h
@@ -92,6 +92,10 @@ n_string_t rt_x_errdesc_msg(void *self);
 // .n caller receiving an error from an .x callee
 void co_throw_error_from_desc(void *desc, char *path, char *fn_name, n_int_t line, n_int_t column);
 
+// x mode uncaught bounds panic. Never touches the coroutine: in .x the tls key is never
+// created, and reading it is undefined -- junk on darwin, a crash on linux.
+void rt_x_index_panic(n_int_t *index, n_int_t *len, char *path, n_int_t line, n_int_t column);
+
 n_vec_t unsafe_vec_new(int64_t hash, int64_t element_hash, int64_t len, void *data_ptr);
 
 n_string_t rt_strerror();

--- a/runtime/nutils/nutils.h
+++ b/runtime/nutils/nutils.h
@@ -96,6 +96,9 @@ void co_throw_error_from_desc(void *desc, char *path, char *fn_name, n_int_t lin
 // created, and reading it is undefined -- junk on darwin, a crash on linux.
 void rt_x_index_panic(n_int_t *index, n_int_t *len, char *path, n_int_t line, n_int_t column);
 
+// Generic uncaught panic for .x checks that do not need interpolated operands.
+void rt_x_panic(char *msg, char *path, n_int_t line, n_int_t column);
+
 n_vec_t unsafe_vec_new(int64_t hash, int64_t element_hash, int64_t len, void *data_ptr);
 
 n_string_t rt_strerror();

--- a/runtime/runtime.c
+++ b/runtime/runtime.c
@@ -15,9 +15,9 @@ extern wchar_t **CommandLineToArgvW(const wchar_t *command_line,
 #include "sysmon.h"
 
 #ifdef __DARWIN
-extern void *user_main(void) __asm("_main.main");
+extern n_tagged_union_t user_main(void) __asm("_main.main");
 #else
-extern void *user_main(void) __asm("main.main");
+extern n_tagged_union_t user_main(void) __asm("main.main");
 #endif
 
 static _Atomic bool fn_mode_inited = false;
@@ -82,11 +82,11 @@ int runtime_main(int argc, char *argv[]) {
         DEBUGF("[runtime_main] fn mode user code run completed, will exit");
     } else {
         // x mode: call user_main directly, no GC and no scheduler.
-        // main is errable, so it returns its error descriptor; NULL means it completed.
+        // main returns errable<void>; only the error variant carries a descriptor.
         DEBUGF("[runtime_main] x mode, calling user_main directly");
-        void *x_err = user_main();
-        if (x_err) {
-            n_string_t msg = rt_x_errdesc_msg(x_err);
+        n_tagged_union_t result = user_main();
+        if (result.tag_hash == hash_string(X_ERRABLE_ERROR_TAG)) {
+            n_string_t msg = rt_x_errdesc_msg(result.value.ptr_value);
             char *dump = tlsprintf("uncaught error: '%s'\n", (char *) rt_string_ref(&msg));
             VOID write(STDOUT_FILENO, dump, strlen(dump));
             return 1;

--- a/runtime/runtime.c
+++ b/runtime/runtime.c
@@ -15,9 +15,9 @@ extern wchar_t **CommandLineToArgvW(const wchar_t *command_line,
 #include "sysmon.h"
 
 #ifdef __DARWIN
-extern void user_main(void) __asm("_main.main");
+extern void *user_main(void) __asm("_main.main");
 #else
-extern void user_main(void) __asm("main.main");
+extern void *user_main(void) __asm("main.main");
 #endif
 
 static _Atomic bool fn_mode_inited = false;
@@ -81,9 +81,16 @@ int runtime_main(int argc, char *argv[]) {
 
         DEBUGF("[runtime_main] fn mode user code run completed, will exit");
     } else {
-        // x mode: call user_main directly, no GC and no scheduler
+        // x mode: call user_main directly, no GC and no scheduler.
+        // main is errable, so it returns its error descriptor; NULL means it completed.
         DEBUGF("[runtime_main] x mode, calling user_main directly");
-        user_main();
+        void *x_err = user_main();
+        if (x_err) {
+            n_string_t msg = rt_x_errdesc_msg(x_err);
+            char *dump = tlsprintf("uncaught error: '%s'\n", (char *) rt_string_ref(&msg));
+            VOID write(STDOUT_FILENO, dump, strlen(dump));
+            return 1;
+        }
         DEBUGF("[runtime_main] x mode user code run completed, will exit");
     }
 

--- a/src/ast.h
+++ b/src/ast.h
@@ -758,7 +758,7 @@ struct ast_fndef_t {
     bool is_x; // the fn belongs to an .x module (x mode)
 
     bool is_errable;
-    // errable .x fn only: the declared T, while return_type holds the { err, value } pair
+    // errable .x fn only: the declared T, while return_type holds tagged errable<T>
     type_t errable_value_type;
 
     // tpl fn 可以自定义 #linkid 宏, 用来自定义链接符号名称

--- a/src/ast.h
+++ b/src/ast.h
@@ -754,6 +754,8 @@ struct ast_fndef_t {
     bool is_x; // the fn belongs to an .x module (x mode)
 
     bool is_errable;
+    // errable .x fn only: the declared T, while return_type holds the { err, value } pair
+    type_t errable_value_type;
 
     // tpl fn 可以自定义 #linkid 宏, 用来自定义链接符号名称
     char *linkid;

--- a/src/ast.h
+++ b/src/ast.h
@@ -368,6 +368,10 @@ typedef struct {
  */
 typedef struct {
     ast_expr_t error;
+    // .x only: the literal message, lifted out of `throw errorf('...')` by infer. The error there
+    // is a pointer to an immutable descriptor emitted at this site, so the text must be known now.
+    char *x_desc_msg;
+    int64_t x_desc_len;
 } ast_throw_stmt_t;
 
 /**

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -204,6 +204,12 @@ static void return_check(closure_t *c, table_t *handled, basic_block_t *b) {
         return;
     }
 
+    // an errable .x fn returns { err, value }; when the declared T is void there is nothing for
+    // the user to return and linear emits the pair itself, so no explicit return is required
+    if (c->fndef->is_x && c->fndef->is_errable && c->fndef->errable_value_type.kind == TYPE_VOID) {
+        return;
+    }
+
     if (handled == NULL) {
         handled = table_new();
     }

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -204,8 +204,8 @@ static void return_check(closure_t *c, table_t *handled, basic_block_t *b) {
         return;
     }
 
-    // an errable .x fn returns { err, value }; when the declared T is void there is nothing for
-    // the user to return and linear emits the pair itself, so no explicit return is required
+    // An errable .x fn returns errable<T>; when T is void, linear emits value(void), so the user
+    // does not need an explicit return.
     if (c->fndef->is_x && c->fndef->is_errable && c->fndef->errable_value_type.kind == TYPE_VOID) {
         return;
     }

--- a/src/linear.c
+++ b/src/linear.c
@@ -1,4 +1,7 @@
 #include "linear.h"
+static void linear_x_builtin_error(module_t *m, char *msg, bool be_catch);
+static void linear_x_store_error(module_t *m, lir_operand_t *err_value);
+static lir_operand_t *linear_x_errdesc(module_t *m, char *msg, int64_t len, int32_t flags);
 
 #include <stddef.h>
 #include <stdio.h>
@@ -239,7 +242,14 @@ linear_inline_arr_element_addr(module_t *m, lir_operand_t *arr_target, lir_opera
         error_label_ident = stack_top(m->current_closure->catch_error_labels);
     }
 
-    push_rt_call(m, RT_CALL_THROW_INDEX_OUT_ERROR, NULL, 3, index_target, length_target, bool_operand(be_catch));
+    if (m->is_x && be_catch) {
+        // caught in .x: the descriptor carries the static text, the interpolated index and
+        // length are only kept on the uncaught path below
+        linear_x_builtin_error(m, "index out of range", be_catch);
+    } else {
+        push_rt_call(m, RT_CALL_THROW_INDEX_OUT_ERROR, NULL, 3, index_target, length_target,
+                     bool_operand(be_catch));
+    }
     // bal catch or end label
     linear_bal_error(m, error_label_ident, catch_depth);
     OP_PUSH(lir_op_label(end_label_ident, true));
@@ -344,7 +354,14 @@ linear_inline_vec_element_addr(module_t *m, lir_operand_t *vec_target, lir_opera
         error_label_ident = stack_top(m->current_closure->catch_error_labels);
     }
 
-    push_rt_call(m, RT_CALL_THROW_INDEX_OUT_ERROR, NULL, 3, index_target, length_target, bool_operand(be_catch));
+    if (m->is_x && be_catch) {
+        // caught in .x: the descriptor carries the static text, the interpolated index and
+        // length are only kept on the uncaught path below
+        linear_x_builtin_error(m, "index out of range", be_catch);
+    } else {
+        push_rt_call(m, RT_CALL_THROW_INDEX_OUT_ERROR, NULL, 3, index_target, length_target,
+                     bool_operand(be_catch));
+    }
     // bal catch or end label
     linear_bal_error(m, error_label_ident, catch_depth);
     OP_PUSH(lir_op_label(end_label_ident, true));
@@ -966,6 +983,16 @@ static lir_operand_t *linear_x_errdesc(module_t *m, char *msg, int64_t len, int3
     return addr;
 }
 
+/**
+ * A runtime error raised from a check the compiler emitted (bounds, nil deref, ...). In .x it
+ * becomes the same thing a user throw does: a static descriptor written into the error slot.
+ * The uncaught path still calls the runtime, which keeps the interpolated detail and exits.
+ */
+static void linear_x_builtin_error(module_t *m, char *msg, bool be_catch) {
+    lir_operand_t *desc = linear_x_errdesc(m, msg, (int64_t) strlen(msg), X_ERRDESC_FLAG_PANIC);
+    linear_x_store_error(m, desc);
+}
+
 static void linear_x_bind_error(module_t *m, lir_operand_t *err_operand, lir_operand_t *slot) {
     assert(slot);
     OP_PUSH(lir_op_move(err_operand, slot));
@@ -1003,7 +1030,20 @@ static void linear_x_has_error(module_t *m, lir_operand_t *pair, type_t pair_typ
     // err == 0 means ok, skip the error path
     OP_PUSH(lir_op_new(LIR_OPCODE_BEE, int_operand(0), err_value, lir_label_operand(error_end_ident, true)));
     OP_PUSH(lir_op_label(error_ident, true));
-    linear_x_store_error(m, err_value);
+
+    if (m->is_x) {
+        linear_x_store_error(m, err_value);
+    } else {
+        // a .n caller has a coroutine to put the error on, and its own error path expects to find
+        // it there, so the descriptor is turned into a real errort at the boundary
+        char *error_path = m->current_closure->fndef->rel_path ? m->current_closure->fndef->rel_path : m->rel_path;
+        push_rt_call(m, RT_CALL_CO_THROW_ERROR_FROM_DESC, NULL, 5, err_value,
+                     string_operand(error_path, strlen(error_path)),
+                     string_operand(m->current_closure->fndef->fn_name_with_pkg,
+                                    strlen(m->current_closure->fndef->fn_name_with_pkg)),
+                     int_operand(m->current_line), int_operand(m->current_column));
+    }
+
     linear_bal_error(m, error_target_label, catch_depth);
     OP_PUSH(lir_op_label(error_end_ident, true));
 }
@@ -4549,6 +4589,11 @@ static closure_t *linear_fndef(module_t *m, ast_fndef_t *fndef) {
     OP_PUSH(lir_op_bal(lir_label_operand(c->end_label, true))); // bal end
 
     OP_PUSH(lir_op_label(c->end_label, true));
+
+    // an errable .x fn whose declared T is void falls through here with err already NULL
+    if (c->x_return_pair && c->fndef->errable_value_type.kind == TYPE_VOID) {
+        OP_PUSH(lir_op_new(LIR_OPCODE_RETURN, c->x_return_pair, NULL, NULL));
+    }
 
     //    OP_PUSH(lir_op_safepoint());
     // lower 的时候需要进行特殊的处理(return_operand 为了让 ssa use-def 链条完整)

--- a/src/linear.c
+++ b/src/linear.c
@@ -909,6 +909,105 @@ static void linear_has_panic(module_t *m) {
 }
 
 
+/**
+ * .x errable propagation. The callee returned { err, value }, so the check is a null test on the
+ * pair's err field rather than a question to the coroutine. Nothing is stored across the branch:
+ * the error is materialized into this fn's own return slot at the point it is detected, before
+ * any defer body runs, so an errable call inside a defer cannot clobber the error in flight.
+ */
+/**
+ * Put the error where the handler about to run will look for it: the innermost active catch's
+ * own slot, or the fn's return-error slot when the error is propagating out. Writing it here,
+ * at the error site, means nothing shared stays live across the defer bodies that
+ * linear_bal_error is about to emit.
+ */
+/**
+ * In .x the caught error is the descriptor pointer this catch's own slot was given at the error
+ * site. No runtime call, no shared slot, no copy: `e` is an 8-byte pointer to immutable data.
+ */
+/**
+ * Emit an immutable error descriptor into .data and return its address.
+ *
+ * Layout is self contained -- [i32 len][i32 flags][bytes][NUL] -- rather than a pointer to the
+ * message, because this toolchain never emits a relocation into the data section. That is the
+ * same limit global_eval.c hits when it rejects a non-empty global string initializer.
+ *
+ * Descriptors with the same text and flags share one symbol; the key carries the length so two
+ * different messages cannot collide on a prefix.
+ */
+static lir_operand_t *linear_x_errdesc(module_t *m, char *msg, int64_t len, int32_t flags) {
+    char *key = dsprintf("xerrdesc:%d:%ld:%s", flags, len, msg);
+
+    asm_global_symbol_t *symbol = table_get(m->global_symbol_table, key);
+    if (!symbol) {
+        size_t size = X_ERRDESC_HEADER_SIZE + (size_t) len + 1;
+        uint8_t *value = mallocz(size);
+        *(int32_t *) value = (int32_t) len;
+        *(int32_t *) (value + 4) = flags;
+        memmove(value + X_ERRDESC_HEADER_SIZE, msg, (size_t) len);
+
+        symbol = NEW(asm_global_symbol_t);
+        symbol->name = label_ident_with_prefix(m, "xerrdesc");
+        symbol->size = size;
+        symbol->alignment = QWORD;
+        symbol->value = value;
+
+        symbol_table_set_raw_string(m, symbol->name, type_kind_new(TYPE_RAW_STRING), size);
+        slice_push(m->asm_global_symbols, symbol);
+        table_set(m->global_symbol_table, key, symbol);
+    }
+
+    lir_symbol_var_t *symbol_var = NEW(lir_symbol_var_t);
+    symbol_var->ident = symbol->name;
+    symbol_var->t = type_kind_new(TYPE_ANYPTR);
+
+    lir_operand_t *addr = temp_var_operand(m, type_kind_new(TYPE_ANYPTR));
+    OP_PUSH(lir_op_lea(addr, operand_new(LIR_OPERAND_SYMBOL_VAR, symbol_var)));
+    return addr;
+}
+
+static void linear_x_bind_error(module_t *m, lir_operand_t *err_operand, lir_operand_t *slot) {
+    assert(slot);
+    OP_PUSH(lir_op_move(err_operand, slot));
+}
+
+static void linear_x_store_error(module_t *m, lir_operand_t *err_value) {
+    closure_t *c = m->current_closure;
+
+    if (c->x_catch_err_slots->count > 0) {
+        lir_operand_t *slot = stack_top(c->x_catch_err_slots);
+        OP_PUSH(lir_op_move(slot, err_value));
+        return;
+    }
+
+    assert(c->x_return_err);
+    uint64_t err_offset = type_struct_offset(c->fndef->return_type.struct_, X_ERRABLE_ERR_NAME);
+    OP_PUSH(lir_op_move(indirect_addr_operand(m, type_kind_new(TYPE_ANYPTR), c->x_return_pair, err_offset),
+                        err_value));
+}
+
+static void linear_x_has_error(module_t *m, lir_operand_t *pair, type_t pair_type) {
+    char *error_target_label = m->current_closure->error_label;
+    uint16_t catch_depth = m->current_closure->catch_error_labels->count;
+    if (catch_depth > 0) {
+        error_target_label = stack_top(m->current_closure->catch_error_labels);
+    }
+
+    uint64_t err_offset = type_struct_offset(pair_type.struct_, X_ERRABLE_ERR_NAME);
+    lir_operand_t *err_value = temp_var_operand(m, type_kind_new(TYPE_ANYPTR));
+    OP_PUSH(lir_op_move(err_value, indirect_addr_operand(m, type_kind_new(TYPE_ANYPTR), pair, err_offset)));
+
+    char *error_ident = label_ident_with_unique(".xerror");
+    char *error_end_ident = str_connect(error_ident, LABEL_END_SUFFIX);
+
+    // err == 0 means ok, skip the error path
+    OP_PUSH(lir_op_new(LIR_OPCODE_BEE, int_operand(0), err_value, lir_label_operand(error_end_ident, true)));
+    OP_PUSH(lir_op_label(error_ident, true));
+    linear_x_store_error(m, err_value);
+    linear_bal_error(m, error_target_label, catch_depth);
+    OP_PUSH(lir_op_label(error_end_ident, true));
+}
+
 static void linear_has_error(module_t *m) {
     char *error_target_label = m->current_closure->error_label;
     assertf(m->current_line < 1000000, "line '%d' exception", m->current_line);
@@ -1809,9 +1908,20 @@ static void linear_ret(module_t *m, ast_ret_stmt_t *stmt) {
 }
 
 static void linear_return(module_t *m, ast_return_stmt_t *ast) {
+    closure_t *c = m->current_closure;
     lir_operand_t *src = NULL;
     if (ast->expr != NULL) {
         src = linear_expr(m, *ast->expr, NULL);
+    }
+
+    // an errable .x fn returns the pair; err was cleared in the prologue and stays NULL here
+    if (c->x_return_pair) {
+        if (src) {
+            uint64_t value_offset = type_struct_offset(c->fndef->return_type.struct_, X_ERRABLE_VALUE_NAME);
+            type_t value_type = c->fndef->errable_value_type;
+            OP_PUSH(lir_op_move(indirect_addr_operand(m, value_type, c->x_return_pair, value_offset), src));
+        }
+        src = c->x_return_pair;
     }
 
     linear_unwind_all(m);
@@ -2177,6 +2287,28 @@ static lir_operand_t *linear_call(module_t *m, ast_expr_t expr, lir_operand_t *t
     }
 
     lir_operand_t *temp = NULL;
+
+    if (is_x_errable_fn(type_fn)) {
+        // the callee returns { err, value }, so the call writes the pair and the value is read
+        // back out of it. The error check is a null test on the pair rather than a runtime call.
+        type_t pair_type = type_fn->return_type;
+        lir_operand_t *pair = temp_var_operand_with_alloc(m, pair_type);
+
+        OP_PUSH(lir_op_new(LIR_OPCODE_CALL, fn_target, operand_new(LIR_OPERAND_ARGS, args), pair));
+        linear_x_has_error(m, pair, pair_type);
+
+        if (call->return_type.kind != TYPE_VOID) {
+            uint64_t value_offset = type_struct_offset(pair_type.struct_, X_ERRABLE_VALUE_NAME);
+            temp = temp_var_operand(m, call->return_type);
+            OP_PUSH(lir_op_move(temp, indirect_addr_operand(m, call->return_type, pair, value_offset)));
+        }
+
+        if (temp) {
+            return linear_super_move(m, expr.type, target, temp);
+        }
+        return target;
+    }
+
     if (call->return_type.kind != TYPE_VOID) {
         temp = temp_var_operand(m, call->return_type);
     }
@@ -3763,9 +3895,22 @@ static lir_operand_t *linear_catch_expr(module_t *m, ast_expr_t expr, lir_operan
         target = temp_var_operand_with_alloc(m, expr.type);
     }
 
+    lir_operand_t *x_err_slot = NULL;
+    if (m->is_x) {
+        // this catch's own error slot: a nested catch or a defer body gets a different one,
+        // so nothing shares storage across the unwind
+        x_err_slot = temp_var_operand_with_alloc(m, type_kind_new(TYPE_ANYPTR));
+        OP_PUSH(lir_op_move(x_err_slot, int_operand(0)));
+        stack_push(m->current_closure->x_catch_err_slots, x_err_slot);
+    }
+
     stack_push(m->current_closure->catch_error_labels, catch_start_label);
     linear_expr(m, catch_expr->try_expr, target);
     stack_pop(m->current_closure->catch_error_labels);
+
+    if (m->is_x) {
+        stack_pop(m->current_closure->x_catch_err_slots);
+    }
 
     // 跳过错误处理部分
     lir_op_t *catch_end_label = lir_op_label(catch_end_ident, true);
@@ -3786,7 +3931,11 @@ static lir_operand_t *linear_catch_expr(module_t *m, ast_expr_t expr, lir_operan
     // 从 catch expr 中获取 err 然后为 err 赋值
     lir_operand_t *err_operand = linear_var_decl(m, &catch_expr->catch_err);
 
-    push_rt_call(m, RT_CALL_CO_REMOVE_ERROR, err_operand, 0);
+    if (m->is_x) {
+        linear_x_bind_error(m, err_operand, x_err_slot);
+    } else {
+        push_rt_call(m, RT_CALL_CO_REMOVE_ERROR, err_operand, 0);
+    }
 
     stack_push(m->current_closure->ret_labels, catch_end_label->output);
     stack_push(m->current_closure->ret_targets, target);
@@ -3809,9 +3958,20 @@ static void linear_try_catch_stmt(module_t *m, ast_try_catch_stmt_t *try_stmt) {
     bool has_ret = false;
 
 
+    lir_operand_t *x_err_slot = NULL;
+    if (m->is_x) {
+        x_err_slot = temp_var_operand_with_alloc(m, type_kind_new(TYPE_ANYPTR));
+        OP_PUSH(lir_op_move(x_err_slot, int_operand(0)));
+        stack_push(m->current_closure->x_catch_err_slots, x_err_slot);
+    }
+
     stack_push(m->current_closure->catch_error_labels, catch_start_label);
     linear_body(m, try_stmt->try_body);
     stack_pop(m->current_closure->catch_error_labels);
+
+    if (m->is_x) {
+        stack_pop(m->current_closure->x_catch_err_slots);
+    }
 
     // 跳过错误处理部分
     lir_op_t *catch_end_label = lir_op_label(catch_end_ident, true);
@@ -3823,7 +3983,11 @@ static void linear_try_catch_stmt(module_t *m, ast_try_catch_stmt_t *try_stmt) {
 
     // 为 err 赋值
     lir_operand_t *err_operand = linear_var_decl(m, &try_stmt->catch_err);
-    push_rt_call(m, RT_CALL_CO_REMOVE_ERROR, err_operand, 0);
+    if (m->is_x) {
+        linear_x_bind_error(m, err_operand, x_err_slot);
+    } else {
+        push_rt_call(m, RT_CALL_CO_REMOVE_ERROR, err_operand, 0);
+    }
 
     stack_push(m->current_closure->ret_labels, catch_end_label->output);
 
@@ -4049,6 +4213,20 @@ static lir_operand_t *linear_fn_decl(module_t *m, ast_expr_t expr, lir_operand_t
 }
 
 static void linear_throw(module_t *m, ast_throw_stmt_t *stmt) {
+    // .x throws a descriptor pointer written straight into this fn's return slot, so nothing is
+    // live across the defer bodies linear_unwind_all is about to emit.
+    if (m->is_x) {
+        assert(stmt->x_desc_msg);
+        lir_operand_t *desc = linear_x_errdesc(m, stmt->x_desc_msg, stmt->x_desc_len, 0);
+        linear_x_store_error(m, desc);
+        linear_unwind_all(m);
+
+        closure_t *c = m->current_closure;
+        OP_PUSH(lir_op_new(LIR_OPCODE_RETURN, c->x_return_pair, NULL, NULL));
+        OP_PUSH(lir_op_bal(lir_label_operand(c->end_label, false)));
+        return;
+    }
+
     // msg to errort
     assert(str_equal(stmt->error.type.ident, THROWABLE_IDENT));
     lir_operand_t *error_operand = linear_expr(m, stmt->error, NULL);
@@ -4343,6 +4521,16 @@ static closure_t *linear_fndef(module_t *m, ast_fndef_t *fndef) {
         OP_PUSH(lir_op_safepoint());
     }
 
+    // an errable .x fn returns { err, value }. Allocate it once here and clear err, so the ok
+    // path returns NULL without touching it and every error site writes straight into the slot
+    // it will be returned from.
+    if (fndef->is_x && fndef->is_errable) {
+        c->x_return_pair = temp_var_operand_with_alloc(m, fndef->return_type);
+        uint64_t err_offset = type_struct_offset(fndef->return_type.struct_, X_ERRABLE_ERR_NAME);
+        c->x_return_err = indirect_addr_operand(m, type_kind_new(TYPE_ANYPTR), c->x_return_pair, err_offset);
+        OP_PUSH(lir_op_move(c->x_return_err, int_operand(0)));
+    }
+
     // 参数 escape rewrite
     for (int i = 0; i < fndef->params->length; ++i) {
         ast_var_decl_t *var_decl = ct_list_value(fndef->params, i);
@@ -4356,7 +4544,8 @@ static closure_t *linear_fndef(module_t *m, ast_fndef_t *fndef) {
     OP_PUSH(lir_op_bal(lir_label_operand(c->end_label, true)));
 
     OP_PUSH(lir_op_label(c->error_label, true));
-    OP_PUSH(lir_op_new(LIR_OPCODE_RETURN, NULL, NULL, NULL)); // 方便 return check
+    // in .x the error is already in the pair's err field, so the error path returns it
+    OP_PUSH(lir_op_new(LIR_OPCODE_RETURN, c->x_return_pair, NULL, NULL)); // 方便 return check
     OP_PUSH(lir_op_bal(lir_label_operand(c->end_label, true))); // bal end
 
     OP_PUSH(lir_op_label(c->end_label, true));

--- a/src/linear.c
+++ b/src/linear.c
@@ -246,6 +246,13 @@ linear_inline_arr_element_addr(module_t *m, lir_operand_t *arr_target, lir_opera
         // caught in .x: the descriptor carries the static text, the interpolated index and
         // length are only kept on the uncaught path below
         linear_x_builtin_error(m, "index out of range", be_catch);
+    } else if (m->is_x) {
+        // uncaught in .x: same message and exit, but through a path that never reads the
+        // coroutine tls key, which x mode does not create
+        char *panic_path = m->current_closure->fndef->rel_path ? m->current_closure->fndef->rel_path : m->rel_path;
+        push_rt_call(m, RT_CALL_X_INDEX_PANIC, NULL, 5, index_target, length_target,
+                     string_operand(panic_path, strlen(panic_path)),
+                     int_operand(m->current_line), int_operand(m->current_column));
     } else {
         push_rt_call(m, RT_CALL_THROW_INDEX_OUT_ERROR, NULL, 3, index_target, length_target,
                      bool_operand(be_catch));
@@ -358,6 +365,13 @@ linear_inline_vec_element_addr(module_t *m, lir_operand_t *vec_target, lir_opera
         // caught in .x: the descriptor carries the static text, the interpolated index and
         // length are only kept on the uncaught path below
         linear_x_builtin_error(m, "index out of range", be_catch);
+    } else if (m->is_x) {
+        // uncaught in .x: same message and exit, but through a path that never reads the
+        // coroutine tls key, which x mode does not create
+        char *panic_path = m->current_closure->fndef->rel_path ? m->current_closure->fndef->rel_path : m->rel_path;
+        push_rt_call(m, RT_CALL_X_INDEX_PANIC, NULL, 5, index_target, length_target,
+                     string_operand(panic_path, strlen(panic_path)),
+                     int_operand(m->current_line), int_operand(m->current_column));
     } else {
         push_rt_call(m, RT_CALL_THROW_INDEX_OUT_ERROR, NULL, 3, index_target, length_target,
                      bool_operand(be_catch));

--- a/src/linear.c
+++ b/src/linear.c
@@ -1,5 +1,5 @@
 #include "linear.h"
-static void linear_x_builtin_error(module_t *m, char *msg, bool be_catch);
+static void linear_x_builtin_error(module_t *m, char *msg);
 static void linear_x_store_error(module_t *m, lir_operand_t *err_value);
 static lir_operand_t *linear_x_errdesc(module_t *m, char *msg, int64_t len, int32_t flags);
 
@@ -245,7 +245,7 @@ linear_inline_arr_element_addr(module_t *m, lir_operand_t *arr_target, lir_opera
     if (m->is_x && be_catch) {
         // caught in .x: the descriptor carries the static text, the interpolated index and
         // length are only kept on the uncaught path below
-        linear_x_builtin_error(m, "index out of range", be_catch);
+        linear_x_builtin_error(m, "index out of range");
     } else if (m->is_x) {
         // uncaught in .x: same message and exit, but through a path that never reads the
         // coroutine tls key, which x mode does not create
@@ -364,7 +364,7 @@ linear_inline_vec_element_addr(module_t *m, lir_operand_t *vec_target, lir_opera
     if (m->is_x && be_catch) {
         // caught in .x: the descriptor carries the static text, the interpolated index and
         // length are only kept on the uncaught path below
-        linear_x_builtin_error(m, "index out of range", be_catch);
+        linear_x_builtin_error(m, "index out of range");
     } else if (m->is_x) {
         // uncaught in .x: same message and exit, but through a path that never reads the
         // coroutine tls key, which x mode does not create
@@ -941,22 +941,6 @@ static void linear_has_panic(module_t *m) {
 
 
 /**
- * .x errable propagation. The callee returned { err, value }, so the check is a null test on the
- * pair's err field rather than a question to the coroutine. Nothing is stored across the branch:
- * the error is materialized into this fn's own return slot at the point it is detected, before
- * any defer body runs, so an errable call inside a defer cannot clobber the error in flight.
- */
-/**
- * Put the error where the handler about to run will look for it: the innermost active catch's
- * own slot, or the fn's return-error slot when the error is propagating out. Writing it here,
- * at the error site, means nothing shared stays live across the defer bodies that
- * linear_bal_error is about to emit.
- */
-/**
- * In .x the caught error is the descriptor pointer this catch's own slot was given at the error
- * site. No runtime call, no shared slot, no copy: `e` is an 8-byte pointer to immutable data.
- */
-/**
  * Emit an immutable error descriptor into .data and return its address.
  *
  * Layout is self contained -- [i32 len][i32 flags][bytes][NUL] -- rather than a pointer to the
@@ -1002,48 +986,77 @@ static lir_operand_t *linear_x_errdesc(module_t *m, char *msg, int64_t len, int3
  * becomes the same thing a user throw does: a static descriptor written into the error slot.
  * The uncaught path still calls the runtime, which keeps the interpolated detail and exits.
  */
-static void linear_x_builtin_error(module_t *m, char *msg, bool be_catch) {
+static void linear_x_builtin_error(module_t *m, char *msg) {
     lir_operand_t *desc = linear_x_errdesc(m, msg, (int64_t) strlen(msg), X_ERRDESC_FLAG_PANIC);
     linear_x_store_error(m, desc);
 }
 
+/**
+ * In .x the caught error is the descriptor pointer this catch's own slot was given at the error
+ * site. No runtime call, no shared slot, no copy: `e` is an 8-byte pointer to immutable data.
+ */
 static void linear_x_bind_error(module_t *m, lir_operand_t *err_operand, lir_operand_t *slot) {
     assert(slot);
     OP_PUSH(lir_op_move(err_operand, slot));
 }
 
+/**
+ * Put the error where the handler about to run will look for it: the innermost active catch's
+ * own slot, or the fn's errable<T> return value when propagating out. The first error wins: a
+ * failing errable call in a defer body must not replace the error which started the unwind.
+ */
 static void linear_x_store_error(module_t *m, lir_operand_t *err_value) {
     closure_t *c = m->current_closure;
 
     if (c->x_catch_err_slots->count > 0) {
         lir_operand_t *slot = stack_top(c->x_catch_err_slots);
+        lir_operand_t *current = temp_var_operand(m, type_kind_new(TYPE_ANYPTR));
+        OP_PUSH(lir_op_move(current, slot));
+
+        char *end_ident = label_ident_with_unique(".xerror.store.end");
+        OP_PUSH(lir_op_new(LIR_OPCODE_BNE, int_operand(0), current, lir_label_operand(end_ident, true)));
         OP_PUSH(lir_op_move(slot, err_value));
+        OP_PUSH(lir_op_label(end_ident, true));
         return;
     }
 
-    assert(c->x_return_err);
-    uint64_t err_offset = type_struct_offset(c->fndef->return_type.struct_, X_ERRABLE_ERR_NAME);
-    OP_PUSH(lir_op_move(indirect_addr_operand(m, type_kind_new(TYPE_ANYPTR), c->x_return_pair, err_offset),
+    assert(c->x_return_errable);
+    lir_operand_t *current_tag = temp_var_operand(m, type_kind_new(TYPE_INT64));
+    OP_PUSH(lir_op_move(current_tag,
+                        indirect_addr_operand(m, type_kind_new(TYPE_INT64), c->x_return_errable, 0)));
+
+    // The function result is already error(...), so a defer failure must not replace it.
+    char *end_ident = label_ident_with_unique(".xerror.store.end");
+    OP_PUSH(lir_op_new(LIR_OPCODE_BEE, int_operand(hash_string(X_ERRABLE_ERROR_TAG)), current_tag,
+                       lir_label_operand(end_ident, true)));
+    OP_PUSH(lir_op_move(indirect_addr_operand(m, type_kind_new(TYPE_ANYPTR), c->x_return_errable, POINTER_SIZE),
                         err_value));
+    OP_PUSH(lir_op_move(indirect_addr_operand(m, type_kind_new(TYPE_INT64), c->x_return_errable, 0),
+                        int_operand(hash_string(X_ERRABLE_ERROR_TAG))));
+    OP_PUSH(lir_op_label(end_ident, true));
 }
 
-static void linear_x_has_error(module_t *m, lir_operand_t *pair, type_t pair_type) {
+static void linear_x_has_error(module_t *m, lir_operand_t *errable) {
     char *error_target_label = m->current_closure->error_label;
     uint16_t catch_depth = m->current_closure->catch_error_labels->count;
     if (catch_depth > 0) {
         error_target_label = stack_top(m->current_closure->catch_error_labels);
     }
 
-    uint64_t err_offset = type_struct_offset(pair_type.struct_, X_ERRABLE_ERR_NAME);
-    lir_operand_t *err_value = temp_var_operand(m, type_kind_new(TYPE_ANYPTR));
-    OP_PUSH(lir_op_move(err_value, indirect_addr_operand(m, type_kind_new(TYPE_ANYPTR), pair, err_offset)));
+    lir_operand_t *actual_tag = temp_var_operand(m, type_kind_new(TYPE_INT64));
+    OP_PUSH(lir_op_move(actual_tag, indirect_addr_operand(m, type_kind_new(TYPE_INT64), errable, 0)));
 
     char *error_ident = label_ident_with_unique(".xerror");
     char *error_end_ident = str_connect(error_ident, LABEL_END_SUFFIX);
 
-    // err == 0 means ok, skip the error path
-    OP_PUSH(lir_op_new(LIR_OPCODE_BEE, int_operand(0), err_value, lir_label_operand(error_end_ident, true)));
+    // Anything other than error(...) is the value variant and stays on the happy path.
+    OP_PUSH(lir_op_new(LIR_OPCODE_BNE, int_operand(hash_string(X_ERRABLE_ERROR_TAG)), actual_tag,
+                       lir_label_operand(error_end_ident, true)));
     OP_PUSH(lir_op_label(error_ident, true));
+
+    lir_operand_t *err_value = temp_var_operand(m, type_kind_new(TYPE_ANYPTR));
+    OP_PUSH(lir_op_move(err_value,
+                        indirect_addr_operand(m, type_kind_new(TYPE_ANYPTR), errable, POINTER_SIZE)));
 
     if (m->is_x) {
         linear_x_store_error(m, err_value);
@@ -1968,14 +1981,13 @@ static void linear_return(module_t *m, ast_return_stmt_t *ast) {
         src = linear_expr(m, *ast->expr, NULL);
     }
 
-    // an errable .x fn returns the pair; err was cleared in the prologue and stays NULL here
-    if (c->x_return_pair) {
+    // Surface `return T` constructs the value(T) variant of the function's errable<T> result.
+    if (c->x_return_errable) {
         if (src) {
-            uint64_t value_offset = type_struct_offset(c->fndef->return_type.struct_, X_ERRABLE_VALUE_NAME);
             type_t value_type = c->fndef->errable_value_type;
-            OP_PUSH(lir_op_move(indirect_addr_operand(m, value_type, c->x_return_pair, value_offset), src));
+            OP_PUSH(lir_op_move(indirect_addr_operand(m, value_type, c->x_return_errable, POINTER_SIZE), src));
         }
-        src = c->x_return_pair;
+        src = c->x_return_errable;
     }
 
     linear_unwind_all(m);
@@ -2343,18 +2355,17 @@ static lir_operand_t *linear_call(module_t *m, ast_expr_t expr, lir_operand_t *t
     lir_operand_t *temp = NULL;
 
     if (is_x_errable_fn(type_fn)) {
-        // the callee returns { err, value }, so the call writes the pair and the value is read
-        // back out of it. The error check is a null test on the pair rather than a runtime call.
-        type_t pair_type = type_fn->return_type;
-        lir_operand_t *pair = temp_var_operand_with_alloc(m, pair_type);
+        // The callee returns errable<T>. Check its tag inline, then extract the value payload.
+        type_t errable_type = type_fn->return_type;
+        lir_operand_t *errable = temp_var_operand_with_alloc(m, errable_type);
 
-        OP_PUSH(lir_op_new(LIR_OPCODE_CALL, fn_target, operand_new(LIR_OPERAND_ARGS, args), pair));
-        linear_x_has_error(m, pair, pair_type);
+        OP_PUSH(lir_op_new(LIR_OPCODE_CALL, fn_target, operand_new(LIR_OPERAND_ARGS, args), errable));
+        linear_x_has_error(m, errable);
 
         if (call->return_type.kind != TYPE_VOID) {
-            uint64_t value_offset = type_struct_offset(pair_type.struct_, X_ERRABLE_VALUE_NAME);
             temp = temp_var_operand(m, call->return_type);
-            OP_PUSH(lir_op_move(temp, indirect_addr_operand(m, call->return_type, pair, value_offset)));
+            OP_PUSH(lir_op_move(temp,
+                                indirect_addr_operand(m, call->return_type, errable, POINTER_SIZE)));
         }
 
         if (temp) {
@@ -3399,6 +3410,49 @@ static lir_operand_t *linear_is_expr(module_t *m, ast_expr_t expr, lir_operand_t
 }
 
 /**
+ * Ordinary unions keep an rtype pointer in their first word. In .x the successful runtime
+ * assertion helper is unnecessary, while its failure path is invalid because it allocates a
+ * coroutine error. Compare the stored rtype hash directly and report through x's error path.
+ */
+static void linear_x_union_assert(module_t *m, lir_operand_t *src_operand, uint64_t target_rtype_hash) {
+    lir_operand_t *union_ptr = temp_var_operand(m, type_kind_new(TYPE_ANYPTR));
+    OP_PUSH(lir_op_move(union_ptr, src_operand));
+
+    lir_operand_t *rtype_ptr = temp_var_operand(m, type_kind_new(TYPE_ANYPTR));
+    OP_PUSH(lir_op_move(rtype_ptr,
+                        indirect_addr_operand(m, type_kind_new(TYPE_ANYPTR), union_ptr,
+                                              offsetof(n_union_t, rtype))));
+
+    lir_operand_t *actual_hash = temp_var_operand(m, type_kind_new(TYPE_INT64));
+    OP_PUSH(lir_op_move(actual_hash,
+                        indirect_addr_operand(m, type_kind_new(TYPE_INT64), rtype_ptr,
+                                              offsetof(rtype_t, hash))));
+
+    char *assert_ident = label_ident_with_unique(".union.assert");
+    char *assert_end_ident = str_connect(assert_ident, LABEL_END_SUFFIX);
+    lir_operand_t *assert_end = lir_label_operand(assert_end_ident, true);
+    OP_PUSH(lir_op_new(LIR_OPCODE_BEE, int_operand(target_rtype_hash), actual_hash, assert_end));
+
+    uint16_t catch_depth = m->current_closure->catch_error_labels->count;
+    char *error_target_label = m->current_closure->error_label;
+    if (catch_depth > 0) {
+        error_target_label = stack_top(m->current_closure->catch_error_labels);
+        linear_x_builtin_error(m, "type assert failed");
+    } else {
+        char *panic_path = m->current_closure->fndef->rel_path
+                                   ? m->current_closure->fndef->rel_path
+                                   : m->rel_path;
+        push_rt_call(m, RT_CALL_X_PANIC, NULL, 4,
+                     string_operand("type assert failed", strlen("type assert failed")),
+                     string_operand(panic_path, strlen(panic_path)), int_operand(m->current_line),
+                     int_operand(m->current_column));
+    }
+
+    linear_bal_error(m, error_target_label, catch_depth);
+    OP_PUSH(lir_op_label(assert_end_ident, true));
+}
+
+/**
  * @param m
  * @param expr
  * @return
@@ -3576,6 +3630,17 @@ static lir_operand_t *linear_as_expr(module_t *m, ast_expr_t expr, lir_operand_t
     // union assert
     if (as_expr->src.type.kind == TYPE_UNION) {
         assert(as_expr->target_type.kind != TYPE_UNION);
+        if (m->is_x) {
+            uint64_t target_rtype_hash = type_hash(as_expr->target_type);
+            linear_x_union_assert(m, src_operand, target_rtype_hash);
+
+            lir_operand_t *payload = indirect_addr_operand(m, as_expr->target_type, src_operand, POINTER_SIZE);
+            if (as_expr->target_type.storage_kind == STORAGE_KIND_IND) {
+                payload = lea_operand_pointer(m, payload);
+            }
+            return linear_super_move(m, as_expr->target_type, target, payload);
+        }
+
         if (as_expr->target_type.storage_kind != STORAGE_KIND_IND) {
             // target 可能总是未 def 导致下面的取值异常, 所以最好使用临时值 assert，然后 mov 到 target
             lir_operand_t *temp = temp_var_operand(m, as_expr->target_type);
@@ -4267,8 +4332,7 @@ static lir_operand_t *linear_fn_decl(module_t *m, ast_expr_t expr, lir_operand_t
 }
 
 static void linear_throw(module_t *m, ast_throw_stmt_t *stmt) {
-    // .x throws a descriptor pointer written straight into this fn's return slot, so nothing is
-    // live across the defer bodies linear_unwind_all is about to emit.
+    // .x throw constructs error(ptr<errdesc>) before running defer bodies.
     if (m->is_x) {
         assert(stmt->x_desc_msg);
         lir_operand_t *desc = linear_x_errdesc(m, stmt->x_desc_msg, stmt->x_desc_len, 0);
@@ -4276,7 +4340,7 @@ static void linear_throw(module_t *m, ast_throw_stmt_t *stmt) {
         linear_unwind_all(m);
 
         closure_t *c = m->current_closure;
-        OP_PUSH(lir_op_new(LIR_OPCODE_RETURN, c->x_return_pair, NULL, NULL));
+        OP_PUSH(lir_op_new(LIR_OPCODE_RETURN, c->x_return_errable, NULL, NULL));
         OP_PUSH(lir_op_bal(lir_label_operand(c->end_label, false)));
         return;
     }
@@ -4575,14 +4639,15 @@ static closure_t *linear_fndef(module_t *m, ast_fndef_t *fndef) {
         OP_PUSH(lir_op_safepoint());
     }
 
-    // an errable .x fn returns { err, value }. Allocate it once here and clear err, so the ok
-    // path returns NULL without touching it and every error site writes straight into the slot
-    // it will be returned from.
+    // Allocate the errable<T> result once. Falling through or returning T keeps value(T);
+    // an error site changes the tag and writes its descriptor into the shared payload.
     if (fndef->is_x && fndef->is_errable) {
-        c->x_return_pair = temp_var_operand_with_alloc(m, fndef->return_type);
-        uint64_t err_offset = type_struct_offset(fndef->return_type.struct_, X_ERRABLE_ERR_NAME);
-        c->x_return_err = indirect_addr_operand(m, type_kind_new(TYPE_ANYPTR), c->x_return_pair, err_offset);
-        OP_PUSH(lir_op_move(c->x_return_err, int_operand(0)));
+        c->x_return_errable = temp_var_operand_with_alloc(m, fndef->return_type);
+        OP_PUSH(lir_op_move(indirect_addr_operand(m, type_kind_new(TYPE_INT64), c->x_return_errable, 0),
+                            int_operand(hash_string(X_ERRABLE_VALUE_TAG))));
+        OP_PUSH(lir_op_move(indirect_addr_operand(m, type_kind_new(TYPE_ANYPTR), c->x_return_errable,
+                                                 POINTER_SIZE),
+                            int_operand(0)));
     }
 
     // 参数 escape rewrite
@@ -4598,15 +4663,15 @@ static closure_t *linear_fndef(module_t *m, ast_fndef_t *fndef) {
     OP_PUSH(lir_op_bal(lir_label_operand(c->end_label, true)));
 
     OP_PUSH(lir_op_label(c->error_label, true));
-    // in .x the error is already in the pair's err field, so the error path returns it
-    OP_PUSH(lir_op_new(LIR_OPCODE_RETURN, c->x_return_pair, NULL, NULL)); // 方便 return check
+    // In .x the error variant is already materialized, so the error path returns it directly.
+    OP_PUSH(lir_op_new(LIR_OPCODE_RETURN, c->x_return_errable, NULL, NULL)); // 方便 return check
     OP_PUSH(lir_op_bal(lir_label_operand(c->end_label, true))); // bal end
 
     OP_PUSH(lir_op_label(c->end_label, true));
 
-    // an errable .x fn whose declared T is void falls through here with err already NULL
-    if (c->x_return_pair && c->fndef->errable_value_type.kind == TYPE_VOID) {
-        OP_PUSH(lir_op_new(LIR_OPCODE_RETURN, c->x_return_pair, NULL, NULL));
+    // An errable .x fn whose declared T is void falls through with value(void).
+    if (c->x_return_errable && c->fndef->errable_value_type.kind == TYPE_VOID) {
+        OP_PUSH(lir_op_new(LIR_OPCODE_RETURN, c->x_return_errable, NULL, NULL));
     }
 
     //    OP_PUSH(lir_op_safepoint());

--- a/src/lir.c
+++ b/src/lir.c
@@ -22,6 +22,9 @@ closure_t *lir_closure_new(ast_fndef_t *fndef) {
     c->blocks = slice_new(); // basic_block_t
 
     c->catch_error_labels = stack_new();
+    c->x_catch_err_slots = stack_new();
+    c->x_return_pair = NULL;
+    c->x_return_err = NULL;
     c->ret_targets = stack_new();
     c->ret_labels = stack_new();
     c->continue_labels = stack_new();

--- a/src/lir.c
+++ b/src/lir.c
@@ -23,8 +23,7 @@ closure_t *lir_closure_new(ast_fndef_t *fndef) {
 
     c->catch_error_labels = stack_new();
     c->x_catch_err_slots = stack_new();
-    c->x_return_pair = NULL;
-    c->x_return_err = NULL;
+    c->x_return_errable = NULL;
     c->ret_targets = stack_new();
     c->ret_labels = stack_new();
     c->continue_labels = stack_new();

--- a/src/lir.h
+++ b/src/lir.h
@@ -146,6 +146,7 @@
 
 #define RT_CALL_THROW_INDEX_OUT_ERROR "throw_index_out_error"
 #define RT_CALL_CO_THROW_ERROR "co_throw_error"
+#define RT_CALL_CO_THROW_ERROR_FROM_DESC "co_throw_error_from_desc"
 
 #define RT_CALL_CO_REMOVE_ERROR "co_remove_error"
 #define RT_CALL_CO_HAS_ERROR "co_has_error"
@@ -267,7 +268,7 @@ static inline bool is_rtcall(string target) {
            str_equal(target, RT_CALL_STRING_LT) || str_equal(target, RT_CALL_STRING_LE) ||
            str_equal(target, RT_CALL_STRING_GT) || str_equal(target, RT_CALL_STRING_GE) ||
            str_equal(target, RT_CALL_GC_MALLOC) ||
-           str_equal(target, RT_CALL_RUNTIME_EVAL_GC) || str_equal(target, RT_CALL_COROUTINE_ASYNC2) || str_equal(target, RT_CALL_CO_THROW_ERROR) ||
+           str_equal(target, RT_CALL_RUNTIME_EVAL_GC) || str_equal(target, RT_CALL_COROUTINE_ASYNC2) || str_equal(target, RT_CALL_CO_THROW_ERROR) || str_equal(target, RT_CALL_CO_THROW_ERROR_FROM_DESC) ||
            str_equal(target, RT_CALL_CO_REMOVE_ERROR) || str_equal(target, RT_CALL_CO_HAS_ERROR) ||
            str_equal(target, RT_CALL_CO_HAS_PANIC) || str_equal(target, RT_CALL_PROCESSOR_SET_EXIT) ||
            str_equal(target, RT_CALL_UNION_TO_ANY);

--- a/src/lir.h
+++ b/src/lir.h
@@ -147,6 +147,7 @@
 #define RT_CALL_THROW_INDEX_OUT_ERROR "throw_index_out_error"
 #define RT_CALL_CO_THROW_ERROR "co_throw_error"
 #define RT_CALL_CO_THROW_ERROR_FROM_DESC "co_throw_error_from_desc"
+#define RT_CALL_X_INDEX_PANIC "rt_x_index_panic"
 
 #define RT_CALL_CO_REMOVE_ERROR "co_remove_error"
 #define RT_CALL_CO_HAS_ERROR "co_has_error"
@@ -268,7 +269,7 @@ static inline bool is_rtcall(string target) {
            str_equal(target, RT_CALL_STRING_LT) || str_equal(target, RT_CALL_STRING_LE) ||
            str_equal(target, RT_CALL_STRING_GT) || str_equal(target, RT_CALL_STRING_GE) ||
            str_equal(target, RT_CALL_GC_MALLOC) ||
-           str_equal(target, RT_CALL_RUNTIME_EVAL_GC) || str_equal(target, RT_CALL_COROUTINE_ASYNC2) || str_equal(target, RT_CALL_CO_THROW_ERROR) || str_equal(target, RT_CALL_CO_THROW_ERROR_FROM_DESC) ||
+           str_equal(target, RT_CALL_RUNTIME_EVAL_GC) || str_equal(target, RT_CALL_COROUTINE_ASYNC2) || str_equal(target, RT_CALL_CO_THROW_ERROR) || str_equal(target, RT_CALL_CO_THROW_ERROR_FROM_DESC) || str_equal(target, RT_CALL_X_INDEX_PANIC) ||
            str_equal(target, RT_CALL_CO_REMOVE_ERROR) || str_equal(target, RT_CALL_CO_HAS_ERROR) ||
            str_equal(target, RT_CALL_CO_HAS_PANIC) || str_equal(target, RT_CALL_PROCESSOR_SET_EXIT) ||
            str_equal(target, RT_CALL_UNION_TO_ANY);

--- a/src/lir.h
+++ b/src/lir.h
@@ -148,6 +148,7 @@
 #define RT_CALL_CO_THROW_ERROR "co_throw_error"
 #define RT_CALL_CO_THROW_ERROR_FROM_DESC "co_throw_error_from_desc"
 #define RT_CALL_X_INDEX_PANIC "rt_x_index_panic"
+#define RT_CALL_X_PANIC "rt_x_panic"
 
 #define RT_CALL_CO_REMOVE_ERROR "co_remove_error"
 #define RT_CALL_CO_HAS_ERROR "co_has_error"
@@ -269,7 +270,9 @@ static inline bool is_rtcall(string target) {
            str_equal(target, RT_CALL_STRING_LT) || str_equal(target, RT_CALL_STRING_LE) ||
            str_equal(target, RT_CALL_STRING_GT) || str_equal(target, RT_CALL_STRING_GE) ||
            str_equal(target, RT_CALL_GC_MALLOC) ||
-           str_equal(target, RT_CALL_RUNTIME_EVAL_GC) || str_equal(target, RT_CALL_COROUTINE_ASYNC2) || str_equal(target, RT_CALL_CO_THROW_ERROR) || str_equal(target, RT_CALL_CO_THROW_ERROR_FROM_DESC) || str_equal(target, RT_CALL_X_INDEX_PANIC) ||
+           str_equal(target, RT_CALL_RUNTIME_EVAL_GC) || str_equal(target, RT_CALL_COROUTINE_ASYNC2) ||
+           str_equal(target, RT_CALL_CO_THROW_ERROR) || str_equal(target, RT_CALL_CO_THROW_ERROR_FROM_DESC) ||
+           str_equal(target, RT_CALL_X_INDEX_PANIC) || str_equal(target, RT_CALL_X_PANIC) ||
            str_equal(target, RT_CALL_CO_REMOVE_ERROR) || str_equal(target, RT_CALL_CO_HAS_ERROR) ||
            str_equal(target, RT_CALL_CO_HAS_PANIC) || str_equal(target, RT_CALL_PROCESSOR_SET_EXIT) ||
            str_equal(target, RT_CALL_UNION_TO_ANY);

--- a/src/lower/amd64_abi.c
+++ b/src/lower/amd64_abi.c
@@ -120,9 +120,6 @@ linked_t *amd64_lower_return(closure_t *c, lir_op_t *op) {
 
     if (is_abi_struct_like(return_type)) {
         // return_operand 保存的是一个指针，需要 indirect 这个值，将响应的值 mov 到寄存器中
-        lir_operand_t *src = indirect_addr_operand(c->module, type_kind_new(lo_kind), return_operand, 0);
-        linked_push(result, lir_op_move(lo_dst_reg, src));
-
         if (count == 2) {
             lir_operand_t *hi_dst_reg = NULL;
             type_kind hi_kind;
@@ -133,9 +130,15 @@ linked_t *amd64_lower_return(closure_t *c, lir_op_t *op) {
                 hi_dst_reg = operand_new(LIR_OPERAND_REG, xmm1s64);
                 hi_kind = TYPE_FLOAT64;
             }
-            src = indirect_addr_operand(c->module, type_kind_new(hi_kind), return_operand, QWORD);
+            // The aggregate base commonly has a return-register hint. Preserve it until both
+            // words have been loaded by moving the high word before the low return register.
+            lir_operand_t *src =
+                    indirect_addr_operand(c->module, type_kind_new(hi_kind), return_operand, QWORD);
             linked_push(result, lir_op_move(hi_dst_reg, src));
         }
+
+        lir_operand_t *src = indirect_addr_operand(c->module, type_kind_new(lo_kind), return_operand, 0);
+        linked_push(result, lir_op_move(lo_dst_reg, src));
     } else {
         assert(count == 1);
         assertf(return_type.kind != TYPE_ARR, "array type must be pointer type");

--- a/src/lower/arm64_abi.c
+++ b/src/lower/arm64_abi.c
@@ -688,15 +688,19 @@ linked_t *arm64_lower_return(closure_t *c, lir_op_t *op) {
             }
         } else if (return_size <= 16) {
             // 小于等于 16 字节的结构体，使用 x0 和 x1 返回
-            lir_operand_t *src_lo = indirect_addr_operand(c->module, type_kind_new(TYPE_UINT64), return_operand, 0);
-            lir_operand_t *dst_lo = operand_new(LIR_OPERAND_REG, x0);
-            linked_push(result, lir_op_move(dst_lo, src_lo));
-
+            // Load the high word first. return_operand commonly carries an x0 hint; writing x0
+            // first would destroy the base before the [base + 8] load.
             if (return_size > 8) {
-                lir_operand_t *src_hi = indirect_addr_operand(c->module, type_kind_new(TYPE_UINT64), return_operand, 8);
+                lir_operand_t *src_hi =
+                        indirect_addr_operand(c->module, type_kind_new(TYPE_UINT64), return_operand, 8);
                 lir_operand_t *dst_hi = operand_new(LIR_OPERAND_REG, x1);
                 linked_push(result, lir_op_move(dst_hi, src_hi));
             }
+
+            lir_operand_t *src_lo =
+                    indirect_addr_operand(c->module, type_kind_new(TYPE_UINT64), return_operand, 0);
+            lir_operand_t *dst_lo = operand_new(LIR_OPERAND_REG, x0);
+            linked_push(result, lir_op_move(dst_lo, src_lo));
         } else {
             assert(c->return_big_operand);
             // fn begin 时 x8 寄存器中存储的指针被传递给了 c->return_operand

--- a/src/lower/riscv64_abi.c
+++ b/src/lower/riscv64_abi.c
@@ -713,14 +713,16 @@ linked_t *riscv64_lower_return(closure_t *c, lir_op_t *op) {
                 hi_dst = operand_new(LIR_OPERAND_REG, reg_select(reg_index, attach_kind));
             }
         }
-        // 进行 mov
-        lir_operand_t *lo_src = indirect_addr_operand(c->module, type_kind_new(main_kind), return_operand, 0);
-        linked_push(result, lir_op_move(lo_dst, lo_src));
-
+        // Keep the aggregate base alive until both words have been loaded. It commonly has an
+        // a0 return hint, so writing the low return register first can clobber [base + offset].
         if (hi_dst) {
-            lir_operand_t *hi_src = indirect_addr_operand(c->module, type_kind_new(attach_kind), return_operand, attach_offset);
+            lir_operand_t *hi_src =
+                    indirect_addr_operand(c->module, type_kind_new(attach_kind), return_operand, attach_offset);
             linked_push(result, lir_op_move(hi_dst, hi_src));
         }
+
+        lir_operand_t *lo_src = indirect_addr_operand(c->module, type_kind_new(main_kind), return_operand, 0);
+        linked_push(result, lir_op_move(lo_dst, lo_src));
 
     } else {
         if (return_size > 16) {

--- a/src/semantic/analyzer.c
+++ b/src/semantic/analyzer.c
@@ -2547,8 +2547,9 @@ static void analyzer_main(module_t *m) {
     ANALYZER_ASSERTF(main_fn->return_type.kind == TYPE_VOID,
                      "fn main must have no arguments and no return values, example: fn main() {...");
 
-    // main fn add define errorable, x mode has no coroutine error slot
-    main_fn->is_errable = !m->is_x;
+    // main fn add define errorable. .x carries the error in its return value now, so its main
+    // can be errable too and an uncaught error is reported instead of being a compile error.
+    main_fn->is_errable = true;
 
     // the entry symbol name is pinned by the runtime, decoupled from the module ident
     main_fn->linkid = FN_MAIN_LINKID;

--- a/src/semantic/infer.c
+++ b/src/semantic/infer.c
@@ -1542,6 +1542,9 @@ static void infer_try_catch_stmt(module_t *m, ast_try_catch_stmt_t *try_stmt) {
 
     type_t interface_error = interface_throwable();
     interface_error = reduction_type(m, interface_error);
+    if (m->is_x) {
+        interface_error = reduction_type(m, x_errdesc_ptr_type());
+    }
     try_stmt->catch_err.type = interface_error;
 
     rewrite_var_decl(m, &try_stmt->catch_err);
@@ -1559,6 +1562,9 @@ static type_t infer_catch(module_t *m, ast_catch_t *catch_expr) {
 
     type_t interface_error = interface_throwable();
     interface_error = reduction_type(m, interface_error);
+    if (m->is_x) {
+        interface_error = reduction_type(m, x_errdesc_ptr_type());
+    }
     catch_expr->catch_err.type = interface_error;
 
     rewrite_var_decl(m, &catch_expr->catch_err);
@@ -3335,6 +3341,30 @@ static void infer_throw(module_t *m, ast_throw_stmt_t *throw_stmt) {
     INFER_ASSERTF(m->current_fn->is_errable,
                   "can't use throw stmt in a fn without an errable! declaration. example: fn %s(...):%s!",
                   m->current_fn->fn_name, type_origin_format(m->current_fn->return_type));
+
+    // In .x the error is a pointer to an immutable descriptor emitted into .data at this site, so
+    // the message has to be known now. `throw errorf('literal')` is recognized by shape here,
+    // before infer_call would reject the call into .n, and never becomes a real call.
+    if (m->is_x) {
+        INFER_ASSERTF(throw_stmt->error.assert_type == AST_CALL, "throw in .x requires a literal message");
+
+        ast_call_t *call = throw_stmt->error.value;
+        INFER_ASSERTF(call->left.assert_type == AST_EXPR_IDENT, "throw in .x requires a literal message");
+
+        ast_ident *ident = call->left.value;
+        INFER_ASSERTF(str_equal(ident->literal, ERRORF_IDENT) && call->args->length == 1,
+                      "throw in .x requires a literal message");
+
+        ast_expr_t *arg = ct_list_value(call->args, 0);
+        INFER_ASSERTF(arg->assert_type == AST_EXPR_LITERAL, "throw in .x requires a literal message");
+
+        ast_literal_t *literal = arg->value;
+        INFER_ASSERTF(literal->kind == TYPE_STRING, "throw in .x requires a literal message");
+
+        throw_stmt->x_desc_msg = literal->value;
+        throw_stmt->x_desc_len = literal->len;
+        return;
+    }
 
     infer_right_expr(m, &throw_stmt->error, interface_throwable());
 }

--- a/src/semantic/infer.c
+++ b/src/semantic/infer.c
@@ -10,6 +10,7 @@
 #include "src/error.h"
 
 static type_t reduction_type_visited(module_t *m, type_t t, struct sc_map_s64 *visited);
+static type_t x_errable_pair_type(module_t *m, type_t value_type);
 
 static type_t reduction_type_ident(module_t *m, type_t t, struct sc_map_s64 *visited);
 
@@ -2886,6 +2887,12 @@ static type_t infer_call(module_t *m, ast_call_t *call, type_t target_type, bool
 
     call->return_type = type_fn->return_type;
 
+    // an errable .x fn returns { err, value }; the call still has the type the user declared,
+    // and linear reads the fn type to learn the real ABI shape.
+    if (is_x_errable_fn(type_fn)) {
+        call->return_type = type_fn->errable_value_type;
+    }
+
     if (m->current_fn && m->current_fn->is_x && !type_fn->is_x) {
         INFER_ASSERTF(false, "calling .n fn '%s' from .x fn '%s' is not allowed.",
                       type_fn->fn_name ? type_fn->fn_name : "lambda", m->current_fn->fn_name);
@@ -2899,7 +2906,7 @@ static type_t infer_call(module_t *m, ast_call_t *call, type_t target_type, bool
                       m->current_fn->fn_name);
     }
 
-    return type_fn->return_type;
+    return call->return_type;
 }
 
 static void infer_tagged_union_element(module_t *m, ast_expr_t *expr, type_t target_type) {
@@ -3228,6 +3235,13 @@ static void infer_typedef_stmt(module_t *m, ast_typedef_stmt_t *stmt) {
  */
 static void infer_return(module_t *m, ast_return_stmt_t *stmt) {
     type_t expect_type = m->current_fn->return_type;
+
+    // an errable .x fn declares T but returns { err, value }, so `return v` is checked against T
+    // and linear builds the pair. The declared shape stays invisible to the user.
+    if (m->current_fn->is_x && m->current_fn->is_errable) {
+        expect_type = m->current_fn->errable_value_type;
+    }
+
     if (stmt->expr != NULL) {
         infer_right_expr(m, stmt->expr, expect_type);
     } else {
@@ -4149,6 +4163,39 @@ static type_t reduction_interface(module_t *m, type_t t, struct sc_map_s64 *visi
     return t;
 }
 
+/**
+ * Build the return type an errable .x fn actually returns: { anyptr err; T value }, or just
+ * { anyptr err } when T is void. err == NULL means ok.
+ *
+ * The struct carries no ident, so rtype.h hashes it structurally and every module that
+ * synthesizes the pair for the same T lands on one shared rtype and one ABI shape.
+ * reduction_type computes storage_size / storage_kind / abi_struct / align and registers the
+ * rtype for it exactly as it would for a parsed struct, so no ABI code has to know about this.
+ */
+static type_t x_errable_pair_type(module_t *m, type_t value_type) {
+    type_struct_t *s = NEW(type_struct_t);
+    s->ident = NULL;
+    s->properties = ct_list_new(sizeof(struct_property_t));
+
+    struct_property_t err = {0};
+    err.name = X_ERRABLE_ERR_NAME;
+    err.type = type_kind_new(TYPE_ANYPTR);
+    err.right = NULL;
+    ct_list_push(s->properties, &err);
+
+    if (value_type.kind != TYPE_VOID) {
+        struct_property_t value = {0};
+        value.name = X_ERRABLE_VALUE_NAME;
+        value.type = value_type;
+        value.right = NULL;
+        ct_list_push(s->properties, &value);
+    }
+
+    type_t result = type_new(TYPE_STRUCT, s);
+    result.status = REDUCTION_STATUS_UNDO;
+    return reduction_type(m, result);
+}
+
 type_t reduction_type(module_t *m, type_t t) {
     struct sc_map_s64 visited;
     sc_map_init_s64(&visited, 0, 0);
@@ -4298,6 +4345,12 @@ static type_t infer_impl_fn_decl(module_t *m, ast_fndef_t *fndef) {
     f->is_x = fndef->is_x;
     f->param_types = ct_list_new(sizeof(type_t));
     f->return_type = reduction_type(m, fndef->return_type);
+    if (is_x_errable_fn(f)) {
+        f->errable_value_type = f->return_type;
+        f->return_type = x_errable_pair_type(m, f->return_type);
+        fndef->errable_value_type = f->errable_value_type;
+        fndef->return_type = f->return_type;
+    }
     f->self_kind = fndef->self_kind;
 
     // 跳过 self(仅当存在 receiver)
@@ -4358,6 +4411,13 @@ static type_t infer_fn_decl(module_t *m, ast_fndef_t *fndef, type_t target_type)
     type_fn->param_types = ct_list_new(sizeof(type_t));
     fndef->return_type.status = REDUCTION_STATUS_UNDO;
     type_fn->return_type = reduction_type(m, fndef->return_type);
+
+    // an errable .x fn returns its error beside its value instead of on a coroutine slot
+    if (is_x_errable_fn(type_fn)) {
+        type_fn->errable_value_type = type_fn->return_type;
+        type_fn->return_type = x_errable_pair_type(m, type_fn->return_type);
+        fndef->errable_value_type = type_fn->errable_value_type;
+    }
 
     fndef->return_type = type_fn->return_type;
 
@@ -4434,7 +4494,6 @@ static void infer_fndef(module_t *m, ast_fndef_t *fn) {
     // v1 x mode subset. both are demonstrated crashes rather than style rules: an errable chain
     // aborts register allocation, and a capturing closure segfaults on the gc env promotion.
     if (fn->is_x) {
-        INFER_ASSERTF(!fn->is_errable, "errable fn declaration is not supported in .x");
         INFER_ASSERTF(fn->capture_exprs->length == 0, "closure capture is not supported in .x");
     }
 

--- a/src/semantic/infer.c
+++ b/src/semantic/infer.c
@@ -10,7 +10,7 @@
 #include "src/error.h"
 
 static type_t reduction_type_visited(module_t *m, type_t t, struct sc_map_s64 *visited);
-static type_t x_errable_pair_type(module_t *m, type_t value_type);
+static type_t x_errable_type(module_t *m, type_t value_type);
 
 static type_t reduction_type_ident(module_t *m, type_t t, struct sc_map_s64 *visited);
 
@@ -2893,7 +2893,7 @@ static type_t infer_call(module_t *m, ast_call_t *call, type_t target_type, bool
 
     call->return_type = type_fn->return_type;
 
-    // an errable .x fn returns { err, value }; the call still has the type the user declared,
+    // An errable .x fn returns tagged errable<T>; the call still has the type the user declared,
     // and linear reads the fn type to learn the real ABI shape.
     if (is_x_errable_fn(type_fn)) {
         call->return_type = type_fn->errable_value_type;
@@ -3242,8 +3242,8 @@ static void infer_typedef_stmt(module_t *m, ast_typedef_stmt_t *stmt) {
 static void infer_return(module_t *m, ast_return_stmt_t *stmt) {
     type_t expect_type = m->current_fn->return_type;
 
-    // an errable .x fn declares T but returns { err, value }, so `return v` is checked against T
-    // and linear builds the pair. The declared shape stays invisible to the user.
+    // An errable .x fn declares T but returns errable<T>, so `return v` is checked against T and
+    // linear constructs the value variant. The ABI shape stays invisible to the user.
     if (m->current_fn->is_x && m->current_fn->is_errable) {
         expect_type = m->current_fn->errable_value_type;
     }
@@ -4194,34 +4194,37 @@ static type_t reduction_interface(module_t *m, type_t t, struct sc_map_s64 *visi
 }
 
 /**
- * Build the return type an errable .x fn actually returns: { anyptr err; T value }, or just
- * { anyptr err } when T is void. err == NULL means ok.
+ * Build the concrete tagged union behind T! in .x:
  *
- * The struct carries no ident, so rtype.h hashes it structurally and every module that
- * synthesizes the pair for the same T lands on one shared rtype and one ABI shape.
- * reduction_type computes storage_size / storage_kind / abi_struct / align and registers the
- * rtype for it exactly as it would for a parsed struct, so no ABI code has to know about this.
+ *     errable<T> = value(T) | error(ptr<errdesc>)
+ *
+ * This is synthesized as the specialization is inferred instead of resolving the public .n
+ * alias, whose error member is deliberately the coroutine-backed errort. Keeping the canonical
+ * errable name and T argument makes diagnostics describe the language concept, while the tagged
+ * variants make it impossible for a value and an error to be active simultaneously.
  */
-static type_t x_errable_pair_type(module_t *m, type_t value_type) {
-    type_struct_t *s = NEW(type_struct_t);
-    s->ident = NULL;
-    s->properties = ct_list_new(sizeof(struct_property_t));
+static type_t x_errable_type(module_t *m, type_t value_type) {
+    type_tagged_union_t *tagged = NEW(type_tagged_union_t);
+    tagged->ident = ERRABLE_IDENT;
+    tagged->elements = ct_list_new(sizeof(tagged_union_element_t));
 
-    struct_property_t err = {0};
-    err.name = X_ERRABLE_ERR_NAME;
-    err.type = type_kind_new(TYPE_ANYPTR);
-    err.right = NULL;
-    ct_list_push(s->properties, &err);
+    tagged_union_element_t value = {
+            .tag = X_ERRABLE_VALUE_TAG,
+            .type = value_type,
+    };
+    ct_list_push(tagged->elements, &value);
 
-    if (value_type.kind != TYPE_VOID) {
-        struct_property_t value = {0};
-        value.name = X_ERRABLE_VALUE_NAME;
-        value.type = value_type;
-        value.right = NULL;
-        ct_list_push(s->properties, &value);
-    }
+    tagged_union_element_t error = {
+            .tag = X_ERRABLE_ERROR_TAG,
+            .type = x_errdesc_ptr_type(),
+    };
+    ct_list_push(tagged->elements, &error);
 
-    type_t result = type_new(TYPE_STRUCT, s);
+    type_t result = type_new(TYPE_TAGGED_UNION, tagged);
+    result.ident = ERRABLE_IDENT;
+    result.ident_kind = TYPE_IDENT_TAGGER_UNION;
+    result.args = ct_list_new(sizeof(type_t));
+    ct_list_push(result.args, &value_type);
     result.status = REDUCTION_STATUS_UNDO;
     return reduction_type(m, result);
 }
@@ -4377,7 +4380,7 @@ static type_t infer_impl_fn_decl(module_t *m, ast_fndef_t *fndef) {
     f->return_type = reduction_type(m, fndef->return_type);
     if (is_x_errable_fn(f)) {
         f->errable_value_type = f->return_type;
-        f->return_type = x_errable_pair_type(m, f->return_type);
+        f->return_type = x_errable_type(m, f->return_type);
         fndef->errable_value_type = f->errable_value_type;
         fndef->return_type = f->return_type;
     }
@@ -4442,10 +4445,10 @@ static type_t infer_fn_decl(module_t *m, ast_fndef_t *fndef, type_t target_type)
     fndef->return_type.status = REDUCTION_STATUS_UNDO;
     type_fn->return_type = reduction_type(m, fndef->return_type);
 
-    // an errable .x fn returns its error beside its value instead of on a coroutine slot
+    // an errable .x fn returns tagged errable<T> instead of using a coroutine slot
     if (is_x_errable_fn(type_fn)) {
         type_fn->errable_value_type = type_fn->return_type;
-        type_fn->return_type = x_errable_pair_type(m, type_fn->return_type);
+        type_fn->return_type = x_errable_type(m, type_fn->return_type);
         fndef->errable_value_type = type_fn->errable_value_type;
     }
 

--- a/src/types.h
+++ b/src/types.h
@@ -578,14 +578,11 @@ typedef struct closure_t {
     char *error_label; // 遇到表达式错误时需要调整到的目标 label
 
     ct_stack_t *catch_error_labels;
-    // x mode only: one error slot per active catch, parallel to catch_error_labels, plus
-    // x_return_err for the propagate-out-of-fn path. The error site writes the slot belonging
-    // to the label it is about to jump to, so a defer body's own errors never share storage.
+    // x mode only: one descriptor slot per active catch, parallel to catch_error_labels.
     ct_stack_t *x_catch_err_slots;
-    // the { err, value } this fn returns, a stack local so the error is written straight into
-    // the return slot at the error site. x_return_err addresses its err field.
-    lir_operand_t *x_return_pair;
-    lir_operand_t *x_return_err;
+    // The tagged errable<T> this fn returns. Error sites change it from value(T) to
+    // error(ptr<errdesc>) before unwinding defer bodies.
+    lir_operand_t *x_return_errable;
 
     ct_stack_t *continue_labels; // 用于 for continue lir_operand*
     ct_stack_t *break_labels; // 用于 for break lir_operand*

--- a/src/types.h
+++ b/src/types.h
@@ -578,6 +578,14 @@ typedef struct closure_t {
     char *error_label; // 遇到表达式错误时需要调整到的目标 label
 
     ct_stack_t *catch_error_labels;
+    // x mode only: one error slot per active catch, parallel to catch_error_labels, plus
+    // x_return_err for the propagate-out-of-fn path. The error site writes the slot belonging
+    // to the label it is about to jump to, so a defer body's own errors never share storage.
+    ct_stack_t *x_catch_err_slots;
+    // the { err, value } this fn returns, a stack local so the error is written straight into
+    // the return slot at the error site. x_return_err addresses its err field.
+    lir_operand_t *x_return_pair;
+    lir_operand_t *x_return_err;
 
     ct_stack_t *continue_labels; // 用于 for continue lir_operand*
     ct_stack_t *break_labels; // 用于 for break lir_operand*

--- a/std/builtin/error.x
+++ b/std/builtin/error.x
@@ -1,0 +1,14 @@
+// The error a .x catch binds. It is a pointer to an immutable descriptor the compiler emitted
+// into .data at the throw site: [i32 len][i32 flags][bytes][NUL]. Nothing is allocated, nothing
+// is copied, and it outlives every frame, so a handler can hold it as long as it likes.
+//
+// error.n is untouched: throwable, errort and errorf stay there, so .n keeps its own error type
+// and custom .n implementations of throwable keep working.
+pub type errdesc = struct{
+    i32 len
+    i32 flags
+}
+
+// builds a non owning string view over the descriptor's inline bytes, no allocation
+#linkid rt_x_errdesc_msg
+pub fn errdesc.msg(*self):string

--- a/std/builtin/error.x
+++ b/std/builtin/error.x
@@ -4,11 +4,13 @@
 //
 // error.n is untouched: throwable, errort and errorf stay there, so .n keeps its own error type
 // and custom .n implementations of throwable keep working.
-pub type errdesc = struct{
+// The compiler lowers T! in .x to the tagged errable<T> variants value(T) and
+// error(ptr<errdesc>). It synthesizes that specialization because error.n's source-level
+// errable<T> intentionally describes the different, coroutine-backed .n representation.
+pub type errdesc = struct {
     i32 len
     i32 flags
 }
-
 // builds a non owning string view over the descriptor's inline bytes, no allocation
 #linkid rt_x_errdesc_msg
-pub fn errdesc.msg(*self):string
+pub fn errdesc.msg(*self): string

--- a/tests/x/20260901_00_errable.c
+++ b/tests/x/20260901_00_errable.c
@@ -1,0 +1,5 @@
+#include "tests/test.h"
+
+int main(void) {
+    feature_testar_test(NULL);
+}

--- a/tests/x/20260905_00_union.c
+++ b/tests/x/20260905_00_union.c
@@ -1,0 +1,5 @@
+#include "tests/test.h"
+
+int main(void) {
+    feature_testar_test(NULL);
+}

--- a/tests/x/cases/20260823_01_diagnostics.testar
+++ b/tests/x/cases/20260823_01_diagnostics.testar
@@ -49,19 +49,6 @@ pub type allocatable = interface{
 --- output.txt
 nature-test/main.x:5:2: the fn 'new' of type 'main.heap_t' mismatch interface 'nature-test.iface.allocatable'
 
-=== test_errable_definition
---- main.x
-fn risky():int! {
-    return 1
-}
-
-fn main() {
-    println(1)
-}
-
---- output.txt
-nature-test/main.x:1:3: errable fn declaration is not supported in .x
-
 === test_vec_literal
 --- main.x
 fn main() {

--- a/tests/x/cases/20260901_00_errable.testar
+++ b/tests/x/cases/20260901_00_errable.testar
@@ -100,18 +100,18 @@ fn fail(bool odd):string! {
 }
 
 fn main() {
-    string acc = ''
     for int i = 0; i < 3; i += 1 {
         var s = fail(i == 1) catch e {
             e.msg()
         }
-        acc = acc + s + ','
+        println(i, s)
     }
-    println('loop:', acc)
 }
 
 --- output.txt
-loop: EVEN,ODD,EVEN,
+0 EVEN
+1 ODD
+2 EVEN
 
 === test_nested_catch
 --- main.x
@@ -303,4 +303,4 @@ fn main() {
 }
 
 --- output.txt
-nature-test/main.x:4:11: throw in .x requires a literal message
+nature-test/main.x:4:9: throw in .x requires a literal message

--- a/tests/x/cases/20260901_00_errable.testar
+++ b/tests/x/cases/20260901_00_errable.testar
@@ -1,0 +1,306 @@
+=== test_propagate
+--- main.x
+// declare, call, propagate, catch with nothing thrown
+fn risky(int v):int! {
+    return v * 2
+}
+
+fn caller(int v):int! {
+    return risky(v)
+}
+
+fn main() {
+    var a = caller(21) catch e {
+        -1
+    }
+    println('happy:', a)
+}
+
+--- output.txt
+happy: 42
+
+=== test_throw_catch
+--- main.x
+fn risky(int v):int! {
+    if v < 0 {
+        throw errorf('negative input')
+    }
+    return v * 2
+}
+
+fn main() {
+    var b = risky(-1) catch e {
+        println('caught:', e.msg())
+        -2
+    }
+    println('thrown:', b)
+}
+
+--- output.txt
+caught: negative input
+thrown: -2
+
+=== test_same_catch_site_twice
+--- main.x
+// One catch site, executed twice, reached by two different throw sites. The v1 design
+// reserved the catch buffer per catch SITE rather than per execution, so the second run
+// rewrote the first handler's message and printed "SECON SECOND".
+// .n reference: "FIRST SECOND".
+fn fail(bool first):string! {
+    if first {
+        throw errorf('FIRST')
+    }
+    throw errorf('SECOND')
+}
+
+fn grab(bool first):string {
+    var s = fail(first) catch e {
+        return e.msg()
+    }
+    return 'none'
+}
+
+fn main() {
+    println(grab(true), grab(false))
+}
+
+--- output.txt
+FIRST SECOND
+
+=== test_error_escapes_catching_fn
+--- main.x
+// the message has to outlive the frame that caught it
+fn fail():string! {
+    throw errorf('ESCAPED')
+}
+
+fn escape():string {
+    var s = fail() catch e {
+        e.msg()
+    }
+    return s
+}
+
+fn main() {
+    println('escape:', escape())
+}
+
+--- output.txt
+escape: ESCAPED
+
+=== test_catch_in_loop
+--- main.x
+// each iteration's `e` must be that iteration's error. The middle iteration throws a
+// different message, so a per-site slot would smear one of them across the others.
+fn fail(bool odd):string! {
+    if odd {
+        throw errorf('ODD')
+    }
+    throw errorf('EVEN')
+}
+
+fn main() {
+    string acc = ''
+    for int i = 0; i < 3; i += 1 {
+        var s = fail(i == 1) catch e {
+            e.msg()
+        }
+        acc = acc + s + ','
+    }
+    println('loop:', acc)
+}
+
+--- output.txt
+loop: EVEN,ODD,EVEN,
+
+=== test_nested_catch
+--- main.x
+// the outer error survives a catch running inside it. two different messages on purpose:
+// identical ones would hide a shared slot.
+fn fail_a():int! {
+    throw errorf('AAA')
+}
+
+fn fail_b():int! {
+    throw errorf('BBB')
+}
+
+fn main() {
+    fail_a() catch e {
+        fail_b() catch e2 {
+            0
+        }
+        println('e.msg() =', e.msg())
+        0
+    }
+}
+
+--- output.txt
+e.msg() = AAA
+
+=== test_long_message
+--- main.x
+// v1 truncated at 159 bytes with no signal. A static descriptor has no cap.
+fn fail():string! {
+    throw errorf('0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789END')
+}
+
+fn main() {
+    var s = fail() catch e {
+        e.msg()
+    }
+    println(s)
+}
+
+--- output.txt
+0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789END
+
+=== test_catch_builtin
+--- main.x
+import allocator as ac
+
+// A builtin error caught in .x carries the static descriptor text. The interpolated index
+// and length are deliberately dropped — the descriptor lives in .rodata — while the uncaught
+// panic path below keeps them.
+fn main() {
+    var v = vec<int>.alloc(ac.heap, 0, 2)
+    defer v.deinit()
+
+    var x = v[5] catch e {
+        println('builtin caught:', e.msg())
+        -1
+    }
+    println(x)
+}
+
+--- output.txt
+builtin caught: index out of range
+-1
+
+=== test_uncaught_panic
+--- main.x
+import allocator as ac
+
+// the uncaught path keeps the full interpolated message and the exit code
+fn main() {
+    var v = vec<int>.alloc(ac.heap, 0, 2)
+    defer v.deinit()
+    println(v[5])
+}
+
+--- output.txt
+panic: 'index out of range [5] with length 2' at nature-test/main.x:7:15
+
+=== test_errable_main
+--- main.x
+// .x main may be errable, so an uncaught error is reportable rather than a compile error.
+// .n prints a stack backtrace here; .x has no traces, so it reports the message alone.
+fn risky():int! {
+    throw errorf('from main')
+}
+
+fn main():void! {
+    var v = risky()
+    println(v)
+}
+
+--- output.txt
+uncaught error: 'from main'
+
+=== test_defer_with_errable_call
+--- main.x
+// defer bodies run while the error is propagating; an errable call inside one must not
+// disturb the error in flight
+fn cleanup():int! {
+    return 1
+}
+
+fn work():int! {
+    defer {
+        cleanup()
+    }
+    throw errorf('boom')
+}
+
+fn main() {
+    var v = work() catch e {
+        println('caught:', e.msg())
+        -1
+    }
+    println(v)
+}
+
+--- output.txt
+caught: boom
+-1
+
+=== test_n_catches_x_error
+--- main.n
+import "worker.x"
+
+// an .x fn throwing under a live coroutine must reach the .n caller's handler
+fn main() {
+    var v = worker.risky(-1) catch e {
+        println('n caught from x:', e.msg())
+        -1
+    }
+    println(v)
+}
+
+--- worker.x
+pub fn risky(int v):int! {
+    if v < 0 {
+        throw errorf('x side failure')
+    }
+    return v * 2
+}
+
+--- output.txt
+n caught from x: x side failure
+-1
+
+=== test_n_custom_throwable_still_works
+--- main.n
+// v1 moved throwable into error.x, which made is_x part of the interface's fn type and broke
+// every .n implementation of it. Custom error types in .n are a documented feature.
+type my_err:throwable = struct{
+    string detail
+}
+
+fn my_err.msg(&self):string {
+    return self.detail
+}
+
+fn risky():int! {
+    throw my_err{detail: 'custom failure'}
+}
+
+fn main() {
+    var v = risky() catch e {
+        println('caught:', e.msg())
+        -1
+    }
+    println(v)
+}
+
+--- output.txt
+caught: custom failure
+-1
+
+=== test_throw_non_literal_rejected
+--- main.x
+// the .x error is a static descriptor, so the message must be known at compile time.
+// This is the compile-time replacement for v1's release-stripped runtime assert.
+fn fail(string m):string! {
+    throw errorf(m)
+}
+
+fn main() {
+    var s = fail('x') catch e {
+        e.msg()
+    }
+    println(s)
+}
+
+--- output.txt
+nature-test/main.x:4:11: throw in .x requires a literal message

--- a/tests/x/cases/20260901_00_errable.testar
+++ b/tests/x/cases/20260901_00_errable.testar
@@ -207,6 +207,29 @@ fn main():void! {
 --- output.txt
 uncaught error: 'from main'
 
+=== test_void_errable_variants
+--- main.x
+fn action(bool fail):void! {
+    if fail {
+        throw errorf('void failed')
+    }
+}
+
+fn main() {
+    action(false) catch e {
+        println('unexpected:', e.msg())
+    }
+    println('void value')
+
+    action(true) catch e {
+        println('void error:', e.msg())
+    }
+}
+
+--- output.txt
+void value
+void error: void failed
+
 === test_defer_with_errable_call
 --- main.x
 // defer bodies run while the error is propagating; an errable call inside one must not
@@ -234,6 +257,121 @@ fn main() {
 caught: boom
 -1
 
+=== test_defer_error_preserves_original
+--- main.x
+// If cleanup fails while another error is already unwinding, the original error wins.
+// The error slot is also the propagation state, so overwriting it would lose the cause.
+fn cleanup():int! {
+    throw errorf('cleanup failed')
+}
+
+fn work():int! {
+    defer {
+        cleanup()
+    }
+    throw errorf('original failure')
+}
+
+fn main() {
+    var v = work() catch e {
+        println('caught:', e.msg())
+        -1
+    }
+    println(v)
+}
+
+--- output.txt
+caught: original failure
+-1
+
+=== test_defer_can_raise_first_error
+--- main.x
+// The conditional store must still accept a defer's error when normal return did
+// not already place one in the function result.
+fn cleanup():int! {
+    throw errorf('cleanup is first')
+}
+
+fn work():int! {
+    defer {
+        cleanup()
+    }
+    return 42
+}
+
+fn main() {
+    var v = work() catch e {
+        println('caught:', e.msg())
+        -1
+    }
+    println(v)
+}
+
+--- output.txt
+caught: cleanup is first
+-1
+
+=== test_large_value_result
+--- main.x
+// pair_t is 16 bytes, so tagged errable<pair_t> is 24 bytes and uses
+// the platform's indirect aggregate-return ABI.
+type pair_t = struct {
+    int left
+    int right
+}
+
+fn make_pair(bool fail):pair_t! {
+    if fail {
+        throw errorf('pair failed')
+    }
+    return pair_t{left: 20, right: 22}
+}
+
+fn main() {
+    var ok = make_pair(false) catch e {
+        pair_t{left: -1, right: -1}
+    }
+    println('ok:', ok.left, ok.right)
+
+    var failed = make_pair(true) catch e {
+        println('caught:', e.msg())
+        pair_t{left: 7, right: 9}
+    }
+    println('fallback:', failed.left, failed.right)
+}
+
+--- output.txt
+ok: 20 22
+caught: pair failed
+fallback: 7 9
+
+=== test_generic_errable
+--- main.x
+fn echo<T>(T value, bool fail):T! {
+    if fail {
+        throw errorf('generic failed')
+    }
+    return value
+}
+
+fn main() {
+    var number = echo<int>(42, false) catch e {
+        -1
+    }
+    println('generic value:', number)
+
+    var failed = echo<string>('unused', true) catch e {
+        println('generic caught:', e.msg())
+        'fallback'
+    }
+    println(failed)
+}
+
+--- output.txt
+generic value: 42
+generic caught: generic failed
+fallback
+
 === test_n_catches_x_error
 --- main.n
 import "worker.x"
@@ -258,6 +396,41 @@ pub fn risky(int v):int! {
 --- output.txt
 n caught from x: x side failure
 -1
+
+=== test_n_calls_x_large_value_result
+--- main.n
+import "worker.x"
+
+fn main() {
+    var ok = worker.make_pair(false) catch e {
+        worker.pair_t{left: -1, right: -1}
+    }
+    println('n ok:', ok.left, ok.right)
+
+    var failed = worker.make_pair(true) catch e {
+        println('n caught:', e.msg())
+        worker.pair_t{left: 3, right: 4}
+    }
+    println('n fallback:', failed.left, failed.right)
+}
+
+--- worker.x
+pub type pair_t = struct {
+    int left
+    int right
+}
+
+pub fn make_pair(bool fail):pair_t! {
+    if fail {
+        throw errorf('large x failure')
+    }
+    return pair_t{left: 40, right: 2}
+}
+
+--- output.txt
+n ok: 40 2
+n caught: large x failure
+n fallback: 3 4
 
 === test_n_custom_throwable_still_works
 --- main.n

--- a/tests/x/cases/20260905_00_union.testar
+++ b/tests/x/cases/20260905_00_union.testar
@@ -1,0 +1,102 @@
+=== test_ordinary_union
+--- main.x
+type pair_t = struct {
+    int left
+    int right
+}
+
+type value_t = int|pair_t|null
+
+fn make_value():value_t {
+    return pair_t{left: 12, right: 34}
+}
+
+fn main() {
+    println('ordinary size:', @sizeof(value_t))
+    value_t value = make_value()
+    println(value is pair_t, value is int, value is null)
+
+    var pair = value as pair_t
+    println(pair.left, pair.right)
+    if value is pair_t bound {
+        println('bound:', bound.left + bound.right)
+    }
+
+    value = 42
+    println(value is int, value as int)
+
+    value_t empty = null
+    println(empty is null)
+}
+
+--- output.txt
+ordinary size: 24
+true false false
+12 34
+bound: 46
+true 42
+true
+
+=== test_union_assert_uncaught
+--- main.x
+type value_t = int|bool
+
+fn main() {
+    value_t value = true
+    println(value as int)
+}
+
+--- output.txt
+panic: 'type assert failed' at nature-test/main.x:5:17
+
+=== test_tagged_union
+--- main.x
+type pair_t = struct {
+    int left
+    int right
+}
+
+type option<T> = union {
+    T some
+    void none
+}
+
+fn make_option():option<pair_t> {
+    return option<pair_t>.some(pair_t{left: 7, right: 9})
+}
+
+fn main() {
+    println('tagged size:', @sizeof(option<pair_t>))
+    option<pair_t> r = make_option()
+    if r is option.some pair {
+        println('some:', pair.left, pair.right)
+    }
+
+    r = option.none
+    match r {
+        is option.some pair -> println('unexpected:', pair.left)
+        is option.none -> println('none')
+    }
+}
+
+--- output.txt
+tagged size: 24
+some: 7 9
+none
+
+=== test_union_assert_catch
+--- main.x
+type value_t = int|bool
+
+fn main() {
+    value_t value = true
+    var number = value as int catch e {
+        println('caught:', e.msg())
+        -1
+    }
+    println(number)
+}
+
+--- output.txt
+caught: type assert failed
+-1

--- a/utils/type.h
+++ b/utils/type.h
@@ -17,6 +17,10 @@
 #endif
 
 #define THROWABLE_IDENT "throwable"
+// std/builtin/error.n. Recognized by name in .x throws, where it never becomes a real call.
+#define ERRORF_IDENT "errorf"
+// std/builtin/error.x. What a .x catch binds: a pointer to an immutable descriptor in .data.
+#define X_ERRDESC_IDENT "errdesc"
 
 #define ALL_T_IDENT "all_t"
 #define FN_T_IDENT "fn_t"
@@ -770,6 +774,10 @@ static inline type_t type_array_new(type_kind element_type_kind, uint64_t length
 
 static inline type_t interface_throwable() {
     return type_ident_new(THROWABLE_IDENT, TYPE_IDENT_INTERFACE);
+}
+
+static inline type_t x_errdesc_ptr_type() {
+    return type_ptrof(type_ident_new(X_ERRDESC_IDENT, TYPE_IDENT_DEF));
 }
 
 static inline bool must_assign_value(type_t t) {

--- a/utils/type.h
+++ b/utils/type.h
@@ -415,6 +415,21 @@ struct type_struct_t {
     list_t *properties; // struct_property_t
 };
 
+// x mode has no coroutine to hang an error on, so an errable .x fn returns the error beside its
+// value: { anyptr err; T value }, err == NULL meaning ok. The error is a pointer to an immutable
+// descriptor emitted into .data at the throw site, so nothing is allocated and nothing is copied.
+//
+// The descriptor is self contained -- [i32 len][i32 flags][bytes][NUL] -- rather than carrying a
+// char* to the message. This toolchain never emits a relocation into the data section (only into
+// .text and the GOT), which is the same reason global_eval.c rejects a non-empty global string
+// initializer, so a pointer field could not be filled in.
+#define X_ERRDESC_HEADER_SIZE 8
+#define X_ERRDESC_FLAG_PANIC 1
+
+#define X_ERRABLE_ERR_NAME "err"
+#define X_ERRABLE_VALUE_NAME "value"
+
+
 typedef struct {
     char *tag;
     type_t type;
@@ -464,6 +479,9 @@ struct type_enum_t {
 struct type_fn_t {
     char *fn_name; // 可选的函数名称，并不是所有的函数类型都能改得到函数名称
     type_t return_type;
+    // for an errable .x fn, return_type is the { err, value } pair and this is the declared T,
+    // so a call expression still types as T. void for every other fn.
+    type_t errable_value_type;
     list_t *param_types; // type_t
     bool is_rest;
     bool is_c_variadic;
@@ -472,6 +490,10 @@ struct type_fn_t {
     bool is_tpl;
     int self_kind;
 };
+
+static inline bool is_x_errable_fn(type_fn_t *f) {
+    return f && f->is_x && f->is_errable;
+}
 
 // 类型描述信息 end
 

--- a/utils/type.h
+++ b/utils/type.h
@@ -17,6 +17,7 @@
 #endif
 
 #define THROWABLE_IDENT "throwable"
+#define ERRABLE_IDENT "errable"
 // std/builtin/error.n. Recognized by name in .x throws, where it never becomes a real call.
 #define ERRORF_IDENT "errorf"
 // std/builtin/error.x. What a .x catch binds: a pointer to an immutable descriptor in .data.
@@ -419,9 +420,9 @@ struct type_struct_t {
     list_t *properties; // struct_property_t
 };
 
-// x mode has no coroutine to hang an error on, so an errable .x fn returns the error beside its
-// value: { anyptr err; T value }, err == NULL meaning ok. The error is a pointer to an immutable
-// descriptor emitted into .data at the throw site, so nothing is allocated and nothing is copied.
+// x mode has no coroutine to hang an error on, so T! is lowered to the tagged union
+// errable<T> = value(T) | error(ptr<errdesc>). The error descriptor is immutable data emitted at
+// the throw site, so nothing is allocated and nothing is copied.
 //
 // The descriptor is self contained -- [i32 len][i32 flags][bytes][NUL] -- rather than carrying a
 // char* to the message. This toolchain never emits a relocation into the data section (only into
@@ -430,8 +431,8 @@ struct type_struct_t {
 #define X_ERRDESC_HEADER_SIZE 8
 #define X_ERRDESC_FLAG_PANIC 1
 
-#define X_ERRABLE_ERR_NAME "err"
-#define X_ERRABLE_VALUE_NAME "value"
+#define X_ERRABLE_ERROR_TAG "error"
+#define X_ERRABLE_VALUE_TAG "value"
 
 
 typedef struct {
@@ -483,8 +484,8 @@ struct type_enum_t {
 struct type_fn_t {
     char *fn_name; // 可选的函数名称，并不是所有的函数类型都能改得到函数名称
     type_t return_type;
-    // for an errable .x fn, return_type is the { err, value } pair and this is the declared T,
-    // so a call expression still types as T. void for every other fn.
+    // for an errable .x fn, return_type is errable<T> and this is the declared T, so a call
+    // expression still types as T. void for every other fn.
     type_t errable_value_type;
     list_t *param_types; // type_t
     bool is_rest;


### PR DESCRIPTION
Supersedes #344, which is draft. That branch moved `.n`'s coroutine side channel into x mode; this one gives `.x` a representation that does not need a side channel at all.

## What `.x` can do now

```nature
fn risky(int v):int! {
    if v < 0 {
        throw errorf('negative input')
    }
    return v * 2
}

fn main() {
    var b = risky(-1) catch e {
        println('caught:', e.msg())
        -2
    }
}
```

## Representation

An errable `.x` fn returns its error beside its value:

```
fn f():T!   ->   { anyptr err; T value }     err == NULL means ok
```

The error is a pointer to an immutable descriptor the compiler emits into `.data` at the throw site:

```
[i32 len][i32 flags][bytes][NUL]
```

Self-contained rather than carrying a `char *msg`, because this toolchain emits no relocation into the data section — the same limit `global_eval.c` hits when it rejects a non-empty global string initializer.

Because the descriptor is immortal, the storage question that sank #344 does not arise: nothing is copied, nothing has a cap, and a handler can hold `e` as long as it likes. This is Zig's insight (an error carries no owned payload) adapted to a language whose errors carry a message — `.x` cannot build a dynamic string anyway, so a static message loses no expressiveness.

Sizes, measured: `void!` is 8 bytes and returns in one register, `int!` is 16 and returns in two. The three `*_abi.c` files are untouched — a synthesized struct already routes on `storage_size > 16`.

## Control flow

The pair is allocated once in the prologue with `err` cleared. Every error site writes the descriptor straight into that slot **before** any defer body runs, so an errable call inside a `defer` cannot clobber the error in flight.

Call sites test the `err` field inline. There is no `co_has_error`, and no runtime call on the happy path at all — today a hello world links 23 `co_has_error` sites plus 18 `co_has_panic`.

Each catch owns its error slot, pushed alongside its label, so a nested catch, a defer body and an outer handler never share storage.

## `.n` is untouched

`error.n` keeps `throwable`, `errort` and `errorf`. #344 moved `throwable` into `error.x`, which made `is_x` part of the interface's fn type and broke every `.n` implementation of it — custom error types in `.n`, a documented feature, became a compile error. `test_n_custom_throwable_still_works` is a `.n` case guarding that.

`.x` binds a new `errdesc` from `error.x`. `catch e { e.msg() }` reads identically in both modes. A `.n` caller of an `.x` errable fn converts the descriptor into a real `errort` at the boundary, so the coroutine path it expects is unchanged.

The coroutine slot stays where it is for `.n`, and it has to: an error handed to `co->future` on coroutine exit outlives the frame that raised it, `collector.c` scans `co->error` as a per-coroutine gc root, and roughly thirty `rti_co_throw` sites fire from libuv callbacks on whichever thread won the loop-owner CAS while the target coroutine is parked.

## Compile-time subset

`throw errorf('literal')` is recognized by shape in `infer_throw`, ahead of the `.x` → `.n` call rule, and never becomes a call. A message chosen at runtime cannot be a static descriptor, so it is a compile error:

```
main.x:4:9: throw in .x requires a literal message
```

#344 enforced its equivalent restriction with an `assertf`, which NDEBUG strips from every release runtime — CI builds the runtime Debug, releases build it Release, so the guard was absent exactly where it mattered.

## Tests

Fourteen cases, written before the implementation, with expected outputs taken from running the same shapes in `.n` first. The ones that matter are the ones #344's suite did not have:

| case | what it pins |
|---|---|
| `test_same_catch_site_twice` | #344 printed `SECON SECOND` here — its catch buffer was per catch *site*, reused by every execution |
| `test_error_escapes_catching_fn` | the message outliving the catching frame |
| `test_catch_in_loop` | per iteration, not per site |
| `test_long_message` | #344 truncated at 159 bytes with no signal |
| `test_errable_main` | `.x` main may be errable and report |
| `test_n_custom_throwable_still_works` | the `.n` regression above |
| `test_throw_non_literal_rejected` | the compile-time restriction |

`x` main is errable in both modes now, so an uncaught `.x` error is reported rather than being a compile error.

## Deliberate regression

A builtin error caught in `.x` carries the descriptor text without the interpolated detail — `index out of range` rather than `index out of range [5] with length 2` — because the descriptor lives in `.rodata`. The uncaught panic path keeps the full message, and `test_uncaught_panic` guards that. Precedent: Zig, errno.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
