### PR TITLE
fix: handle union assertions in x mode

### DIFF
--- a/runtime/nutils/nutils.c
+++ b/runtime/nutils/nutils.c
@@ -1034,6 +1034,13 @@ n_int_t rt_errno() {
     return errno;
 }
 
+void rt_x_panic(char *msg, char *path, n_int_t line, n_int_t column) {
+    char *dump = tlsprintf("panic: '%s' at %s:%llu:%llu\n", msg, path,
+                           (unsigned long long) line, (unsigned long long) column);
+    VOID write(STDOUT_FILENO, dump, strlen(dump));
+    exit(EXIT_FAILURE);
+}
+
 n_anyptr_t rt_array_new(int64_t element_hash, int64_t length) {
     if (length < 0) {
         rti_throw("array_new length must be non-negative", true);

--- a/runtime/nutils/nutils.h
+++ b/runtime/nutils/nutils.h
@@ -86,6 +86,9 @@ void rt_assert(n_bool_t cond);
 // allocate array data by element rtype hash
 n_anyptr_t rt_array_new(int64_t element_hash, int64_t length);
 
+// Report an uncaught .x panic without accessing coroutine state.
+void rt_x_panic(char *msg, char *path, n_int_t line, n_int_t column);
+
 n_vec_t unsafe_vec_new(int64_t hash, int64_t element_hash, int64_t len, void *data_ptr);
 
 n_string_t rt_strerror();

--- a/src/linear.c
+++ b/src/linear.c
@@ -3213,6 +3213,40 @@ static lir_operand_t *linear_is_expr(module_t *m, ast_expr_t expr, lir_operand_t
 }
 
 /**
+ * Ordinary unions keep an rtype pointer in their first word. In .x the runtime assertion's
+ * failure path cannot be used because it reports through coroutine state, which x mode does not
+ * create. Compare the stored rtype hash directly and panic through the x runtime on mismatch.
+ */
+static void linear_x_union_assert(module_t *m, lir_operand_t *src_operand, uint64_t target_rtype_hash) {
+    lir_operand_t *union_ptr = temp_var_operand(m, type_kind_new(TYPE_ANYPTR));
+    OP_PUSH(lir_op_move(union_ptr, src_operand));
+
+    lir_operand_t *rtype_ptr = temp_var_operand(m, type_kind_new(TYPE_ANYPTR));
+    OP_PUSH(lir_op_move(rtype_ptr,
+                        indirect_addr_operand(m, type_kind_new(TYPE_ANYPTR), union_ptr,
+                                              offsetof(n_union_t, rtype))));
+
+    lir_operand_t *actual_hash = temp_var_operand(m, type_kind_new(TYPE_INT64));
+    OP_PUSH(lir_op_move(actual_hash,
+                        indirect_addr_operand(m, type_kind_new(TYPE_INT64), rtype_ptr,
+                                              offsetof(rtype_t, hash))));
+
+    char *assert_end_ident = label_ident_with_unique(".union.assert.end");
+    OP_PUSH(lir_op_new(LIR_OPCODE_BEE, int_operand(target_rtype_hash), actual_hash,
+                       lir_label_operand(assert_end_ident, true)));
+
+    char *panic_path = m->current_closure->fndef->rel_path
+                               ? m->current_closure->fndef->rel_path
+                               : m->rel_path;
+    push_rt_call(m, RT_CALL_X_PANIC, NULL, 4,
+                 string_operand("type assert failed", strlen("type assert failed")),
+                 string_operand(panic_path, strlen(panic_path)), int_operand(m->current_line),
+                 int_operand(m->current_column));
+
+    OP_PUSH(lir_op_label(assert_end_ident, true));
+}
+
+/**
  * @param m
  * @param expr
  * @return
@@ -3390,6 +3424,19 @@ static lir_operand_t *linear_as_expr(module_t *m, ast_expr_t expr, lir_operand_t
     // union assert
     if (as_expr->src.type.kind == TYPE_UNION) {
         assert(as_expr->target_type.kind != TYPE_UNION);
+        if (m->is_x) {
+            uint64_t target_rtype_hash = type_hash(as_expr->target_type);
+            linear_x_union_assert(m, src_operand, target_rtype_hash);
+
+            lir_operand_t *payload =
+                    indirect_addr_operand(m, as_expr->target_type, src_operand,
+                                          offsetof(n_union_t, value));
+            if (as_expr->target_type.storage_kind == STORAGE_KIND_IND) {
+                payload = lea_operand_pointer(m, payload);
+            }
+            return linear_super_move(m, as_expr->target_type, target, payload);
+        }
+
         if (as_expr->target_type.storage_kind != STORAGE_KIND_IND) {
             // target 可能总是未 def 导致下面的取值异常, 所以最好使用临时值 assert，然后 mov 到 target
             lir_operand_t *temp = temp_var_operand(m, as_expr->target_type);

--- a/src/lir.h
+++ b/src/lir.h
@@ -146,6 +146,7 @@
 
 #define RT_CALL_THROW_INDEX_OUT_ERROR "throw_index_out_error"
 #define RT_CALL_CO_THROW_ERROR "co_throw_error"
+#define RT_CALL_X_PANIC "rt_x_panic"
 
 #define RT_CALL_CO_REMOVE_ERROR "co_remove_error"
 #define RT_CALL_CO_HAS_ERROR "co_has_error"
@@ -267,7 +268,8 @@ static inline bool is_rtcall(string target) {
            str_equal(target, RT_CALL_STRING_LT) || str_equal(target, RT_CALL_STRING_LE) ||
            str_equal(target, RT_CALL_STRING_GT) || str_equal(target, RT_CALL_STRING_GE) ||
            str_equal(target, RT_CALL_GC_MALLOC) ||
-           str_equal(target, RT_CALL_RUNTIME_EVAL_GC) || str_equal(target, RT_CALL_COROUTINE_ASYNC2) || str_equal(target, RT_CALL_CO_THROW_ERROR) ||
+           str_equal(target, RT_CALL_RUNTIME_EVAL_GC) || str_equal(target, RT_CALL_COROUTINE_ASYNC2) ||
+           str_equal(target, RT_CALL_CO_THROW_ERROR) || str_equal(target, RT_CALL_X_PANIC) ||
            str_equal(target, RT_CALL_CO_REMOVE_ERROR) || str_equal(target, RT_CALL_CO_HAS_ERROR) ||
            str_equal(target, RT_CALL_CO_HAS_PANIC) || str_equal(target, RT_CALL_PROCESSOR_SET_EXIT) ||
            str_equal(target, RT_CALL_UNION_TO_ANY);

--- a/tests/x/20260905_00_union.c
+++ b/tests/x/20260905_00_union.c
@@ -1,0 +1,5 @@
+#include "tests/test.h"
+
+int main(void) {
+    feature_testar_test(NULL);
+}

--- a/tests/x/cases/20260905_00_union.testar
+++ b/tests/x/cases/20260905_00_union.testar
@@ -1,0 +1,85 @@
+=== test_ordinary_union
+--- main.x
+type pair_t = struct {
+    int left
+    int right
+}
+
+type value_t = int|pair_t|null
+
+fn make_value():value_t {
+    return pair_t{left: 12, right: 34}
+}
+
+fn main() {
+    println('ordinary size:', @sizeof(value_t))
+    value_t value = make_value()
+    println(value is pair_t, value is int, value is null)
+
+    var pair = value as pair_t
+    println(pair.left, pair.right)
+    if value is pair_t bound {
+        println('bound:', bound.left + bound.right)
+    }
+
+    value = 42
+    println(value is int, value as int)
+
+    value_t empty = null
+    println(empty is null)
+}
+
+--- output.txt
+ordinary size: 24
+true false false
+12 34
+bound: 46
+true 42
+true
+
+=== test_union_assert_uncaught
+--- main.x
+type value_t = int|bool
+
+fn main() {
+    value_t value = true
+    println(value as int)
+}
+
+--- output.txt
+panic: 'type assert failed' at nature-test/main.x:5:17
+
+=== test_tagged_union
+--- main.x
+type pair_t = struct {
+    int left
+    int right
+}
+
+type option<T> = union {
+    T some
+    void none
+}
+
+fn make_option():option<pair_t> {
+    return option<pair_t>.some(pair_t{left: 7, right: 9})
+}
+
+fn main() {
+    println('tagged size:', @sizeof(option<pair_t>))
+    option<pair_t> r = make_option()
+    if r is option.some pair {
+        println('some:', pair.left, pair.right)
+    }
+
+    r = option.none
+    match r {
+        is option.some pair -> println('unexpected:', pair.left)
+        is option.none -> println('none')
+    }
+}
+
+--- output.txt
+tagged size: 24
+some: 7 9
+none


### PR DESCRIPTION
## Summary

- lower ordinary union assertions directly in `.x` mode instead of using the coroutine-backed runtime assertion path
- report failed `.x` assertions through a small non-coroutine panic entry point
- cover ordinary and tagged unions in `.x`, including construction, returns, `is`, payload binding, `match`, successful `as`, and an uncaught failed `as`

This PR does not add errable/catch support and is independent of #349.

## Verification

- `cmake --build build-runtime --target runtime`
- `cmake --build build -- -j8`
- focused union tests: 3/3 passed
- full `ctest --output-on-failure`: 243/244 passed
- the only failure was the existing environment-dependent `20250324_00_llama` output assertion