### PR TITLE
fix: preserve aggregate return base across register loads

### DIFF
--- a/src/lower/amd64_abi.c
+++ b/src/lower/amd64_abi.c
@@ -120,9 +120,6 @@ linked_t *amd64_lower_return(closure_t *c, lir_op_t *op) {
 
     if (is_abi_struct_like(return_type)) {
         // return_operand 保存的是一个指针，需要 indirect 这个值，将响应的值 mov 到寄存器中
-        lir_operand_t *src = indirect_addr_operand(c->module, type_kind_new(lo_kind), return_operand, 0);
-        linked_push(result, lir_op_move(lo_dst_reg, src));
-
         if (count == 2) {
             lir_operand_t *hi_dst_reg = NULL;
             type_kind hi_kind;
@@ -133,9 +130,15 @@ linked_t *amd64_lower_return(closure_t *c, lir_op_t *op) {
                 hi_dst_reg = operand_new(LIR_OPERAND_REG, xmm1s64);
                 hi_kind = TYPE_FLOAT64;
             }
-            src = indirect_addr_operand(c->module, type_kind_new(hi_kind), return_operand, QWORD);
+            // The aggregate base commonly has a return-register hint. Preserve it until both
+            // words have been loaded by moving the high word before the low return register.
+            lir_operand_t *src =
+                    indirect_addr_operand(c->module, type_kind_new(hi_kind), return_operand, QWORD);
             linked_push(result, lir_op_move(hi_dst_reg, src));
         }
+
+        lir_operand_t *src = indirect_addr_operand(c->module, type_kind_new(lo_kind), return_operand, 0);
+        linked_push(result, lir_op_move(lo_dst_reg, src));
     } else {
         assert(count == 1);
         assertf(return_type.kind != TYPE_ARR, "array type must be pointer type");

--- a/src/lower/arm64_abi.c
+++ b/src/lower/arm64_abi.c
@@ -688,15 +688,19 @@ linked_t *arm64_lower_return(closure_t *c, lir_op_t *op) {
             }
         } else if (return_size <= 16) {
             // 小于等于 16 字节的结构体，使用 x0 和 x1 返回
-            lir_operand_t *src_lo = indirect_addr_operand(c->module, type_kind_new(TYPE_UINT64), return_operand, 0);
-            lir_operand_t *dst_lo = operand_new(LIR_OPERAND_REG, x0);
-            linked_push(result, lir_op_move(dst_lo, src_lo));
-
+            // Load the high word first. return_operand commonly carries an x0 hint; writing x0
+            // first would destroy the base before the [base + 8] load.
             if (return_size > 8) {
-                lir_operand_t *src_hi = indirect_addr_operand(c->module, type_kind_new(TYPE_UINT64), return_operand, 8);
+                lir_operand_t *src_hi =
+                        indirect_addr_operand(c->module, type_kind_new(TYPE_UINT64), return_operand, 8);
                 lir_operand_t *dst_hi = operand_new(LIR_OPERAND_REG, x1);
                 linked_push(result, lir_op_move(dst_hi, src_hi));
             }
+
+            lir_operand_t *src_lo =
+                    indirect_addr_operand(c->module, type_kind_new(TYPE_UINT64), return_operand, 0);
+            lir_operand_t *dst_lo = operand_new(LIR_OPERAND_REG, x0);
+            linked_push(result, lir_op_move(dst_lo, src_lo));
         } else {
             assert(c->return_big_operand);
             // fn begin 时 x8 寄存器中存储的指针被传递给了 c->return_operand

--- a/src/lower/riscv64_abi.c
+++ b/src/lower/riscv64_abi.c
@@ -713,14 +713,16 @@ linked_t *riscv64_lower_return(closure_t *c, lir_op_t *op) {
                 hi_dst = operand_new(LIR_OPERAND_REG, reg_select(reg_index, attach_kind));
             }
         }
-        // 进行 mov
-        lir_operand_t *lo_src = indirect_addr_operand(c->module, type_kind_new(main_kind), return_operand, 0);
-        linked_push(result, lir_op_move(lo_dst, lo_src));
-
+        // Keep the aggregate base alive until both words have been loaded. It commonly has an
+        // a0 return hint, so writing the low return register first can clobber [base + offset].
         if (hi_dst) {
-            lir_operand_t *hi_src = indirect_addr_operand(c->module, type_kind_new(attach_kind), return_operand, attach_offset);
+            lir_operand_t *hi_src =
+                    indirect_addr_operand(c->module, type_kind_new(attach_kind), return_operand, attach_offset);
             linked_push(result, lir_op_move(hi_dst, hi_src));
         }
+
+        lir_operand_t *lo_src = indirect_addr_operand(c->module, type_kind_new(main_kind), return_operand, 0);
+        linked_push(result, lir_op_move(lo_dst, lo_src));
 
     } else {
         if (return_size > 16) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -406,3 +406,7 @@ endif ()
 add_executable(test_amd64_windows_abi test_amd64_windows_abi.c)
 target_link_libraries(test_amd64_windows_abi nature_common_test m)
 add_test(test_amd64_windows_abi test_amd64_windows_abi)
+
+add_executable(test_aggregate_return_abi test_aggregate_return_abi.c)
+target_link_libraries(test_aggregate_return_abi nature_common_test m)
+add_test(test_aggregate_return_abi test_aggregate_return_abi)

--- a/tests/test_aggregate_return_abi.c
+++ b/tests/test_aggregate_return_abi.c
@@ -1,0 +1,93 @@
+#include "src/lower/amd64_abi.h"
+#include "src/lower/arm64_abi.h"
+#include "src/lower/riscv64_abi.h"
+#include "src/register/register.h"
+#include "src/symbol/symbol.h"
+
+#include <stdio.h>
+
+#define ABI_CHECK(condition)                                                    \
+    do {                                                                        \
+        if (!(condition)) {                                                     \
+            fprintf(stderr, "aggregate return ABI check failed at %s:%d: %s\n", \
+                    __FILE__, __LINE__, #condition);                            \
+            return false;                                                       \
+        }                                                                       \
+    } while (0)
+
+static type_t pair_type(void) {
+    type_t element = type_kind_new(TYPE_INT64);
+    type_tuple_t *tuple = NEW(type_tuple_t);
+    tuple->elements = ct_list_new(sizeof(type_t));
+    ct_list_push(tuple->elements, &element);
+    ct_list_push(tuple->elements, &element);
+
+    type_t result = type_new(TYPE_TUPLE, tuple);
+    result.storage_kind = STORAGE_KIND_IND;
+    result.map_imm_kind = TYPE_ANYPTR;
+    result.storage_size = 16;
+    result.align = 8;
+    result.abi_struct = type_abi_struct(result);
+    return result;
+}
+
+static module_t *test_module(void) {
+    module_t *module = NEW(module_t);
+    module->ident = "aggregate_return_abi_test";
+    module->global_symbol_table = table_new();
+    module->global_symbols = slice_new();
+    module->asm_global_symbols = slice_new();
+    return module;
+}
+
+static linked_t *lower_pair_return(int arch) {
+    BUILD_ARCH = arch;
+    BUILD_OS = arch == ARCH_ARM64 ? OS_DARWIN : OS_LINUX;
+    reg_init();
+
+    type_t return_type = pair_type();
+    ast_fndef_t *fndef = NEW(ast_fndef_t);
+    fndef->return_type = return_type;
+
+    module_t *module = test_module();
+    closure_t *closure = lir_closure_new(fndef);
+    closure->module = module;
+    module->current_closure = closure;
+
+    lir_var_t *return_var = NEW(lir_var_t);
+    return_var->ident = "return_value";
+    return_var->old = return_var->ident;
+    return_var->type = return_type;
+
+    lir_op_t *return_op = lir_op_new(
+            LIR_OPCODE_RETURN, operand_new(LIR_OPERAND_VAR, return_var), NULL, NULL);
+    if (arch == ARCH_AMD64) return amd64_lower_return(closure, return_op);
+    if (arch == ARCH_ARM64) return arm64_lower_return(closure, return_op);
+    return riscv64_lower_return(closure, return_op);
+}
+
+static bool check_arch(int arch) {
+    linked_t *lowered = lower_pair_return(arch);
+    ABI_CHECK(linked_count(lowered) == 3U);
+
+    lir_op_t *high_move = linked_first(lowered)->value;
+    lir_op_t *low_move = linked_first(lowered)->succ->value;
+    ABI_CHECK(high_move->code == LIR_OPCODE_MOVE);
+    ABI_CHECK(low_move->code == LIR_OPCODE_MOVE);
+    ABI_CHECK(high_move->first->assert_type == LIR_OPERAND_INDIRECT_ADDR);
+    ABI_CHECK(low_move->first->assert_type == LIR_OPERAND_INDIRECT_ADDR);
+
+    lir_indirect_addr_t *high = high_move->first->value;
+    lir_indirect_addr_t *low = low_move->first->value;
+    ABI_CHECK(high->offset == 8);
+    ABI_CHECK(low->offset == 0);
+    return true;
+}
+
+int main(void) {
+    symbol_init();
+    if (!check_arch(ARCH_AMD64)) return 1;
+    if (!check_arch(ARCH_ARM64)) return 1;
+    if (!check_arch(ARCH_RISCV64)) return 1;
+    return 0;
+}


### PR DESCRIPTION
## Summary

- load the high word before the low return register for 9–16 byte aggregate returns
- apply the fix consistently to AMD64 SysV, ARM64, and RISC-V64 lowering
- add a lowering regression test covering all three architectures

The aggregate address may carry the first return-register hint. Writing that register before reading `[base + 8]` can overwrite the base and make the second load use an invalid address.

## Verification

- `cmake --build build -- -j8`
- `ctest --output-on-failure`: 243/244 passed
- the only failure was the existing environment-dependent `20250324_00_llama` output assertion
- `test_aggregate_return_abi`, `test_amd64_windows_abi`, and `20250528_00_abi` passed